### PR TITLE
Fixing sync scheduler not firing after the appropriate delay

### DIFF
--- a/src/main/java/org/spongepowered/common/service/scheduler/SyncScheduler.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/SyncScheduler.java
@@ -252,6 +252,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (nonRepeatingTask == null) {
             Sponge.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            nonRepeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, nonRepeatingTask);
         }
 
@@ -306,6 +307,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (nonRepeatingTask == null) {
             Sponge.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            nonRepeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, nonRepeatingTask);
         }
 
@@ -376,6 +378,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (repeatingTask == null) {
             Sponge.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            repeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, repeatingTask);
         }
 
@@ -446,6 +449,7 @@ public class SyncScheduler implements SynchronousScheduler {
         if (repeatingTask == null) {
             Sponge.getLogger().warn(SchedulerLogMessages.CANNOT_MAKE_TASK_WARNING);
         } else {
+            repeatingTask.setTimestamp(this.counter);
             resultTask = this.schedulerHelper.utilityForAddingTask(this.taskMap, repeatingTask);
         }
 


### PR DESCRIPTION
When a task is scheduled inside of a command executor, tasks do not get run after the appropriate delay. This PR fixes that by setting the timestamp at the appropriate time when the task is created. This fixes #33 (please read for complete details)

If you want to reproduce, checkout [my fork of SpongeCommon](https://github.com/RobertHerhold/SpongeCommon) and build it. I tested this with [BLWarps](https://github.com/BlockLaunch/BLWarps/releases/tag/v1.0.0), my warping plugin. To reproduce:
* Use both the BLWarps plugin and my fork of SpongeCommon
* In game, make a warp: "/warp add mywarp"
* Warp to the newly created warp: "/warp mywarp". After about 5 seconds, you will be warped.
* If you want proof, just run the same thing without my fork of SpongeCommon and compare results. When running "/warp mywarp", you will be warped immediately rather than after 5 seconds.

This is the same as SpongePowered/Sponge#225. However, the reviewers tested this in a different environment than my plugin (not scheduling a task from a command), and I do take responsibility for not having detailed reproduction procedures
