### PR TITLE
Introduce multi-world support to the entire Sponge ecosystem.

### DIFF
--- a/src/main/java/org/spongepowered/common/AbstractPlatform.java
+++ b/src/main/java/org/spongepowered/common/AbstractPlatform.java
@@ -67,6 +67,7 @@ public abstract class AbstractPlatform implements Platform {
         final Map<String, Object> map = Maps.newHashMap();
         map.put("Name", this.getName());
         map.put("Type", this.getType());
+        map.put("ExecutionType", this.getExecutionType());
         map.put("ApiVersion", this.getApiVersion());
         map.put("ImplementationVersion", this.getVersion());
         map.put("MinecraftVersion", this.getMinecraftVersion());

--- a/src/main/java/org/spongepowered/common/Sponge.java
+++ b/src/main/java/org/spongepowered/common/Sponge.java
@@ -29,33 +29,12 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.spongepowered.common.configuration.SpongeConfig.Type.GLOBAL;
 
 import com.google.inject.Injector;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.dedicated.DedicatedServer;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.spi.AbstractLogger;
-import org.slf4j.impl.SLF4JLogger;
 import org.spongepowered.api.Game;
-import org.spongepowered.api.Platform;
 import org.spongepowered.api.plugin.PluginContainer;
-import org.spongepowered.api.service.ProviderExistsException;
-import org.spongepowered.api.service.command.CommandService;
-import org.spongepowered.api.service.command.SimpleCommandService;
-import org.spongepowered.api.service.pagination.PaginationService;
-import org.spongepowered.api.service.persistence.SerializationService;
-import org.spongepowered.api.service.rcon.RconService;
-import org.spongepowered.api.service.scheduler.AsynchronousScheduler;
-import org.spongepowered.api.service.scheduler.SynchronousScheduler;
-import org.spongepowered.api.service.sql.SqlService;
-import org.spongepowered.common.command.SpongeCommandDisambiguator;
 import org.spongepowered.common.configuration.SpongeConfig;
 import org.spongepowered.common.launch.SpongeLaunch;
 import org.spongepowered.common.registry.SpongeGameRegistry;
-import org.spongepowered.common.service.pagination.SpongePaginationService;
-import org.spongepowered.common.service.persistence.SpongeSerializationService;
-import org.spongepowered.common.service.rcon.MinecraftRconService;
-import org.spongepowered.common.service.scheduler.AsyncScheduler;
-import org.spongepowered.common.service.scheduler.SyncScheduler;
-import org.spongepowered.common.service.sql.SqlServiceImpl;
 
 import java.io.File;
 
@@ -67,8 +46,32 @@ import javax.inject.Singleton;
 @Singleton
 public class Sponge {
 
+    public static final String ECOSYSTEM_NAME = "Sponge";
+    private static final File gameDir = SpongeLaunch.getGameDirectory();
+    private static final File configDir = SpongeLaunch.getConfigDirectory();
+    private static final File pluginsDir = SpongeLaunch.getPluginsDirectory();
     @Nullable
     private static Sponge instance;
+    @Nullable private static SpongeConfig<SpongeConfig.GlobalConfig> globalConfig;
+    private final Injector injector;
+    private final Game game;
+    private final Logger logger;
+    private final PluginContainer plugin;
+    private final PluginContainer minecraftPlugin;
+
+    @Inject
+    public Sponge(Injector injector, Game game, Logger logger,
+            @Named(Sponge.ECOSYSTEM_NAME) PluginContainer plugin, @Named("Minecraft") PluginContainer minecraftPlugin) {
+
+        checkState(instance == null, "Sponge was already initialized");
+        instance = this;
+
+        this.injector = checkNotNull(injector, "injector");
+        this.game = checkNotNull(game, "game");
+        this.logger = checkNotNull(logger, "logger");
+        this.plugin = checkNotNull(plugin, "plugin");
+        this.minecraftPlugin = checkNotNull(minecraftPlugin, "minecraftPlugin");
+    }
 
     public static Sponge getInstance() {
         checkState(instance != null, "Sponge was not initialized");
@@ -79,86 +82,16 @@ public class Sponge {
         return instance != null;
     }
 
-    private final Injector injector;
-    private final Game game;
-    private final Logger logger;
-    private final org.slf4j.Logger slf4jLogger;
-
-    private final PluginContainer plugin;
-    private final PluginContainer minecraftPlugin;
-
-    @Inject
-    public Sponge(Injector injector, Game game, Logger logger,
-            @Named("Sponge") PluginContainer plugin, @Named("Minecraft") PluginContainer minecraftPlugin) {
-
-        checkState(instance == null, "Sponge was already initialized");
-        instance = this;
-
-        this.injector = checkNotNull(injector, "injector");
-        this.game = checkNotNull(game, "game");
-        this.logger = checkNotNull(logger, "logger");
-        this.slf4jLogger = new SLF4JLogger((AbstractLogger) this.logger, this.logger.getName());
-
-        this.plugin = checkNotNull(plugin, "plugin");
-        this.minecraftPlugin = checkNotNull(minecraftPlugin, "minecraftPlugin");
-    }
-
-    public void registerServices() {
-        try {
-            SimpleCommandService commandService = new SimpleCommandService(this.game, this.slf4jLogger, new SpongeCommandDisambiguator(this.game));
-            this.game.getServiceManager().setProvider(this.plugin, CommandService.class, commandService);
-        } catch (ProviderExistsException e) {
-            this.logger.warn("Non-Sponge CommandService already registered: " + e.getLocalizedMessage());
-        }
-
-        try {
-            this.game.getServiceManager().setProvider(this.plugin, SqlService.class, new SqlServiceImpl());
-        } catch (ProviderExistsException e) {
-            this.logger.warn("Non-Sponge SqlService already registered: " + e.getLocalizedMessage());
-        }
-
-        try {
-            this.game.getServiceManager().setProvider(this.plugin, SynchronousScheduler.class, SyncScheduler.getInstance());
-            this.game.getServiceManager().setProvider(this.plugin, AsynchronousScheduler.class, AsyncScheduler.getInstance());
-        } catch (ProviderExistsException e) {
-            this.logger.error("Non-Sponge scheduler has been registered. Cannot continue!");
-            throw new ExceptionInInitializerError(e);
-        }
-
-        try {
-            SerializationService serializationService = new SpongeSerializationService();
-            this.game.getServiceManager().setProvider(this.plugin, SerializationService.class, serializationService);
-        } catch (ProviderExistsException e2) {
-            this.logger.warn("Non-Sponge SerializationService already registered: " + e2.getLocalizedMessage());
-        }
-
-        try {
-            this.game.getServiceManager().setProvider(this.plugin, PaginationService.class, new SpongePaginationService());
-        } catch (ProviderExistsException e) {
-            this.logger.warn("Non-Sponge PaginationService already registered: " + e.getLocalizedMessage());
-        }
-
-        if (this.game.getPlatform().getType() == Platform.Type.SERVER) {
-            try {
-                this.game.getServiceManager().setProvider(this.plugin, RconService.class, new MinecraftRconService((DedicatedServer)
-                        MinecraftServer.getServer()));
-            } catch (ProviderExistsException e) {
-                this.logger.warn("Non-Sponge Rcon service already registered: " + e.getLocalizedMessage());
-            }
-        }
-
-    }
-
     public static Injector getInjector() {
         return getInstance().injector;
     }
 
-    public static Game getGame() {
-        return getInstance().game;
+    public static SpongeGame getGame() {
+        return (SpongeGame) getInstance().game;
     }
 
     public static SpongeGameRegistry getSpongeRegistry() {
-        return ((SpongeGameRegistry) getInstance().game.getRegistry());
+        return (SpongeGameRegistry) getInstance().game.getRegistry();
     }
 
     public static Logger getLogger() {
@@ -172,12 +105,6 @@ public class Sponge {
     public static PluginContainer getMinecraftPlugin() {
         return getInstance().minecraftPlugin;
     }
-
-    private static final File gameDir = SpongeLaunch.getGameDirectory();
-    private static final File configDir = SpongeLaunch.getConfigDirectory();
-    private static final File pluginsDir = SpongeLaunch.getPluginsDirectory();
-
-    @Nullable private static SpongeConfig<SpongeConfig.GlobalConfig> globalConfig;
 
     public static File getGameDirectory() {
         return gameDir;

--- a/src/main/java/org/spongepowered/common/SpongeBootstrap.java
+++ b/src/main/java/org/spongepowered/common/SpongeBootstrap.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import org.apache.logging.log4j.spi.AbstractLogger;
+import org.slf4j.impl.SLF4JLogger;
+import org.spongepowered.api.Platform;
+import org.spongepowered.api.service.ProviderExistsException;
+import org.spongepowered.api.service.command.CommandService;
+import org.spongepowered.api.service.command.SimpleCommandService;
+import org.spongepowered.api.service.persistence.SerializationService;
+import org.spongepowered.api.service.rcon.RconService;
+import org.spongepowered.api.service.scheduler.AsynchronousScheduler;
+import org.spongepowered.api.service.scheduler.SynchronousScheduler;
+import org.spongepowered.api.service.sql.SqlService;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.Dimension;
+import org.spongepowered.api.world.DimensionType;
+import org.spongepowered.common.command.SpongeCommandDisambiguator;
+import org.spongepowered.common.registry.SpongeGameRegistry;
+import org.spongepowered.common.service.persistence.SpongeSerializationService;
+import org.spongepowered.common.service.rcon.MinecraftRconService;
+import org.spongepowered.common.service.scheduler.AsyncScheduler;
+import org.spongepowered.common.service.scheduler.SyncScheduler;
+import org.spongepowered.common.service.sql.SqlServiceImpl;
+import org.spongepowered.common.world.DimensionManager;
+import org.spongepowered.common.world.SpongeDimensionType;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Used to setup the ecosystem
+ */
+@NonnullByDefault
+public final class SpongeBootstrap {
+    private static final org.slf4j.Logger slf4jLogger = new SLF4JLogger((AbstractLogger) Sponge.getLogger(), Sponge.getLogger().getName());
+
+    public static void initializeServices() {
+        try {
+            SimpleCommandService commandService = new SimpleCommandService(Sponge.getGame(), slf4jLogger, new SpongeCommandDisambiguator(Sponge.getGame()));
+            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), CommandService.class, commandService);
+        } catch (ProviderExistsException e) {
+            Sponge.getLogger().warn("Non-Sponge CommandService already registered: " + e.getLocalizedMessage());
+        }
+
+        try {
+            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), SqlService.class, new SqlServiceImpl());
+        } catch (ProviderExistsException e) {
+            Sponge.getLogger().warn("Non-Sponge SqlService already registered: " + e.getLocalizedMessage());
+        }
+
+        try {
+            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), SynchronousScheduler.class, SyncScheduler.getInstance());
+            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), AsynchronousScheduler.class, AsyncScheduler.getInstance());
+        } catch (ProviderExistsException e) {
+            Sponge.getLogger().error("Non-Sponge scheduler has been registered. Cannot continue!");
+            throw new ExceptionInInitializerError(e);
+        }
+
+        try {
+            SerializationService serializationService = new SpongeSerializationService();
+            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), SerializationService.class, serializationService);
+        } catch (ProviderExistsException e2) {
+            Sponge.getLogger().warn("Non-Sponge SerializationService already registered: " + e2.getLocalizedMessage());
+        }
+
+        if (Sponge.getGame().getPlatform().getType() == Platform.Type.SERVER) {
+            try {
+                Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), RconService.class, new MinecraftRconService((DedicatedServer)
+                        MinecraftServer.getServer()));
+            } catch (ProviderExistsException e) {
+                Sponge.getLogger().warn("Non-Sponge Rcon service already registered: " + e.getLocalizedMessage());
+            }
+        }
+    }
+
+    public static void preInitializeRegistry() {
+        ((SpongeGameRegistry) Sponge.getGame().getRegistry()).preInit();
+    }
+
+    public static void initializeRegistry() {
+        ((SpongeGameRegistry) Sponge.getGame().getRegistry()).init();
+    }
+
+    public static void postIniitalizeRegistry() {
+        ((SpongeGameRegistry) Sponge.getGame().getRegistry()).postInit();
+    }
+
+    public static void registerWorlds() {
+        final File[] directoryListing = DimensionManager.getCurrentSaveRootDirectory().listFiles();
+        if (directoryListing == null) {
+            return;
+        }
+
+        for (File child : directoryListing) {
+            File levelData = new File(child, "level_sponge.dat");
+            if (!child.isDirectory() || !levelData.exists()) {
+                continue;
+            }
+
+            try {
+                NBTTagCompound nbt = CompressedStreamTools.readCompressed(new FileInputStream(levelData));
+                if (nbt.hasKey(Sponge.ECOSYSTEM_NAME)) {
+                    NBTTagCompound spongeData = nbt.getCompoundTag(Sponge.ECOSYSTEM_NAME);
+                    boolean enabled = spongeData.getBoolean("enabled");
+                    boolean loadOnStartup = spongeData.getBoolean("loadOnStartup");
+                    int dimensionId = spongeData.getInteger("dimensionId");
+                    if (!(dimensionId == -1) && !(dimensionId == 0) && !(dimensionId == 1)) {
+                        if (!enabled) {
+                            Sponge.getLogger().info("World {} is currently disabled. Skipping world load...", child.getName());
+                            continue;
+                        }
+                        if (!loadOnStartup) {
+                            Sponge.getLogger().info("World {} 'loadOnStartup' is disabled.. Skipping world load...", child.getName());
+                            continue;
+                        }
+                    } else if (dimensionId == -1) {
+                        if (!MinecraftServer.getServer().getAllowNether()) {
+                            continue;
+                        }
+                    }
+                    if (spongeData.hasKey("uuid_most") && spongeData.hasKey("uuid_least")) {
+                        UUID uuid = new UUID(spongeData.getLong("uuid_most"), spongeData.getLong("uuid_least"));
+                        Sponge.getSpongeRegistry().registerWorldUniqueId(uuid, child.getName());
+                    }
+                    if (spongeData.hasKey("dimensionId") && spongeData.getBoolean("enabled")) {
+                        int dimension = spongeData.getInteger("dimensionId");
+                        for (Map.Entry<Class<? extends Dimension>, DimensionType> mapEntry : Sponge.getSpongeRegistry().dimensionClassMappings
+                                .entrySet()) {
+                            if (mapEntry.getKey().getCanonicalName().equalsIgnoreCase(spongeData.getString("dimensionType"))) {
+                                Sponge.getSpongeRegistry().registerWorldDimensionId(dimension, child.getName());
+                                if (!DimensionManager.isDimensionRegistered(dimension)) {
+                                    DimensionManager.registerDimension(dimension,
+                                            ((SpongeDimensionType) mapEntry.getValue()).getDimensionTypeId());
+                                }
+                            }
+                        }
+                    } else {
+                        Sponge.getLogger().info("World {} is disabled! Skipping world registration...", child.getName());
+                    }
+                }
+            } catch (Throwable t) {
+                Sponge.getLogger().error("Error during world registration.", t);
+            }
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/common/SpongeGame.java
+++ b/src/main/java/org/spongepowered/common/SpongeGame.java
@@ -42,6 +42,8 @@ import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.common.service.scheduler.AsyncScheduler;
 import org.spongepowered.common.service.scheduler.SyncScheduler;
 
+import java.io.File;
+
 import javax.inject.Singleton;
 
 @Singleton
@@ -113,4 +115,5 @@ public abstract class SpongeGame implements Game {
         return (Server) MinecraftServer.getServer();
     }
 
+    public abstract File getSavesDirectory();
 }

--- a/src/main/java/org/spongepowered/common/event/SpongeImplEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeImplEventFactory.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.event;
+
+import org.spongepowered.api.Game;
+import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.entity.player.PlayerJoinEvent;
+import org.spongepowered.api.event.entity.player.PlayerRespawnEvent;
+import org.spongepowered.api.event.world.WorldLoadEvent;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.sink.MessageSink;
+import org.spongepowered.api.world.Location;
+
+/**
+ * Utility that fires events that normally Forge fires at (in spots). Typically our penultimate goal
+ * is to not remove spots where events occur but sometimes it happens (in @Overwrites typically). Normally events that are
+ * in Forge are called themselves in SpongeVanilla but when it can't really occur, we fix this issue with Sponge by overwriting
+ * this class
+ */
+public class SpongeImplEventFactory {
+
+    public static WorldLoadEvent createWorldLoad(Game game, org.spongepowered.api.world.World world) {
+        return SpongeEventFactory.createWorldLoad(game, world);
+    }
+
+    public static PlayerJoinEvent createPlayerJoin(Game game, Player player, Location location, Text text, MessageSink sink) {
+        return SpongeEventFactory.createPlayerJoin(game, player, location, text, sink);
+    }
+
+    public static PlayerRespawnEvent createPlayerRespawn(Game game, Player player, boolean bedSpawn, Location respawnLocation) {
+        return SpongeEventFactory.createPlayerRespawn(game, player, bedSpawn, respawnLocation);
+    }
+}
+

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinEntity.java
@@ -26,7 +26,6 @@ package org.spongepowered.common.interfaces;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
-import org.spongepowered.api.world.Location;
 
 public interface IMixinEntity {
 
@@ -48,9 +47,9 @@ public interface IMixinEntity {
 
     void inactiveTick();
 
-    NBTTagCompound getSpongeData();
+    NBTTagCompound getEntityData();
 
-    boolean teleportEntity(Entity entity, Location location, int currentDim, int targetDim, boolean forced);
+    NBTTagCompound getSpongeData();
 
     /**
      * Read extra data (SpongeData) from the entity's NBT tag.

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayer.java
@@ -22,26 +22,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.core.world;
+package org.spongepowered.common.interfaces;
 
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.WorldProviderEnd;
-import net.minecraft.world.WorldType;
-import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraft.world.gen.ChunkProviderEnd;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Mixin;
+import net.minecraft.util.BlockPos;
 
-@NonnullByDefault
-@Mixin(WorldProviderEnd.class)
-public abstract class MixinWorldProviderEnd extends WorldProvider {
+public interface IMixinEntityPlayer extends IMixinEntity {
+    BlockPos getBedLocation(int dim);
 
-    @Override
-    public IChunkProvider createChunkGenerator() {
-        if (this.terrainType == WorldType.DEFAULT) {
-            return new ChunkProviderEnd(this.worldObj, this.worldObj.getSeed());
-        } else {
-            return super.createChunkGenerator(); // use custom GeneratorType
-        }
-    }
+    boolean isSpawnForced(int dim);
 }

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayerMP.java
@@ -28,4 +28,6 @@ package org.spongepowered.common.interfaces;
 public interface IMixinEntityPlayerMP {
 
     void reset();
+
+    boolean usesCustomClient();
 }

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinMinecraftServer.java
@@ -22,26 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.core.world;
+package org.spongepowered.common.interfaces;
 
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.WorldProviderEnd;
-import net.minecraft.world.WorldType;
-import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraft.world.gen.ChunkProviderEnd;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Mixin;
+import net.minecraft.world.chunk.storage.AnvilSaveHandler;
 
-@NonnullByDefault
-@Mixin(WorldProviderEnd.class)
-public abstract class MixinWorldProviderEnd extends WorldProvider {
+import java.util.Hashtable;
 
-    @Override
-    public IChunkProvider createChunkGenerator() {
-        if (this.terrainType == WorldType.DEFAULT) {
-            return new ChunkProviderEnd(this.worldObj, this.worldObj.getSeed());
-        } else {
-            return super.createChunkGenerator(); // use custom GeneratorType
-        }
-    }
+public interface IMixinMinecraftServer {
+
+    Hashtable<Integer, long[]> getWorldTickTimes();
+
+    AnvilSaveHandler getHandler(String worldName);
 }

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinWorldProvider.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinWorldProvider.java
@@ -24,13 +24,23 @@
  */
 package org.spongepowered.common.interfaces;
 
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.BlockPos;
 import org.spongepowered.common.configuration.SpongeConfig;
 
 public interface IMixinWorldProvider {
+
+    String getSaveFolder();
+
+    void setDimension(int dim);
 
     void setDimensionConfig(SpongeConfig<SpongeConfig.DimensionConfig> config);
 
     SpongeConfig<SpongeConfig.DimensionConfig> getDimensionConfig();
 
     int getAverageGroundLevel();
+
+    BlockPos getRandomizedSpawnPoint();
+
+    int getRespawnDimension(EntityPlayerMP playerIn);
 }

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinWorldType.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinWorldType.java
@@ -31,9 +31,13 @@ import org.spongepowered.common.world.gen.SpongeWorldGenerator;
 
 public interface IMixinWorldType {
 
-    public static final DataQuery STRING_VALUE = DataQuery.of("customSettings");
+    DataQuery STRING_VALUE = DataQuery.of("customSettings");
 
     SpongeWorldGenerator createGenerator(World world, DataContainer settings);
 
     SpongeWorldGenerator createGeneratorFromString(World world, String settings);
+
+    int getMinimumSpawnHeight(net.minecraft.world.World world);
+
+    int getSpawnFuzz();
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntity.java
@@ -61,11 +61,11 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
     @Override
     public DataContainer toContainer() {
         DataContainer container = new MemoryDataContainer();
-        container.set(of("world"), ((World) this.worldObj).getName());
+        container.set(of("world"), ((World) this.worldObj).getUniqueId().toString());
         container.set(of("x"), this.getPos().getX());
         container.set(of("y"), this.getPos().getY());
         container.set(of("z"), this.getPos().getZ());
-        container.set(of("tileType"), net.minecraft.tileentity.TileEntity.classToNameMap.get(this.getClass()));
+        container.set(of("tileType"), this.getClass().getSimpleName());
         return container;
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -29,9 +29,13 @@ import static org.spongepowered.api.data.DataQuery.of;
 import com.flowpowered.math.vector.Vector3d;
 import com.google.common.base.Optional;
 import net.minecraft.entity.DataWatcher;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.play.server.S07PacketRespawn;
 import net.minecraft.network.play.server.S08PacketPlayerPosLook;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.entity.Entity;
@@ -51,8 +55,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.interfaces.IMixinEntity;
+import org.spongepowered.common.interfaces.IMixinEntityPlayerMP;
 import org.spongepowered.common.registry.SpongeGameRegistry;
 import org.spongepowered.common.util.SpongeHooks;
+import org.spongepowered.common.world.DimensionManager;
 
 import java.util.ArrayDeque;
 import java.util.EnumSet;
@@ -98,7 +104,6 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
     @Shadow public net.minecraft.entity.Entity ridingEntity;
     @Shadow protected DataWatcher dataWatcher;
     @Shadow protected Random rand;
-
     @Shadow public abstract void setPosition(double x, double y, double z);
     @Shadow public abstract void mountEntity(net.minecraft.entity.Entity entityIn);
     @Shadow public abstract void setDead();
@@ -454,6 +459,70 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         return true;
     }
 
+    // for sponge internal use only
+    @SuppressWarnings("unchecked")
+    public boolean teleportEntity(net.minecraft.entity.Entity entity, Location location, int currentDim, int targetDim, boolean forced) {
+        MinecraftServer mcServer = MinecraftServer.getServer();
+        final WorldServer fromWorld = mcServer.worldServerForDimension(currentDim);
+        final WorldServer toWorld = mcServer.worldServerForDimension(targetDim);
+        if (entity instanceof EntityPlayer) {
+            fromWorld.getEntityTracker().removePlayerFromTrackers((EntityPlayerMP) entity);
+            fromWorld.getPlayerManager().removePlayer((EntityPlayerMP) entity);
+            mcServer.getConfigurationManager().playerEntityList.remove(entity);
+        } else {
+            fromWorld.getEntityTracker().untrackEntity(entity);
+        }
+
+        entity.worldObj.removePlayerEntityDangerously(entity);
+        entity.dimension = targetDim;
+        entity.setPositionAndRotation(location.getX(), location.getY(), location.getZ(), 0, 0);
+        if (forced) {
+            while (!toWorld.getCollidingBoundingBoxes(entity, entity.getEntityBoundingBox()).isEmpty() && entity.posY < 256.0D) {
+                entity.setPosition(entity.posX, entity.posY + 1.0D, entity.posZ);
+            }
+        }
+
+        toWorld.theChunkProviderServer.loadChunk((int) entity.posX >> 4, (int) entity.posZ >> 4);
+
+        if (entity instanceof EntityPlayer) {
+            EntityPlayerMP entityplayermp1 = (EntityPlayerMP) entity;
+
+            // Support vanilla clients going into custom dimensions
+            int clientDimension = DimensionManager.getClientDimensionToSend(toWorld.provider.getDimensionId(), toWorld, entityplayermp1);
+            if (((IMixinEntityPlayerMP) entityplayermp1).usesCustomClient()) {
+                DimensionManager.sendDimensionRegistration(toWorld, entityplayermp1, clientDimension);
+            } else {
+                // Send bogus dimension change for same worlds on Vanilla client
+                if (currentDim != targetDim && (currentDim == clientDimension || targetDim == clientDimension)) {
+                    entityplayermp1.playerNetServerHandler.sendPacket(
+                            new S07PacketRespawn(((clientDimension + 2) % 3) - 1, toWorld.getDifficulty(), toWorld.getWorldInfo().getTerrainType(),
+                                    entityplayermp1.theItemInWorldManager.getGameType()));
+                }
+            }
+
+            entityplayermp1.playerNetServerHandler.sendPacket(
+                    new S07PacketRespawn(clientDimension, toWorld.getDifficulty(), toWorld.getWorldInfo().getTerrainType(),
+                            entityplayermp1.theItemInWorldManager.getGameType()));
+            entity.setWorld(toWorld);
+            entity.isDead = false;
+            entityplayermp1.playerNetServerHandler.setPlayerLocation(entityplayermp1.posX, entityplayermp1.posY, entityplayermp1.posZ,
+                    entityplayermp1.rotationYaw, entityplayermp1.rotationPitch);
+            entityplayermp1.setSneaking(false);
+            mcServer.getConfigurationManager().updateTimeAndWeatherForPlayer(entityplayermp1, toWorld);
+            toWorld.getPlayerManager().addPlayer(entityplayermp1);
+            toWorld.spawnEntityInWorld(entityplayermp1);
+            mcServer.getConfigurationManager().playerEntityList.add(entityplayermp1);
+            entityplayermp1.theItemInWorldManager.setWorld(toWorld);
+            entityplayermp1.addSelfToInternalCraftingInventory();
+            entityplayermp1.setHealth(entityplayermp1.getHealth());
+        } else {
+            toWorld.spawnEntityInWorld(entity);
+        }
+
+        fromWorld.resetUpdateEntityTick();
+        toWorld.resetUpdateEntityTick();
+        return true;
+    }
 
     /**
      * Hooks into vanilla's writeToNBT to call {@link #writeToNbt}.
@@ -516,8 +585,11 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
     @Override
     public DataContainer toContainer() {
         DataContainer container = new MemoryDataContainer();
-        container.set(of("World"), this.getWorld().getUniqueId().toString());
-        // TODO do stuff with more container information
+        container.set(of("world"), ((World) this.worldObj).getUniqueId().toString());
+        container.set(of("x"), this.getLocation().getX());
+        container.set(of("y"), this.getLocation().getY());
+        container.set(of("z"), this.getLocation().getZ());
+        container.set(of("entityType"), this.getClass().getSimpleName());
         return container;
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
@@ -34,11 +34,12 @@ import net.minecraft.util.IChatComponent;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.interfaces.IMixinEntityPlayer;
 import org.spongepowered.common.mixin.core.entity.living.MixinEntityLivingBase;
 
 @NonnullByDefault
 @Mixin(EntityPlayer.class)
-public abstract class MixinEntityPlayer extends MixinEntityLivingBase {
+public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements IMixinEntityPlayer {
 
     @Shadow public Container inventoryContainer;
     @Shadow public Container openContainer;
@@ -126,5 +127,4 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase {
     public void setFlying(boolean flying) {
         this.capabilities.isFlying = flying;
     }
-
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -326,6 +326,11 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     }
 
     @Override
+    public boolean usesCustomClient() {
+        return false;
+    }
+
+    @Override
     public JoinData getJoinData() {
         return getData(JoinData.class).get();
     }
@@ -366,6 +371,7 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
         return this.mcScoreboard;
     }
 
+    @Override
     public org.spongepowered.api.scoreboard.Scoreboard getScoreboard() {
         return this.spongeScoreboard;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
@@ -24,48 +24,367 @@
  */
 package org.spongepowered.common.mixin.core.server;
 
-import com.google.common.collect.Maps;
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Optional;
+import com.mojang.authlib.GameProfile;
+import io.netty.buffer.Unpooled;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S01PacketJoinGame;
+import net.minecraft.network.play.server.S03PacketTimeUpdate;
+import net.minecraft.network.play.server.S05PacketSpawnPosition;
+import net.minecraft.network.play.server.S07PacketRespawn;
+import net.minecraft.network.play.server.S09PacketHeldItemChange;
+import net.minecraft.network.play.server.S1DPacketEntityEffect;
+import net.minecraft.network.play.server.S1FPacketSetExperience;
+import net.minecraft.network.play.server.S2BPacketChangeGameState;
+import net.minecraft.network.play.server.S39PacketPlayerAbilities;
+import net.minecraft.network.play.server.S3FPacketCustomPayload;
+import net.minecraft.network.play.server.S41PacketServerDifficulty;
+import net.minecraft.network.play.server.S44PacketWorldBorder;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.scoreboard.ServerScoreboard;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerProfileCache;
 import net.minecraft.server.management.ServerConfigurationManager;
 import net.minecraft.util.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.world.WorldServer;
+import net.minecraft.world.storage.IPlayerFileData;
+import net.minecraft.world.storage.WorldInfo;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.data.manipulator.entity.RespawnLocationData;
 import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.event.entity.player.PlayerJoinEvent;
+import org.spongepowered.api.event.entity.player.PlayerRespawnEvent;
 import org.spongepowered.api.scoreboard.Scoreboard;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Surrogate;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.common.Sponge;
+import org.spongepowered.common.event.SpongeImplEventFactory;
+import org.spongepowered.common.interfaces.IMixinEntityPlayer;
+import org.spongepowered.common.interfaces.IMixinEntityPlayerMP;
+import org.spongepowered.common.interfaces.IMixinServerConfigurationManager;
+import org.spongepowered.common.interfaces.IMixinWorldProvider;
+import org.spongepowered.common.text.SpongeTexts;
+import org.spongepowered.common.world.DimensionManager;
+import org.spongepowered.common.world.border.PlayerBorderListener;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-@Mixin(ServerConfigurationManager.class)
-public class MixinServerConfigurationManager {
+import javax.annotation.Nullable;
 
+@NonnullByDefault
+@Mixin(ServerConfigurationManager.class)
+public abstract class MixinServerConfigurationManager implements IMixinServerConfigurationManager {
+
+    @Shadow private static Logger logger;
+    @Shadow private MinecraftServer mcServer;
+    @Shadow private IPlayerFileData playerNBTManagerObj;
+    @SuppressWarnings("rawtypes")
+    @Shadow public List playerEntityList;
+    @Shadow public abstract NBTTagCompound readPlayerDataFromFile(EntityPlayerMP playerIn);
+    @Shadow public abstract void setPlayerGameTypeBasedOnOther(EntityPlayerMP p_72381_1_, EntityPlayerMP p_72381_2_, net.minecraft.world.World worldIn);
+    @Shadow protected abstract void func_96456_a(ServerScoreboard scoreboardIn, EntityPlayerMP playerIn);
+    @Shadow public abstract MinecraftServer getServerInstance();
+    @Shadow public abstract int getMaxPlayers();
+    @Shadow public abstract void sendChatMsg(IChatComponent component);
+    @Shadow public abstract void playerLoggedIn(EntityPlayerMP playerIn);
     @Shadow public Map<UUID, EntityPlayerMP> uuidToPlayerMap;
 
     private Scoreboard scoreboard;
 
-    @Inject(method = "recreatePlayerEntity", at = @At("HEAD"))
-    public void onRecreatePlayerEntity(EntityPlayerMP playerIn, int dimension, boolean conqueredEnd, CallbackInfoReturnable<EntityPlayerMP> cir) {
+    /**
+     * Bridge methods to proxy modified method in Vanilla, nothing in Forge
+     */
+    public void func_72355_a (NetworkManager netManager, EntityPlayerMP playerIn) {
+        initializeConnectionToPlayer(netManager, playerIn, null);
+    }
+
+    /**
+     * Bridge methods to proxy modified method in Vanilla, nothing in Forge
+     */
+    public void initializeConnectionToPlayer(NetworkManager netManager, EntityPlayerMP playerIn) {
+        initializeConnectionToPlayer(netManager, playerIn, null);
+    }
+
+    @SuppressWarnings("rawtypes")
+    public void initializeConnectionToPlayer(NetworkManager netManager, EntityPlayerMP playerIn, @Nullable NetHandlerPlayServer handler) {
+        GameProfile gameprofile = playerIn.getGameProfile();
+        PlayerProfileCache playerprofilecache = this.mcServer.getPlayerProfileCache();
+        GameProfile gameprofile1 = playerprofilecache.getProfileByUUID(gameprofile.getId());
+        String s = gameprofile1 == null ? gameprofile.getName() : gameprofile1.getName();
+        playerprofilecache.addEntry(gameprofile);
+        NBTTagCompound nbttagcompound = this.readPlayerDataFromFile(playerIn);
+        WorldServer worldserver = this.mcServer.worldServerForDimension(playerIn.dimension);
+
+        if (worldserver == null) {
+            playerIn.dimension = 0;
+            worldserver = this.mcServer.worldServerForDimension(0);
+            BlockPos spawnPoint = ((IMixinWorldProvider) worldserver.provider).getRandomizedSpawnPoint();
+            playerIn.setPosition(spawnPoint.getX(), spawnPoint.getY(), spawnPoint.getZ());
+        }
+
+        playerIn.setWorld(worldserver);
+        playerIn.theItemInWorldManager.setWorld((WorldServer) playerIn.worldObj);
+        String s1 = "local";
+
+        if (netManager.getRemoteAddress() != null) {
+            s1 = netManager.getRemoteAddress().toString();
+        }
+
+        // Sponge Start
+
+        if (handler == null) {
+            // Create the handler here (so the player's gets set)
+            handler = new NetHandlerPlayServer(this.mcServer, netManager, playerIn);
+        }
+
+        playerIn.playerNetServerHandler = handler;
+
+        // Sponge End
+
+        WorldInfo worldinfo = worldserver.getWorldInfo();
+        BlockPos blockpos = worldserver.getSpawnPoint();
+        this.setPlayerGameTypeBasedOnOther(playerIn, null, worldserver);
+
+        // Support vanilla clients logging into custom dimensions
+        int dimension = DimensionManager.getClientDimensionToSend(worldserver.provider.getDimensionId(), worldserver, playerIn);
+        if (((IMixinEntityPlayerMP) playerIn).usesCustomClient()) {
+            DimensionManager.sendDimensionRegistration(worldserver, playerIn, dimension);
+        }
+
+        handler.sendPacket(new S01PacketJoinGame(playerIn.getEntityId(), playerIn.theItemInWorldManager.getGameType(), worldinfo
+                .isHardcoreModeEnabled(), dimension, worldserver.getDifficulty(), this.getMaxPlayers(), worldinfo
+                .getTerrainType(), worldserver.getGameRules().getGameRuleBooleanValue("reducedDebugInfo")));
+        handler.sendPacket(new S3FPacketCustomPayload("MC|Brand", (new PacketBuffer(Unpooled.buffer())).writeString(this
+                .getServerInstance().getServerModName())));
+        handler.sendPacket(new S41PacketServerDifficulty(worldinfo.getDifficulty(), worldinfo.isDifficultyLocked()));
+        handler.sendPacket(new S05PacketSpawnPosition(blockpos));
+        handler.sendPacket(new S39PacketPlayerAbilities(playerIn.capabilities));
+        handler.sendPacket(new S09PacketHeldItemChange(playerIn.inventory.currentItem));
+        playerIn.getStatFile().func_150877_d();
+        playerIn.getStatFile().func_150884_b(playerIn);
+        this.mcServer.refreshStatusNextTick();
+
+        this.playerLoggedIn(playerIn);
+        handler.setPlayerLocation(playerIn.posX, playerIn.posY, playerIn.posZ, playerIn.rotationYaw, playerIn.rotationPitch);
+        this.updateTimeAndWeatherForPlayer(playerIn, worldserver);
+
+        if (this.mcServer.getResourcePackUrl().length() > 0) {
+            playerIn.loadResourcePack(this.mcServer.getResourcePackUrl(), this.mcServer.getResourcePackHash());
+        }
+
+        playerIn.addSelfToInternalCraftingInventory();
+
+
+        // Sponge Start
+
+        // Move logic for creating join message up here
+        ChatComponentTranslation chatcomponenttranslation;
+
+        if (!playerIn.getCommandSenderName().equalsIgnoreCase(s))
+        {
+            chatcomponenttranslation = new ChatComponentTranslation("multiplayer.player.joined.renamed", new Object[] {playerIn.getDisplayName(), s});
+        }
+        else
+        {
+            chatcomponenttranslation = new ChatComponentTranslation("multiplayer.player.joined", new Object[] {playerIn.getDisplayName()});
+        }
+
+        chatcomponenttranslation.getChatStyle().setColor(EnumChatFormatting.YELLOW);
+
+        // Fire PlayerJoinEvent
+        final PlayerJoinEvent event = SpongeImplEventFactory.createPlayerJoin(Sponge.getGame(), (Player) playerIn, ((Player) playerIn).getLocation(),
+                SpongeTexts.toText(chatcomponenttranslation), ((Player) playerIn).getMessageSink());
+        Sponge.getGame().getEventManager().post(event);
+        // Set the resolved location of the event onto the player
+        ((Player) playerIn).setLocation(event.getLocation());
+
+        logger.info(playerIn.getCommandSenderName() + "[" + s1 + "] logged in with entity id " + playerIn.getEntityId() + " at (" + playerIn.posX
+                + ", " + playerIn.posY + ", " + playerIn.posZ + ")");
+
+        // Sponge start -> Send to the sink
+        event.getSink().sendMessage(event.getNewMessage());
+        // Sponge end
+
+        this.func_96456_a((ServerScoreboard) worldserver.getScoreboard(), playerIn);
+
+        for (Object o : playerIn.getActivePotionEffects()) {
+            PotionEffect potioneffect = (PotionEffect) o;
+            handler.sendPacket(new S1DPacketEntityEffect(playerIn.getEntityId(), potioneffect));
+        }
+
+        if (nbttagcompound != null && nbttagcompound.hasKey("Riding", 10)) {
+            Entity entity = EntityList.createEntityFromNBT(nbttagcompound.getCompoundTag("Riding"), worldserver);
+
+            if (entity != null) {
+                entity.forceSpawn = true;
+                worldserver.spawnEntityInWorld(entity);
+                playerIn.mountEntity(entity);
+                entity.forceSpawn = false;
+            }
+        }
+    }
+
+    @SuppressWarnings({"unused", "unchecked"})
+    @Overwrite
+    public EntityPlayerMP recreatePlayerEntity(EntityPlayerMP playerIn, int targetDimension, boolean conqueredEnd) {
         this.scoreboard = ((Player) playerIn).getScoreboard();
+
+        // Phase 1 - check if the player is allowed to respawn in same dimension
+        net.minecraft.world.World world = this.mcServer.worldServerForDimension(targetDimension);
+        World fromWorld = (World) playerIn.worldObj;
+
+        if (!world.provider.canRespawnHere()) {
+            targetDimension = ((IMixinWorldProvider) world.provider).getRespawnDimension(playerIn);
+        }
+
+        // Phase 2 - handle return from End
+        if (conqueredEnd) {
+            WorldServer exitWorld = this.mcServer.worldServerForDimension(targetDimension);
+            Location enter = ((Player) playerIn).getLocation();
+            Optional<Location> exit = Optional.absent();
+            // use bed if available, otherwise default spawn
+            if (((Player) playerIn).getData(RespawnLocationData.class).isPresent()) {
+                exit = Optional.of(((Player) playerIn).getData(RespawnLocationData.class).get().getRespawnLocation());
+            }
+            if (!exit.isPresent() || ((net.minecraft.world.World) exit.get().getExtent()).provider.getDimensionId() != 0) {
+                Vector3i pos = ((World) exitWorld).getProperties().getSpawnPosition();
+                exit = Optional.of(new Location((World) exitWorld, new Vector3d(pos.getX(), pos.getY(), pos.getZ())));
+            }
+        }
+
+        // Phase 3 - remove current player from current dimension
+        playerIn.getServerForPlayer().getEntityTracker().removePlayerFromTrackers(playerIn);
+        playerIn.getServerForPlayer().getPlayerManager().removePlayer(playerIn);
+        this.playerEntityList.remove(playerIn);
+        this.mcServer.worldServerForDimension(playerIn.dimension).removePlayerEntityDangerously(playerIn);
+
+        // Phase 4 - handle bed spawn
+        BlockPos bedSpawnChunkCoords = ((IMixinEntityPlayer) playerIn).getBedLocation(targetDimension);
+        boolean spawnForced = ((IMixinEntityPlayer) playerIn).isSpawnForced(targetDimension);
+        playerIn.dimension = targetDimension;
+        // make sure to update reference for bed spawn logic
+        playerIn.setWorld(this.mcServer.worldServerForDimension(playerIn.dimension));
+        playerIn.playerConqueredTheEnd = false;
+        BlockPos bedSpawnLocation;
+        boolean isBedSpawn = false;
+        World toWorld = ((World) playerIn.worldObj);
+        Location location = null;
+
+        if (bedSpawnChunkCoords != null) { // if player has a bed
+            bedSpawnLocation =
+                    EntityPlayer.getBedSpawnLocation(this.mcServer.worldServerForDimension(playerIn.dimension), bedSpawnChunkCoords, spawnForced);
+
+            if (bedSpawnLocation != null) {
+                isBedSpawn = true;
+                playerIn.setLocationAndAngles(bedSpawnLocation.getX() + 0.5F,
+                        bedSpawnLocation.getY() + 0.1F, bedSpawnLocation.getZ() + 0.5F, 0.0F, 0.0F);
+                playerIn.setSpawnPoint(bedSpawnChunkCoords, spawnForced);
+                location =
+                        new Location(toWorld, new Vector3d(bedSpawnChunkCoords.getX() + 0.5, bedSpawnChunkCoords.getY(),
+                                bedSpawnChunkCoords.getZ() + 0.5));
+            } else { // bed was not found (broken)
+                playerIn.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(0, 0));
+                // use the spawnpoint as location
+                location =
+                        new Location(toWorld, new Vector3d(toWorld.getProperties().getSpawnPosition().getX(), toWorld.getProperties()
+                                .getSpawnPosition().getY(), toWorld.getProperties().getSpawnPosition().getZ()));
+            }
+        }
+
+        if (location == null) {
+            // use the world spawnpoint as default location
+            location =
+                    new Location(toWorld, new Vector3d(toWorld.getProperties().getSpawnPosition().getX(), toWorld.getProperties().getSpawnPosition()
+                            .getY(), toWorld.getProperties().getSpawnPosition().getZ()));
+        }
+
+        if (!conqueredEnd) { // don't reset player if returning from end
+            ((IMixinEntityPlayerMP) playerIn).reset();
+        }
+
+        final PlayerRespawnEvent event = SpongeImplEventFactory.createPlayerRespawn(Sponge.getGame(), (Player) playerIn, isBedSpawn, location);
+        Sponge.getGame().getEventManager().post(event);
+        location = event.getNewRespawnLocation();
+
+        final WorldServer targetWorld = (WorldServer) location.getExtent();
+        targetWorld.theChunkProviderServer.loadChunk((int) location.getX() >> 4, (int) location.getZ() >> 4);
+
+        // Phase 5 - Respawn player in new world
+        // Support vanilla clients logging into custom dimensions
+        int dimension = DimensionManager.getClientDimensionToSend(targetWorld.provider.getDimensionId(), targetWorld, playerIn);
+        if (((IMixinEntityPlayerMP) playerIn).usesCustomClient()) {
+            DimensionManager.sendDimensionRegistration(targetWorld, playerIn, dimension);
+        }
+
+        playerIn.playerNetServerHandler.sendPacket(new S07PacketRespawn(dimension, targetWorld.getDifficulty(), targetWorld
+                .getWorldInfo().getTerrainType(), playerIn.theItemInWorldManager.getGameType()));
+        playerIn.setWorld(targetWorld); // in case plugin changed it
+        playerIn.isDead = false;
+        BlockPos blockpos1 = targetWorld.getSpawnPoint();
+        playerIn.playerNetServerHandler.setPlayerLocation(location.getX(), location.getY(), location.getZ(),
+                playerIn.rotationYaw, playerIn.rotationPitch);
+
+        // Keep players out of blocks
+        while (!targetWorld.getCollidingBoundingBoxes(playerIn, playerIn.getEntityBoundingBox()).isEmpty()) {
+            playerIn.setPosition(playerIn.posX, playerIn.posY + 1.0D, playerIn.posZ);
+        }
+
+        playerIn.setSneaking(false);
+        final BlockPos spawnLocation = targetWorld.getSpawnPoint();
+        playerIn.playerNetServerHandler.sendPacket(new S05PacketSpawnPosition(spawnLocation));
+        playerIn.playerNetServerHandler.sendPacket(new S1FPacketSetExperience(playerIn.experience, playerIn.experienceTotal,
+                playerIn.experienceLevel));
+        this.updateTimeAndWeatherForPlayer(playerIn, targetWorld);
+        targetWorld.getPlayerManager().addPlayer(playerIn);
+        targetWorld.spawnEntityInWorld(playerIn);
+        this.playerEntityList.add(playerIn);
+        playerIn.addSelfToInternalCraftingInventory();
+        playerIn.setHealth(playerIn.getHealth());
+
+        ((Player) playerIn).setScoreboard(this.scoreboard);
+        ((Player) this.uuidToPlayerMap.get(playerIn.getUniqueID())).setScoreboard(this.scoreboard);
+
+        return playerIn;
     }
 
-    @Inject(method = "recreatePlayerEntity", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
-    public void onRecreatePlayerEntityReturn(EntityPlayerMP playerIn, int dimension, boolean conqueredEnd, CallbackInfoReturnable<EntityPlayerMP> cir, World world, BlockPos blockpos, boolean flag1, Object object, EntityPlayerMP entityplayermp1, WorldServer worldserver, BlockPos blockpos1) {
-        ((Player) entityplayermp1).setScoreboard(this.scoreboard);
-        this.scoreboard = null;
+    @Overwrite
+    public void setPlayerManager(WorldServer[] worldServers) {
+        if (this.playerNBTManagerObj != null) {
+            return;
+        }
+        this.playerNBTManagerObj = worldServers[0].getSaveHandler().getPlayerNBTManager();
+        worldServers[0].getWorldBorder().addListener(new PlayerBorderListener());
     }
 
-    // The 'world' local variable is only present in SpongeForge's @Overwrite
-    @Surrogate
-    public void onRecreatePlayerEntityReturn(EntityPlayerMP playerIn, int dimension, boolean conqueredEnd, CallbackInfoReturnable<EntityPlayerMP> cir, BlockPos blockpos, boolean flag1, Object object, EntityPlayerMP entityplayermp1, WorldServer worldserver, BlockPos blockpos1 ) {
-        ((Player) entityplayermp1).setScoreboard(this.scoreboard);
-        this.scoreboard = null;
-    }
+    @Overwrite
+    public void updateTimeAndWeatherForPlayer(EntityPlayerMP playerIn, WorldServer worldIn) {
+        net.minecraft.world.border.WorldBorder worldborder = worldIn.getWorldBorder();
+        playerIn.playerNetServerHandler.sendPacket(new S44PacketWorldBorder(worldborder, S44PacketWorldBorder.Action.INITIALIZE));
+        playerIn.playerNetServerHandler.sendPacket(new S03PacketTimeUpdate(worldIn.getTotalWorldTime(), worldIn.getWorldTime(), worldIn
+                .getGameRules().getGameRuleBooleanValue("doDaylightCycle")));
 
+        if (worldIn.isRaining()) {
+            playerIn.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(1, 0.0F));
+            playerIn.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(7, worldIn.getRainStrength(1.0F)));
+            playerIn.playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(8, worldIn.getThunderStrength(1.0F)));
+        }
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinAnvilSaveHandler.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinAnvilSaveHandler.java
@@ -36,7 +36,7 @@ import java.io.File;
 
 @NonnullByDefault
 @Mixin(net.minecraft.world.chunk.storage.AnvilSaveHandler.class)
-public class MixinAnvilSaveHandler extends SaveHandler {
+public abstract class MixinAnvilSaveHandler extends SaveHandler {
 
     public MixinAnvilSaveHandler(File savesDirectory, String directoryName, boolean playersDirectoryIn) {
         super(savesDirectory, directoryName, playersDirectoryIn);
@@ -45,7 +45,7 @@ public class MixinAnvilSaveHandler extends SaveHandler {
     @Override
     @Overwrite
     public IChunkLoader getChunkLoader(WorldProvider provider) {
-        // To workaround the issue of every world having a seperate savehandler
+        // To workaround the issue of every world having a separate save handler
         // we won't be generating a DIMXX folder for chunk loaders since this name is already generated
         // for the world container with provider.getSaveFolder().
         // This allows users to remove our mod and maintain world compatibility.

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -53,6 +53,7 @@ import net.minecraft.world.storage.ISaveHandler;
 import net.minecraft.world.storage.WorldInfo;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.spongepowered.api.Platform;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.tileentity.TileEntity;
@@ -76,8 +77,10 @@ import org.spongepowered.api.world.WorldBorder;
 import org.spongepowered.api.world.WorldCreationSettings;
 import org.spongepowered.api.world.biome.BiomeType;
 import org.spongepowered.api.world.difficulty.Difficulty;
+import org.spongepowered.api.world.gen.BiomeGenerator;
 import org.spongepowered.api.world.gen.GeneratorPopulator;
 import org.spongepowered.api.world.gen.Populator;
+import org.spongepowered.api.world.gen.WorldGenerator;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 import org.spongepowered.api.world.storage.WorldProperties;
 import org.spongepowered.api.world.weather.Weather;
@@ -101,9 +104,15 @@ import org.spongepowered.common.interfaces.block.IMixinBlock;
 import org.spongepowered.common.scoreboard.SpongeScoreboard;
 import org.spongepowered.common.util.SpongeHooks;
 import org.spongepowered.common.util.VecHelper;
+import org.spongepowered.common.world.border.PlayerBorderListener;
+import org.spongepowered.common.world.gen.CustomChunkProviderGenerate;
+import org.spongepowered.common.world.gen.CustomWorldChunkManager;
+import org.spongepowered.common.world.gen.SpongeBiomeGenerator;
+import org.spongepowered.common.world.gen.SpongeGeneratorPopulator;
 import org.spongepowered.common.world.gen.SpongeWorldGenerator;
 import org.spongepowered.common.world.storage.SpongeChunkLayout;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -139,39 +148,35 @@ public abstract class MixinWorld implements World, IMixinWorld {
     @Shadow(prefix = "shadow$") public abstract net.minecraft.world.border.WorldBorder shadow$getWorldBorder();
     @Shadow(prefix = "shadow$") public abstract EnumDifficulty shadow$getDifficulty();
 
-    @Shadow
-    public abstract boolean spawnEntityInWorld(net.minecraft.entity.Entity entityIn);
-
-    @Shadow
-    public abstract List<net.minecraft.entity.Entity> getEntities(Class<net.minecraft.entity.Entity> entityType,
+    @Shadow public abstract boolean spawnEntityInWorld(net.minecraft.entity.Entity entityIn);
+    @Shadow public abstract List<net.minecraft.entity.Entity> getEntities(Class<net.minecraft.entity.Entity> entityType,
             Predicate<net.minecraft.entity.Entity> filter);
+    @Shadow public abstract void playSoundEffect(double x, double y, double z, String soundName, float volume, float pitch);
+    @Shadow public abstract BiomeGenBase getBiomeGenForCoords(BlockPos pos);
+    @Shadow public abstract IChunkProvider getChunkProvider();
+    @Shadow public abstract WorldChunkManager getWorldChunkManager();
+    @Shadow public abstract net.minecraft.tileentity.TileEntity getTileEntity(BlockPos pos);
+    @Shadow public abstract boolean isBlockPowered(BlockPos pos);
+    @Shadow public abstract IBlockState getBlockState(BlockPos pos);
+    @Shadow public abstract net.minecraft.world.chunk.Chunk getChunkFromChunkCoords(int chunkX, int chunkZ);
+    @Shadow public abstract boolean isChunkLoaded(int x, int z, boolean allowEmpty);
+    @Shadow private net.minecraft.world.border.WorldBorder worldBorder;
 
-    @Shadow
-    public abstract void playSoundEffect(double x, double y, double z, String soundName, float volume, float pitch);
+    @Inject(method = "<init>", at = @At("RETURN"))
+    public void onConstructed(ISaveHandler saveHandlerIn, WorldInfo info, WorldProvider providerIn, Profiler profilerIn, boolean client,
+            CallbackInfo ci) {
+        if (!client) {
+            String providerName = providerIn.getDimensionName().toLowerCase().replace(" ", "_").replace("[^A-Za-z0-9_]", "");
+            this.worldConfig =
+                    new SpongeConfig<SpongeConfig.WorldConfig>(SpongeConfig.Type.WORLD, new File(Sponge.getConfigDirectory() + File.separator +
+                            providerName + File.separator + (providerIn.getDimensionId() == 0 ? "DIM0" : Sponge.getSpongeRegistry().getWorldFolder
+                            (providerIn.getDimensionId())), "world.conf"), Sponge.ECOSYSTEM_NAME.toLowerCase());
+        }
 
-    @Shadow
-    public abstract BiomeGenBase getBiomeGenForCoords(BlockPos pos);
-
-    @Shadow
-    public abstract IChunkProvider getChunkProvider();
-
-    @Shadow
-    public abstract WorldChunkManager getWorldChunkManager();
-
-    @Shadow
-    public abstract net.minecraft.tileentity.TileEntity getTileEntity(BlockPos pos);
-
-    @Shadow
-    public abstract boolean isBlockPowered(BlockPos pos);
-
-    @Shadow
-    public abstract IBlockState getBlockState(BlockPos pos);
-
-    @Shadow
-    public abstract net.minecraft.world.chunk.Chunk getChunkFromChunkCoords(int chunkX, int chunkZ);
-
-    @Shadow
-    public abstract boolean isChunkLoaded(int x, int z, boolean allowEmpty);
+        if (Sponge.getGame().getPlatform().getType() == Platform.Type.SERVER) {
+            this.worldBorder.addListener(new PlayerBorderListener());
+        }
+    }
 
     @SuppressWarnings("rawtypes")
     @Inject(method = "getCollidingBoundingBoxes(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/AxisAlignedBB;)Ljava/util/List;", at = @At("HEAD"))
@@ -423,6 +428,14 @@ public abstract class MixinWorld implements World, IMixinWorld {
         }
     }
 
+    @Inject(method = "updateWeatherBody()V", remap = false, at = {
+            @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;setThundering(Z)V"),
+            @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;setRaining(Z)V")
+    })
+    private void onUpdateWeatherBody(CallbackInfo ci) {
+        this.weatherStartTime = this.worldInfo.getWorldTotalTime();
+    }
+
     @Override
     public Dimension getDimension() {
         return (Dimension) this.provider;
@@ -480,10 +493,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
 
     @Override
     public boolean unloadChunk(Chunk chunk) {
-        if (chunk == null) {
-            return false;
-        }
-        return chunk.unloadChunk();
+        return chunk != null && chunk.unloadChunk();
     }
 
     @Override
@@ -606,10 +616,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
     @Override
     public <T extends DataManipulator<T>> boolean remove(int x, int y, int z, Class<T> manipulatorClass) {
         Optional<SpongeBlockProcessor<T>> blockUtilOptional = SpongeManipulatorRegistry.getInstance().getBlockUtil(manipulatorClass);
-        if (blockUtilOptional.isPresent()) {
-            return blockUtilOptional.get().remove((net.minecraft.world.World) ((Object) this), new BlockPos(x, y, z));
-        }
-        return false;
+        return blockUtilOptional.isPresent() && blockUtilOptional.get().remove((net.minecraft.world.World) ((Object) this), new BlockPos(x, y, z));
     }
 
 
@@ -668,6 +675,42 @@ public abstract class MixinWorld implements World, IMixinWorld {
     @Override
     public boolean containsBlock(int x, int y, int z) {
         return VecHelper.inBounds(x, y, z, BLOCK_MIN, BLOCK_MAX);
+    }
+
+    @Override
+    public void setWorldGenerator(WorldGenerator generator) {
+        // Replace biome generator with possible modified one
+        BiomeGenerator biomeGenerator = generator.getBiomeGenerator();
+        WorldServer thisWorld = (WorldServer) (Object) this;
+        thisWorld.provider.worldChunkMgr = CustomWorldChunkManager.of(biomeGenerator);
+
+        // Replace generator populator with possibly modified one
+        GeneratorPopulator generatorPopulator = generator.getBaseGeneratorPopulator();
+        replaceChunkGenerator(CustomChunkProviderGenerate.of(thisWorld, generatorPopulator, biomeGenerator));
+
+        // Replace populators with possibly modified list
+        this.populators = ImmutableList.copyOf(generator.getPopulators());
+        this.generatorPopulators = ImmutableList.copyOf(generator.getGeneratorPopulators());
+    }
+
+    @Override
+    public WorldGenerator getWorldGenerator() {
+        // We have to create a new instance every time to satisfy the contract
+        // of this method, namely that changing the state of the returned
+        // instance does not affect the world without setWorldGenerator being
+        // called
+        ChunkProviderServer serverChunkProvider = (ChunkProviderServer) this.getChunkProvider();
+        WorldServer world = (WorldServer) (Object) this;
+        return new SpongeWorldGenerator(
+                SpongeBiomeGenerator.of(getWorldChunkManager()),
+                SpongeGeneratorPopulator.of(world, serverChunkProvider.serverChunkGenerator),
+                this.generatorPopulators,
+                this.populators);
+    }
+
+    private void replaceChunkGenerator(IChunkProvider provider) {
+        ChunkProviderServer chunkProviderServer = (ChunkProviderServer) this.getChunkProvider();
+        chunkProviderServer.serverChunkGenerator = provider;
     }
 
     private void checkBiomeBounds(int x, int z) {

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldProviderHell.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldProviderHell.java
@@ -31,14 +31,12 @@ import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.ChunkProviderHell;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 
 @NonnullByDefault
 @Mixin(WorldProviderHell.class)
 public abstract class MixinWorldProviderHell extends WorldProvider {
 
     @Override
-    @Overwrite
     public IChunkProvider createChunkGenerator() {
         if (this.terrainType == WorldType.DEFAULT) {
             return new ChunkProviderHell(this.worldObj, this.worldObj.getWorldInfo().isMapFeaturesEnabled(), this.worldObj.getSeed());

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldSettings.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldSettings.java
@@ -45,7 +45,7 @@ import java.util.Collection;
 
 @NonnullByDefault
 @Mixin(WorldSettings.class)
-public class MixinWorldSettings implements WorldCreationSettings, IMixinWorldSettings {
+public abstract class MixinWorldSettings implements WorldCreationSettings, IMixinWorldSettings {
 
     private DimensionType dimensionType;
     private DataContainer generatorSettings;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
@@ -1,0 +1,164 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.world.storage;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.storage.SaveHandler;
+import net.minecraft.world.storage.WorldInfo;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.common.Sponge;
+import org.spongepowered.common.interfaces.IMixinWorldInfo;
+import org.spongepowered.common.world.DimensionManager;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@NonnullByDefault
+@Mixin(net.minecraft.world.storage.SaveHandler.class)
+public abstract class MixinSaveHandler {
+
+    @Shadow private File worldDirectory;
+    @Shadow private long initializationTime;
+
+    @ModifyArg(method = "checkSessionLock", at = @At(value = "INVOKE",target = "Lnet/minecraft/world/MinecraftException;<init>(Ljava/lang/String;)"
+            + "V", ordinal = 0))
+    public String modifyMinecraftExceptionOutputIfNotInitializationTime(String message) {
+        return "The save folder for world " + this.worldDirectory + " is being accessed from another location, aborting";
+    }
+
+    @ModifyArg(method = "checkSessionLock", at = @At(value = "INVOKE",target = "Lnet/minecraft/world/MinecraftException;<init>(Ljava/lang/String;)"
+            + "V", ordinal = 1))
+    public String modifyMinecraftExceptionOutputIfIOException(String message) {
+        return "Failed to check session lock for world " + this.worldDirectory + ", aborting";
+    }
+
+    @Inject(method = "loadWorldInfo", at = @At(value = "RETURN", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void onLoadWorldInfoBeforeReturn0(CallbackInfoReturnable<WorldInfo> cir, File file1, NBTTagCompound nbttagcompound, NBTTagCompound nbttagcompound1, WorldInfo worldInfo) throws IOException {
+        loadDimensionAndOtherData((SaveHandler) (Object) this, worldInfo, nbttagcompound);
+        loadSpongeDatData(worldInfo);
+    }
+
+    @Inject(method = "loadWorldInfo", at = @At(value = "RETURN", ordinal = 1), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void onLoadWorldInfoBeforeReturn1(CallbackInfoReturnable<WorldInfo> cir, File file1, NBTTagCompound nbttagcompound,
+            NBTTagCompound
+            nbttagcompound1, WorldInfo worldInfo) throws IOException {
+        loadDimensionAndOtherData((SaveHandler) (Object) this, worldInfo, nbttagcompound);
+        loadSpongeDatData(worldInfo);
+    }
+
+    @Inject(method = "saveWorldInfoWithPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;setTag(Ljava/lang/String;"
+            + "Lnet/minecraft/nbt/NBTBase;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void onSaveWorldInfoWithPlayerAfterTagSet(WorldInfo worldInformation, NBTTagCompound tagCompound, CallbackInfo ci, NBTTagCompound nbttagcompound1, NBTTagCompound nbttagcompound2) {
+        saveDimensionAndOtherData((SaveHandler) (Object) this, worldInformation, nbttagcompound2);
+    }
+
+    @Inject(method = "saveWorldInfoWithPlayer", at = @At("RETURN"))
+    public void onSaveWorldInfoWithPlayerEnd(WorldInfo worldInformation, NBTTagCompound tagCompound, CallbackInfo ci) {
+        saveSpongeDatData(worldInformation);
+    }
+
+    @Inject(method = "saveWorldInfo", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;setTag(Ljava/lang/String;"
+            + "Lnet/minecraft/nbt/NBTBase;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+    public void onSaveWorldInfoAfterTagSet(WorldInfo worldInformation, CallbackInfo ci, NBTTagCompound nbttagcompound, NBTTagCompound nbttagcompound1) {
+        saveDimensionAndOtherData((SaveHandler) (Object) this, worldInformation, nbttagcompound1);
+    }
+
+    @Inject(method = "saveWorldInfo", at = @At("RETURN"))
+    public void onSaveWorldInfoEnd(WorldInfo worldInformation, CallbackInfo ci) {
+        saveSpongeDatData(worldInformation);
+    }
+
+    private void loadSpongeDatData(WorldInfo info) throws IOException {
+        final File spongeFile = new File(this.worldDirectory, "level_sponge.dat");
+        final File spongeOldFile = new File(this.worldDirectory, "level_sponge.dat_old");
+
+        if (spongeFile.exists() || spongeOldFile.exists()) {
+            final NBTTagCompound compound = CompressedStreamTools.readCompressed(new FileInputStream(spongeFile.exists() ? spongeFile :
+                    spongeOldFile));
+            ((IMixinWorldInfo) info).setSpongeRootLevelNBT(compound);
+            if (compound.hasKey(Sponge.ECOSYSTEM_NAME)) {
+                ((IMixinWorldInfo) info).readSpongeNbt(compound.getCompoundTag(Sponge.ECOSYSTEM_NAME));
+            }
+        }
+    }
+
+    private void saveSpongeDatData(WorldInfo info) {
+        try {
+            final File spongeFile1 = new File(this.worldDirectory, "level_sponge.dat_new");
+            final File spongeFile2 = new File(this.worldDirectory, "level_sponge.dat_old");
+            final File spongeFile3 = new File(this.worldDirectory, "level_sponge.dat");
+            CompressedStreamTools.writeCompressed(((IMixinWorldInfo) info).getSpongeRootLevelNbt(), new FileOutputStream(spongeFile1));
+
+            if (spongeFile2.exists()) {
+                spongeFile2.delete();
+            }
+
+            spongeFile3.renameTo(spongeFile2);
+
+            if (spongeFile3.exists()) {
+                spongeFile3.delete();
+            }
+
+            spongeFile1.renameTo(spongeFile3);
+
+            if (spongeFile1.exists()) {
+                spongeFile1.delete();
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    private void loadDimensionAndOtherData(SaveHandler handler, WorldInfo info, NBTTagCompound compound) {
+        // Preserve dimension data from Sponge
+        final NBTTagCompound customWorldDataCompound = compound.getCompoundTag("Forge");
+        if (customWorldDataCompound.hasKey("DimensionData")) {
+            DimensionManager.loadDimensionDataMap(customWorldDataCompound.getCompoundTag("DimensionData"));
+        }
+    }
+
+    private void saveDimensionAndOtherData(SaveHandler handler, WorldInfo info, NBTTagCompound compound) {
+        // Only save dimension data to root world
+        if (this.worldDirectory.getParentFile() == null || (Sponge.getGame().getPlatform().getType().isClient() && this.worldDirectory.getParentFile().equals(
+                Sponge.getGame().getSavesDirectory()))) {
+            final NBTTagCompound customWorldDataCompound = new NBTTagCompound();
+            final NBTTagCompound customDimensionDataCompound = DimensionManager.saveDimensionDataMap();
+            customWorldDataCompound.setTag("DimensionData", customDimensionDataCompound);
+            // Share data back to Sponge
+            compound.setTag("Forge", customWorldDataCompound);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
@@ -59,6 +59,7 @@ import net.minecraft.world.WorldProviderEnd;
 import net.minecraft.world.WorldProviderHell;
 import net.minecraft.world.WorldProviderSurface;
 import net.minecraft.world.WorldSettings;
+import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.BiomeGenBase;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializers;
 import org.spongepowered.api.CatalogType;
@@ -233,6 +234,8 @@ import org.spongepowered.api.util.rotation.Rotations;
 import org.spongepowered.api.world.Dimension;
 import org.spongepowered.api.world.DimensionType;
 import org.spongepowered.api.world.DimensionTypes;
+import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.GeneratorTypes;
 import org.spongepowered.api.world.WorldBuilder;
 import org.spongepowered.api.world.biome.BiomeType;
 import org.spongepowered.api.world.biome.BiomeTypes;
@@ -354,6 +357,9 @@ import org.spongepowered.common.weather.SpongeWeather;
 import org.spongepowered.common.world.SpongeDimensionType;
 import org.spongepowered.common.world.SpongeWorldBuilder;
 import org.spongepowered.common.world.gen.WorldGeneratorRegistry;
+import org.spongepowered.common.world.type.SpongeWorldTypeEnd;
+import org.spongepowered.common.world.type.SpongeWorldTypeNether;
+import org.spongepowered.common.world.type.SpongeWorldTypeOverworld;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -495,6 +501,9 @@ public abstract class SpongeGameRegistry implements GameRegistry {
         .put("PINK_TULIP", (PlantType) (Object) BlockFlower.EnumFlowerType.PINK_TULIP)
         .put("OXEYE_DAISY", (PlantType) (Object) BlockFlower.EnumFlowerType.OXEYE_DAISY)
         .build();
+
+    private final Map<String, GeneratorType> generatorTypeMappings = Maps.newHashMap();
+
     private static final ImmutableMap<String, EntityInteractionType> entityInteractionTypeMappings =
             new ImmutableMap.Builder<String, EntityInteractionType>()
                     .put("ATTACK", new SpongeEntityInteractionType("ATTACK"))
@@ -563,11 +572,12 @@ public abstract class SpongeGameRegistry implements GameRegistry {
                     .put(StoneType.class, ImmutableMap.<String, CatalogType>of()) // TODO
                     .put(TextColor.class, textColorMappings)
                     .put(TileEntityType.class, ImmutableMap.<String, CatalogType>of()) // TODO
-                    .put(TreeType.class, treeTypeMappings)
+                    .put(TreeType.class, this.treeTypeMappings)
                     .put(Visibility.class, this.visibilityMappings)
                     .put(WallType.class, ImmutableMap.<String, CatalogType>of()) // TODO
                     .put(Weather.class, ImmutableMap.<String, CatalogType>of()) // TODO
                     .put(WorldGeneratorModifier.class, this.worldGeneratorRegistry.viewModifiersMap())
+                    .put(GeneratorType.class, this.generatorTypeMappings)
                     .build();
     private final Map<Class<?>, Class<?>> builderMap = ImmutableMap.of(); // TODO FIGURE OUT HOW TO DO THIS!!?!
 
@@ -1869,6 +1879,16 @@ public abstract class SpongeGameRegistry implements GameRegistry {
         RegistryHelper.mapFields(RabbitTypes.class, SpongeEntityConstants.RABBIT_TYPES);
     }
 
+    public void setGeneratorTypes() {
+        this.generatorTypeMappings.put("DEFAULT", (GeneratorType) WorldType.DEFAULT);
+        this.generatorTypeMappings.put("FLAT", (GeneratorType) WorldType.FLAT);
+        this.generatorTypeMappings.put("DEBUG", (GeneratorType) WorldType.DEBUG_WORLD);
+        this.generatorTypeMappings.put("NETHER", (GeneratorType) new SpongeWorldTypeNether());
+        this.generatorTypeMappings.put("END", (GeneratorType) new SpongeWorldTypeEnd());
+        this.generatorTypeMappings.put("OVERWORLD", (GeneratorType) new SpongeWorldTypeOverworld());
+        RegistryHelper.mapFields(GeneratorTypes.class, this.generatorTypeMappings);
+    }
+
     private SpongeEntityType newEntityTypeFromName(String spongeName, String mcName) {
         return new SpongeEntityType((Integer) EntityList.stringToIDMapping.get(mcName), spongeName,
                 (Class<? extends Entity>) EntityList.stringToClassMapping.get(mcName));
@@ -1968,6 +1988,7 @@ public abstract class SpongeGameRegistry implements GameRegistry {
         setVisibilities();
         setCriteria();
         setObjectiveDisplayModes();
+        setGeneratorTypes();
     }
 
     public void postInit() {

--- a/src/main/java/org/spongepowered/common/world/DimensionManager.java
+++ b/src/main/java/org/spongepowered/common/world/DimensionManager.java
@@ -1,0 +1,321 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.world;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MapMaker;
+import com.google.common.collect.Multiset;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldManager;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldProviderEnd;
+import net.minecraft.world.WorldProviderHell;
+import net.minecraft.world.WorldProviderSurface;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldServerMulti;
+import net.minecraft.world.storage.ISaveHandler;
+import net.minecraft.world.storage.SaveHandler;
+import org.apache.logging.log4j.Level;
+import org.spongepowered.api.world.Dimension;
+import org.spongepowered.api.world.DimensionTypes;
+import org.spongepowered.common.Sponge;
+import org.spongepowered.common.event.SpongeImplEventFactory;
+import org.spongepowered.common.interfaces.IMixinEntityPlayerMP;
+import org.spongepowered.common.interfaces.IMixinMinecraftServer;
+import org.spongepowered.common.interfaces.IMixinWorldProvider;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+public class DimensionManager {
+
+    public static final Hashtable<Integer, Class<? extends WorldProvider>> providers = new Hashtable<Integer, Class<? extends WorldProvider>>();
+    public static final Hashtable<Integer, Boolean> spawnSettings = new Hashtable<Integer, Boolean>();
+    public static final Hashtable<Integer, Integer> dimensions = new Hashtable<Integer, Integer>();
+    public static final Hashtable<Integer, WorldServer> worlds = new Hashtable<Integer, WorldServer>();
+    public static final ConcurrentMap<World, World> weakWorldMap = new MapMaker().weakKeys().weakValues().makeMap();
+    public static final ArrayList<Integer> unloadQueue = Lists.newArrayList();
+    public static final BitSet dimensionMap = new BitSet(Long.SIZE << 4);
+    public static final Multiset<Integer> leakedWorlds = HashMultiset.create();
+    public static boolean hasInit = false;
+
+    static {
+        init();
+    }
+
+    public static void init() {
+        if (hasInit) {
+            return;
+        }
+
+        hasInit = true;
+        registerProviderType(0, WorldProviderSurface.class, true);
+        registerProviderType(-1, WorldProviderHell.class, true);
+        registerProviderType(1, WorldProviderEnd.class, true);
+        registerDimension(0, 0);
+        registerDimension(-1, -1);
+        registerDimension(1, 1);
+    }
+
+    public static boolean registerProviderType(int id, Class<? extends WorldProvider> provider, boolean keepLoaded) {
+        if (providers.containsKey(id)) {
+            return false;
+        }
+        // register dimension type
+        String worldType;
+        switch (id) {
+            case -1:
+                worldType = "NETHER";
+                break;
+            case 0:
+                worldType = "OVERWORLD";
+                break;
+            case 1:
+                worldType = "END";
+                break;
+            default: // modded
+                worldType = provider.getSimpleName().toLowerCase();
+                worldType = worldType.replace("worldprovider", "");
+                worldType = worldType.replace("provider", "");
+        }
+
+        Sponge.getSpongeRegistry().registerDimensionType(new SpongeDimensionType(worldType, keepLoaded, provider, id));
+        providers.put(id, provider);
+        spawnSettings.put(id, keepLoaded);
+        return true;
+    }
+
+    public static int getProviderType(int dim) {
+        if (!dimensions.containsKey(dim)) {
+            throw new IllegalArgumentException(String.format("Could not get provider type for dimension %d, does not exist", dim));
+        }
+        return dimensions.get(dim);
+    }
+
+    public static WorldProvider createProviderFor(int dim) {
+        try {
+            if (dimensions.containsKey(dim)) {
+                WorldProvider provider = providers.get(getProviderType(dim)).newInstance();
+                ((IMixinWorldProvider) provider).setDimension(dim);
+                return provider;
+            } else {
+                throw new RuntimeException(String.format("No WorldProvider bound for dimension %d", dim));
+            }
+        } catch (Exception e) {
+            Sponge.getLogger().log(Level.ERROR, String.format("An error occurred trying to create an instance of WorldProvider %d (%s)",
+                    dim, providers.get(getProviderType(dim)).getSimpleName()), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean shouldLoadSpawn(int dim) {
+        int id = getProviderType(dim);
+        return spawnSettings.containsKey(id) && spawnSettings.get(id);
+    }
+
+    public static void loadDimensionDataMap(NBTTagCompound compound) {
+        dimensionMap.clear();
+        if (compound == null) {
+            for (Integer id : dimensions.keySet()) {
+                if (id >= 0) {
+                    dimensionMap.set(id);
+                }
+            }
+        } else {
+            int[] intArray = compound.getIntArray("DimensionArray");
+            for (int i = 0; i < intArray.length; i++) {
+                for (int j = 0; j < Integer.SIZE; j++) {
+                    dimensionMap.set(i * Integer.SIZE + j, (intArray[i] & (1 << j)) != 0);
+                }
+            }
+        }
+    }
+
+    public static NBTTagCompound saveDimensionDataMap() {
+        int[] data = new int[(dimensionMap.length() + Integer.SIZE - 1) / Integer.SIZE];
+        NBTTagCompound dimMap = new NBTTagCompound();
+        for (int i = 0; i < data.length; i++) {
+            int val = 0;
+            for (int j = 0; j < Integer.SIZE; j++) {
+                val |= dimensionMap.get(i * Integer.SIZE + j) ? (1 << j) : 0;
+            }
+            data[i] = val;
+        }
+        dimMap.setIntArray("DimensionArray", data);
+        return dimMap;
+    }
+
+    public static Integer[] getIDs() {
+        return worlds.keySet().toArray(new Integer[worlds.size()]); //Only loaded dims, since usually used to cycle through loaded worlds
+    }
+
+    public static Integer[] getStaticDimensionIDs() {
+        return dimensions.keySet().toArray(new Integer[dimensions.keySet().size()]);
+    }
+
+    public static WorldServer getWorldFromDimId(int id) {
+        return worlds.get(id);
+    }
+
+    public static void unloadWorldFromDimId(int id) {
+        unloadQueue.add(id);
+    }
+
+    public static void setWorld(int id, WorldServer world) {
+        if (world != null) {
+            worlds.put(id, world);
+            weakWorldMap.put(world, world);
+            ((IMixinMinecraftServer) MinecraftServer.getServer()).getWorldTickTimes().put(id, new long[100]);
+            Sponge.getLogger().info("Loading dimension %d (%s) (%s)", id, world.getWorldInfo().getWorldName(), world.getMinecraftServer());
+        } else {
+            worlds.remove(id);
+            ((IMixinMinecraftServer) MinecraftServer.getServer()).getWorldTickTimes().remove(id);
+            Sponge.getLogger().info("Unloading dimension %d", id);
+        }
+
+        ArrayList<WorldServer> tmp = new ArrayList<WorldServer>();
+        if (worlds.get(0) != null) {
+            tmp.add(worlds.get(0));
+        }
+        if (worlds.get(-1) != null) {
+            tmp.add(worlds.get(-1));
+        }
+        if (worlds.get(1) != null) {
+            tmp.add(worlds.get(1));
+        }
+
+        for (Map.Entry<Integer, WorldServer> entry : worlds.entrySet()) {
+            int dim = entry.getKey();
+            if (dim >= -1 && dim <= 1) {
+                continue;
+            }
+            tmp.add(entry.getValue());
+        }
+
+        MinecraftServer.getServer().worldServers = tmp.toArray(new WorldServer[tmp.size()]);
+    }
+
+    public static WorldServer[] getWorlds() {
+        return worlds.values().toArray(new WorldServer[worlds.size()]);
+    }
+
+    public static boolean isDimensionRegistered(int dim) {
+        return dimensions.containsKey(dim);
+    }
+
+    public static void registerDimension(int id, int providerType) {
+        if (!providers.containsKey(providerType)) {
+            throw new IllegalArgumentException(
+                    String.format("Failed to register dimension for id %d, provider type %d does not exist", id, providerType));
+        }
+        if (dimensions.containsKey(id)) {
+            throw new IllegalArgumentException(String.format("Failed to register dimension for id %d, One is already registered", id));
+        }
+        dimensions.put(id, providerType);
+        if (id >= 0) {
+            dimensionMap.set(id);
+        }
+    }
+
+    public static int getNextFreeDimId() {
+        int next = 0;
+        while (true) {
+            next = dimensionMap.nextClearBit(next);
+            if (dimensions.containsKey(next)) {
+                dimensionMap.set(next);
+            } else {
+                return next;
+            }
+        }
+    }
+
+    public static File getCurrentSaveRootDirectory() {
+        if (DimensionManager.getWorldFromDimId(0) != null) {
+            return DimensionManager.getWorldFromDimId(0).getSaveHandler().getWorldDirectory();
+        } else if (MinecraftServer.getServer() != null) {
+            MinecraftServer srv = MinecraftServer.getServer();
+            SaveHandler saveHandler = (SaveHandler) srv.getActiveAnvilConverter().getSaveLoader(srv.getFolderName(), false);
+            return saveHandler.getWorldDirectory();
+        } else {
+            return null;
+        }
+    }
+
+    public static void initDimension(int dim) {
+        WorldServer overworld = getWorldFromDimId(0);
+        if (overworld == null) {
+            throw new RuntimeException("Cannot Hotload Dim: Overworld is not Loaded!");
+        }
+        try {
+            DimensionManager.getProviderType(dim);
+        } catch (Exception e) {
+            Sponge.getLogger().log(Level.ERROR, "Cannot Hotload Dim: " + e.getMessage());
+            return; // If a provider hasn't been registered then we can't hotload the dim
+        }
+        MinecraftServer mcServer = overworld.getMinecraftServer();
+        ISaveHandler savehandler = overworld.getSaveHandler();
+
+        WorldServer world =
+                (dim == 0 ? overworld : (WorldServer) (new WorldServerMulti(mcServer, savehandler, dim, overworld, mcServer.theProfiler).init()));
+        world.addWorldAccess(new WorldManager(mcServer, world));
+        Sponge.getGame().getEventManager().post(SpongeImplEventFactory.createWorldLoad(Sponge.getGame(), (org.spongepowered.api.world.World) world));
+        if (!mcServer.isSinglePlayer()) {
+            world.getWorldInfo().setGameType(mcServer.getGameType());
+        }
+
+        mcServer.setDifficultyForAllWorlds(mcServer.getDifficulty());
+    }
+
+    public static int getClientDimensionToSend(int dim, WorldServer worldserver, EntityPlayerMP playerIn) {
+        if (!((IMixinEntityPlayerMP) playerIn).usesCustomClient()) {
+            if (((Dimension) worldserver.provider).getType().equals(DimensionTypes.NETHER)) {
+                dim = -1;
+            } else if (((Dimension) worldserver.provider).getType().equals(DimensionTypes.END)) {
+                dim = 1;
+            } else {
+                dim = 0;
+            }
+        }
+
+        return dim;
+    }
+
+    public static void sendDimensionRegistration(WorldServer worldserver, EntityPlayerMP playerIn, int dim) {
+//        // register dimension on client-side
+//        FMLEmbeddedChannel serverChannel = NetworkRegistry.INSTANCE.getChannel("FORGE", Side.SERVER);
+//        serverChannel.attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.PLAYER);
+//        serverChannel.attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(playerIn);
+//        serverChannel.writeOutbound(new ForgeMessage.DimensionRegisterMessage(dimension,
+//                ((SpongeDimensionType) ((Dimension) worldserver.provider).getType()).getDimensionTypeId()));
+    }
+}

--- a/src/main/java/org/spongepowered/common/world/SpongeTeleportHelper.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeTeleportHelper.java
@@ -162,7 +162,7 @@ public class SpongeTeleportHelper implements TeleportHelper {
             return false;
         }
 
-        if (blockPos.getY() > world.getHeight()) {
+        if (blockPos.getY() > world.getDimension().getHeight()) {
             return false;
         }
 

--- a/src/main/java/org/spongepowered/common/world/SpongeWorldBuilder.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeWorldBuilder.java
@@ -230,7 +230,7 @@ public class SpongeWorldBuilder implements WorldBuilder {
     @Override
     public WorldBuilder reset() {
         this.name = "spongeworld";
-        this.seed = (new Random()).nextLong();
+        this.seed = new Random().nextLong();
         this.gameMode = GameModes.SURVIVAL;
         this.generatorType = GeneratorTypes.DEFAULT;
         this.dimensionType = DimensionTypes.OVERWORLD;

--- a/src/main/java/org/spongepowered/common/world/gen/CustomChunkProviderGenerate.java
+++ b/src/main/java/org/spongepowered/common/world/gen/CustomChunkProviderGenerate.java
@@ -1,0 +1,189 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.world.gen;
+
+import com.flowpowered.math.vector.Vector2i;
+import com.google.common.base.Preconditions;
+import net.minecraft.block.BlockFalling;
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.IProgressUpdate;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.biome.BiomeGenBase.SpawnListEntry;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkPrimer;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderGenerate;
+import org.spongepowered.api.world.gen.BiomeGenerator;
+import org.spongepowered.api.world.gen.GeneratorPopulator;
+import org.spongepowered.common.util.gen.ByteArrayMutableBiomeBuffer;
+import org.spongepowered.common.util.gen.ChunkPrimerBuffer;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Similar class to {@link ChunkProviderGenerate}, but instead gets its blocks
+ * from a custom chunk generator.
+ */
+public final class CustomChunkProviderGenerate implements IChunkProvider {
+
+    private static final Vector2i CHUNK_AREA = new Vector2i(16, 16);
+
+    final GeneratorPopulator generatorPopulator;
+    final BiomeGenerator biomeGenerator;
+    private final World world;
+    private final ByteArrayMutableBiomeBuffer cachedBiomes;
+
+    /**
+     * Gets the chunk generator from the given generator populator and biome
+     * generator.
+     *
+     * @param world The world to bind the chunk provider to.
+     * @param generatorPopulator The generator populator.
+     * @param biomeGenerator Biome generator used to generate chunks.
+     * @return The chunk generator.
+     * @throws IllegalArgumentException If the generator populator cannot be
+     *         bound to the given world.
+     */
+    public static IChunkProvider of(World world, GeneratorPopulator generatorPopulator, BiomeGenerator biomeGenerator) {
+        if (generatorPopulator instanceof SpongeGeneratorPopulator) {
+            // Unwrap instead of wrap
+            return ((SpongeGeneratorPopulator) generatorPopulator).getHandle(world);
+        }
+        // Wrap a custom GeneratorPopulator implementation
+        return new CustomChunkProviderGenerate(world, generatorPopulator, biomeGenerator);
+    }
+
+    private CustomChunkProviderGenerate(World world, GeneratorPopulator generatorPopulator, BiomeGenerator biomeGenerator) {
+        this.world = Preconditions.checkNotNull(world);
+        this.generatorPopulator = Preconditions.checkNotNull(generatorPopulator);
+        this.biomeGenerator = Preconditions.checkNotNull(biomeGenerator);
+
+        // Make initially empty biome cache
+        this.cachedBiomes = new ByteArrayMutableBiomeBuffer(Vector2i.ZERO, CHUNK_AREA);
+        this.cachedBiomes.detach();
+    }
+
+    @Override
+    public void populate(IChunkProvider chunkProvider, int chunkX, int chunkZ) {
+        Random random = new Random(chunkX * 341873128712L + chunkZ * 132897987541L);
+        BlockFalling.fallInstantly = true;
+
+        // Calling the events makes the Sponge-added populators fire
+        // TODO Deamon says he'll figure this one out soon
+
+        BlockFalling.fallInstantly = false;
+    }
+
+    @Override
+    public boolean func_177460_a(IChunkProvider chunkProvider, Chunk chunk, int chunkX, int chunkZ) {
+        // This method normally places ocean monuments in existing chunks
+        return false;
+    }
+
+    @Override
+    public List<SpawnListEntry> getPossibleCreatures(EnumCreatureType creatureType, BlockPos pos) {
+        BiomeGenBase biome = this.world.getBiomeGenForCoords(pos);
+        @SuppressWarnings("unchecked")
+        List<SpawnListEntry> creatures = biome.getSpawnableList(creatureType);
+        return creatures;
+    }
+
+    @Override
+    public BlockPos getStrongholdGen(World worldIn, String structureName, BlockPos position) {
+        // Maybe allow to register stronghold locations?
+        return null;
+    }
+
+    @Override
+    public void recreateStructures(Chunk chunk, int chunkX, int chunkZ) {
+        // No structure support
+    }
+
+    @Override
+    public Chunk provideChunk(int chunkX, int chunkZ) {
+
+        // Generate biomes
+        this.cachedBiomes.reuse(new Vector2i(chunkX << 4, chunkZ << 4));
+        this.biomeGenerator.generateBiomes(this.cachedBiomes);
+
+        // Generate blocks
+        ChunkPrimer chunkprimer = new ChunkPrimer();
+        ChunkPrimerBuffer buffer = new ChunkPrimerBuffer(chunkprimer, chunkX, chunkZ);
+        this.generatorPopulator.populate((org.spongepowered.api.world.World) this.world, buffer, this.cachedBiomes.getImmutableClone());
+
+        // Assemble chunk
+        Chunk chunk = new Chunk(this.world, chunkprimer, chunkX, chunkZ);
+        byte[] biomeArray = chunk.getBiomeArray();
+        System.arraycopy(this.cachedBiomes.detach(), 0, biomeArray, 0, biomeArray.length);
+        chunk.generateSkylightMap();
+
+        return chunk;
+    }
+
+    // Methods below are simply mirrors of the methods in ChunkProviderGenerate
+
+    @Override
+    public Chunk provideChunk(BlockPos blockPosIn) {
+        return provideChunk(blockPosIn.getX() >> 4, blockPosIn.getZ() >> 4);
+    }
+
+    @Override
+    public int getLoadedChunkCount() {
+        return 0;
+    }
+
+    @Override
+    public String makeString() {
+        return "RandomLevelSource";
+    }
+
+    @Override
+    public boolean canSave() {
+        return true;
+    }
+
+    @Override
+    public boolean saveChunks(boolean bool, IProgressUpdate progressUpdate) {
+        return true;
+    }
+
+    @Override
+    public void saveExtraData() {
+    }
+
+    @Override
+    public boolean unloadQueuedChunks() {
+        return false;
+    }
+
+    @Override
+    public boolean chunkExists(int x, int z) {
+        return true;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/world/gen/SpongeGeneratorPopulator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/SpongeGeneratorPopulator.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.world.gen;
+
+import com.flowpowered.math.vector.Vector3i;
+import com.google.common.base.Preconditions;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.util.gen.BiomeBuffer;
+import org.spongepowered.api.util.gen.MutableBlockBuffer;
+import org.spongepowered.api.world.gen.GeneratorPopulator;
+
+/**
+ * Generator populator that wraps a Minecraft {@link IChunkProvider}.
+ */
+public final class SpongeGeneratorPopulator implements GeneratorPopulator {
+
+    private final IChunkProvider chunkGenerator;
+    private final World world;
+
+    /**
+     * Gets the {@link GeneratorPopulator} from the given {@link IChunkProvider}
+     * . If the chunk provider wraps a {@link GeneratorPopulator}, that
+     * populator is returned, otherwise the chunk provider is wrapped.
+     *
+     * @param world The world the chunk generator is bound to.
+     * @param chunkGenerator The chunk generator.
+     * @return The generator populator.
+     */
+    public static GeneratorPopulator of(World world, IChunkProvider chunkGenerator) {
+        if (chunkGenerator instanceof CustomChunkProviderGenerate) {
+            return ((CustomChunkProviderGenerate) chunkGenerator).generatorPopulator;
+        }
+        return new SpongeGeneratorPopulator(world, chunkGenerator);
+    }
+
+    private SpongeGeneratorPopulator(World world, IChunkProvider chunkGenerator) {
+        this.world = Preconditions.checkNotNull(world);
+        this.chunkGenerator = Preconditions.checkNotNull(chunkGenerator);
+    }
+
+    @Override
+    public void populate(org.spongepowered.api.world.World world, MutableBlockBuffer buffer, BiomeBuffer biomes) {
+
+        // Empty the buffer
+        buffer.fill(BlockTypes.AIR.getDefaultState());
+
+        // The block buffer can be of any size. We generate all chunks that
+        // have at least part of the chunk in the given area, and copy the
+        // needed blocks into the buffer
+        Vector3i min = buffer.getBlockMin();
+        Vector3i max = buffer.getBlockMax();
+        int minChunkX = (int) Math.floor(min.getX() / 16.0);
+        int minChunkZ = (int) Math.floor(min.getZ() / 16.0);
+        int maxChunkX = (int) Math.floor(max.getX() / 16.0);
+        int maxChunkZ = (int) Math.floor(max.getZ() / 16.0);
+        for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+            for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ++) {
+                final Chunk generated = this.chunkGenerator.provideChunk(chunkX, chunkZ);
+                placeChunkInBuffer(generated, buffer, chunkX, chunkZ);
+            }
+        }
+    }
+
+    private void placeChunkInBuffer(Chunk chunk, MutableBlockBuffer buffer, int chunkX, int chunkZ) {
+
+        // Calculate bounds
+        int xOffset = chunkX * 16;
+        int zOffset = chunkZ * 16;
+        Vector3i minBound = buffer.getBlockMin();
+        Vector3i maxBound = buffer.getBlockMax();
+        int xInChunkStart = Math.max(0, minBound.getX() - xOffset);
+        int yStart = Math.max(0, minBound.getY());
+        int zInChunkStart = Math.max(0, minBound.getZ() - zOffset);
+        int xInChunkEnd = Math.min(15, maxBound.getX() - xOffset);
+        int yEnd = Math.min(255, maxBound.getY());
+        int zInChunkEnd = Math.min(15, maxBound.getZ() - zOffset);
+
+        // Copy the right blocks in
+        ExtendedBlockStorage[] blockStorage = chunk.getBlockStorageArray();
+        for (ExtendedBlockStorage miniChunk : blockStorage) {
+            if (miniChunk == null) {
+                continue;
+            }
+
+            int yOffset = miniChunk.getYLocation();
+            int yInChunkStart = Math.max(yOffset, yStart);
+            int yInChunkEnd = Math.min(yOffset + 15, yEnd);
+            for (int xInChunk = xInChunkStart; xInChunk <= xInChunkEnd; xInChunk++) {
+                for (int yInChunk = yInChunkStart; yInChunk <= yInChunkEnd; yInChunk++) {
+                    for (int zInChunk = zInChunkStart; zInChunk <= zInChunkEnd; zInChunk++) {
+                        buffer.setBlock(xOffset + xInChunk, yOffset + yInChunk, zOffset + zInChunk,
+                                (BlockState) miniChunk.get(xInChunk, yInChunk, zInChunk));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the chunk provider, if the target world matches the world this chunk
+     * provider was bound to.
+     *
+     * @param targetWorld The target world.
+     * @return The chunk provider.
+     * @throws IllegalArgumentException If the target world is not the world
+     *         this chunk provider is bound to.
+     */
+    IChunkProvider getHandle(World targetWorld) {
+        if (!this.world.equals(targetWorld)) {
+            throw new IllegalArgumentException("Cannot reassign internal generator from world "
+                    + getWorldName(this.world) + " to world " + getWorldName(targetWorld));
+        }
+        return this.chunkGenerator;
+    }
+
+    private static String getWorldName(World world) {
+        return ((org.spongepowered.api.world.World) world).getName();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/world/gen/SpongeWorldGenerator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/SpongeWorldGenerator.java
@@ -36,7 +36,6 @@ import java.util.List;
 
 /**
  * Implementation of {@link WorldGenerator}.
- *
  */
 public final class SpongeWorldGenerator implements WorldGenerator {
 

--- a/src/main/java/org/spongepowered/common/world/gen/WorldGeneratorRegistry.java
+++ b/src/main/java/org/spongepowered/common/world/gen/WorldGeneratorRegistry.java
@@ -29,8 +29,6 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 import org.spongepowered.common.Sponge;
@@ -50,8 +48,6 @@ import java.util.Map;
  * @see GameRegistry#registerWorldGeneratorModifier(WorldGeneratorModifier)
  */
 public final class WorldGeneratorRegistry {
-
-    private static final Logger logger = LogManager.getLogger();
 
     public static WorldGeneratorRegistry getInstance() {
         SpongeGameRegistry registry = (SpongeGameRegistry) Sponge.getGame().getRegistry();
@@ -116,7 +112,7 @@ public final class WorldGeneratorRegistry {
             if (modifier != null) {
                 modifiers.add(modifier);
             } else {
-                logger.error("World generator modifier with id " + id + " not found. Missing plugin?");
+                Sponge.getLogger().error("World generator modifier with id " + id + " not found. Missing plugin?");
             }
         }
         return modifiers;

--- a/src/main/java/org/spongepowered/common/world/type/SpongeWorldType.java
+++ b/src/main/java/org/spongepowered/common/world/type/SpongeWorldType.java
@@ -22,26 +22,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.core.world;
+package org.spongepowered.common.world.type;
 
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.WorldProviderEnd;
 import net.minecraft.world.WorldType;
-import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraft.world.gen.ChunkProviderEnd;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Mixin;
 
-@NonnullByDefault
-@Mixin(WorldProviderEnd.class)
-public abstract class MixinWorldProviderEnd extends WorldProvider {
+import java.util.Arrays;
 
-    @Override
-    public IChunkProvider createChunkGenerator() {
-        if (this.terrainType == WorldType.DEFAULT) {
-            return new ChunkProviderEnd(this.worldObj, this.worldObj.getSeed());
-        } else {
-            return super.createChunkGenerator(); // use custom GeneratorType
+public abstract class SpongeWorldType extends WorldType {
+
+    protected SpongeWorldType(String name) {
+        super(getNextID(), name);
+    }
+
+    private static int getNextID() {
+        for (int x = 0; x < worldTypes.length; x++) {
+            if (worldTypes[x] == null) {
+                return x;
+            }
         }
+
+        int oldLen = worldTypes.length;
+        worldTypes = Arrays.copyOf(worldTypes, oldLen + 16);
+        return oldLen;
     }
 }

--- a/src/main/java/org/spongepowered/common/world/type/SpongeWorldTypeEnd.java
+++ b/src/main/java/org/spongepowered/common/world/type/SpongeWorldTypeEnd.java
@@ -22,26 +22,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.core.world;
+package org.spongepowered.common.world.type;
 
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.WorldProviderEnd;
-import net.minecraft.world.WorldType;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.biome.WorldChunkManager;
+import net.minecraft.world.biome.WorldChunkManagerHell;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.ChunkProviderEnd;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Mixin;
 
-@NonnullByDefault
-@Mixin(WorldProviderEnd.class)
-public abstract class MixinWorldProviderEnd extends WorldProvider {
+public class SpongeWorldTypeEnd extends SpongeWorldType {
 
-    @Override
-    public IChunkProvider createChunkGenerator() {
-        if (this.terrainType == WorldType.DEFAULT) {
-            return new ChunkProviderEnd(this.worldObj, this.worldObj.getSeed());
-        } else {
-            return super.createChunkGenerator(); // use custom GeneratorType
-        }
+    public SpongeWorldTypeEnd() {
+        super("END");
+    }
+
+    public WorldChunkManager getChunkManager(net.minecraft.world.World world) {
+        return new WorldChunkManagerHell(BiomeGenBase.sky, 0f);
+    }
+
+    public IChunkProvider getChunkGenerator(World world, String generatorOptions) {
+        return new ChunkProviderEnd(world, world.getSeed());
     }
 }

--- a/src/main/java/org/spongepowered/common/world/type/SpongeWorldTypeNether.java
+++ b/src/main/java/org/spongepowered/common/world/type/SpongeWorldTypeNether.java
@@ -22,26 +22,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.mixin.core.world;
+package org.spongepowered.common.world.type;
 
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.WorldProviderEnd;
-import net.minecraft.world.WorldType;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.biome.WorldChunkManager;
+import net.minecraft.world.biome.WorldChunkManagerHell;
 import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraft.world.gen.ChunkProviderEnd;
-import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.asm.mixin.Mixin;
+import net.minecraft.world.gen.ChunkProviderHell;
 
-@NonnullByDefault
-@Mixin(WorldProviderEnd.class)
-public abstract class MixinWorldProviderEnd extends WorldProvider {
+public class SpongeWorldTypeNether extends SpongeWorldType {
 
-    @Override
-    public IChunkProvider createChunkGenerator() {
-        if (this.terrainType == WorldType.DEFAULT) {
-            return new ChunkProviderEnd(this.worldObj, this.worldObj.getSeed());
-        } else {
-            return super.createChunkGenerator(); // use custom GeneratorType
-        }
+    public SpongeWorldTypeNether() {
+        super("NETHER");
+    }
+
+    public WorldChunkManager getChunkManager(net.minecraft.world.World world) {
+        return new WorldChunkManagerHell(BiomeGenBase.hell, 0f);
+    }
+
+    public IChunkProvider getChunkGenerator(World world, String generatorOptions) {
+        return new ChunkProviderHell(world, world.getWorldInfo().isMapFeaturesEnabled(), world.getSeed());
     }
 }

--- a/src/main/java/org/spongepowered/common/world/type/SpongeWorldTypeOverworld.java
+++ b/src/main/java/org/spongepowered/common/world/type/SpongeWorldTypeOverworld.java
@@ -22,13 +22,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.interfaces;
+package org.spongepowered.common.world.type;
 
-import net.minecraft.world.chunk.storage.AnvilSaveHandler;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.IChunkProvider;
 
-public interface IMixinServer {
+public class SpongeWorldTypeOverworld extends SpongeWorldType {
 
-    AnvilSaveHandler getHandler(String worldName);
+    public SpongeWorldTypeOverworld() {
+        super("OVERWORLD");
+    }
 
-    void initialSpongeWorldChunkLoad();
+    public IChunkProvider getChunkGenerator(World world, String generatorOptions) {
+        return new net.minecraft.world.gen.ChunkProviderGenerate(world, world.getSeed(), world.getWorldInfo().isMapFeaturesEnabled(),
+                generatorOptions);
+    }
 }

--- a/src/main/resources/common_at.cfg
+++ b/src/main/resources/common_at.cfg
@@ -102,12 +102,18 @@ public net.minecraft.world.World field_147483_b # tileEntitiesToBeRemoved
 public net.minecraft.world.WorldProvider field_76578_c # worldChunkMgr
 public net.minecraft.world.WorldProvider field_76577_b # terrainType
 
+public net.minecraft.world.WorldType <init>(ILjava/lang/String;)V # private WorldType (int id, String name)
+public-f net.minecraft.world.WorldType field_77139_a # worldTypes
+
 public net.minecraft.world.chunk.ChunkPrimer field_177860_a # data
 
+public net.minecraft.world.gen.ChunkProviderServer field_73246_d # serverChunkGenerator
 public net.minecraft.world.gen.ChunkProviderServer field_73251_h # worldObj
 public net.minecraft.world.gen.ChunkProviderServer field_73245_g # loadedChunks
 
 public net.minecraft.world.storage.WorldInfo field_76100_a # randomSeed
+
+public net.minecraft.network.NetworkManager field_150746_k # channel
 
 public net.minecraft.network.handshake.client.C00Handshake field_149598_b # ip
 public net.minecraft.network.handshake.client.C00Handshake field_149599_c # port
@@ -127,7 +133,6 @@ public-f net.minecraft.entity.EntityLivingBase field_94063_bt # _combatTracker
 
 public net.minecraft.util.FoodStats field_75126_c # foodExhaustionLevel
 
-
 public net.minecraft.network.rcon.RConThreadClient field_72657_g # loggedIn
 public net.minecraft.server.dedicated.DedicatedServer field_71339_n # theRConThreadMain
 public net.minecraft.server.management.ServerConfigurationManager func_96456_a(Lnet/minecraft/scoreboard/ServerScoreboard;Lnet/minecraft/entity/player/EntityPlayerMP;)V
@@ -136,3 +141,4 @@ public net.minecraft.scoreboard.Scoreboard *
 public-f net.minecraft.scoreboard.Score *
 public net.minecraft.scoreboard.ScorePlayerTeam *
 public net.minecraft.scoreboard.ScoreObjective *
+

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -192,7 +192,8 @@
         "world.biome.MixinBiomeGenBase",
         "world.difficulty.MixinEnumDifficulty",
         "world.extent.MixinExtent",
-        "world.storage.MixinWorldInfo"
+        "world.storage.MixinWorldInfo",
+        "world.storage.MixinSaveHandler"
     ],
     "server": [
         "server.MixinDedicatedServer",


### PR DESCRIPTION
This graduates up bloodmc's amazing work in Sponge to SpongeCommon so
that SpongeVanilla will have this capability as well. I've also cleaned up
a few spots such as removing some overwrites.

Fix END and NETHER GeneratorTypes not generating a Vanilla The_End or
Nether respectively.

Fix Vanilla DIM-1 and DIM1 not creating the correct config folder on first
generation.

Fix sending incorrect dimension to client (fixes teleports), fix teleport
to world with same client dimension with Vanilla client. Fix generator
modifiers not being applied in WorldBuilder

Signed-off-by: Chris Sanders <zidane@outlook.com>