### PR TITLE
Implement ignoring players when skipping the night

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -106,6 +106,8 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
 
     private net.minecraft.scoreboard.Scoreboard mcScoreboard = this.worldObj.getScoreboard();
 
+    private boolean sleepingIgnored;
+
     @Inject(method = "func_152339_d", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/network/NetHandlerPlayServer;sendPacket(Lnet/minecraft/network/Packet;)V"))
     private void onRemoveEntity(Entity entityIn, CallbackInfo ci) {
@@ -380,5 +382,15 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     public void kick(Text message) {
         final IChatComponent component = SpongeTexts.toComponent(message, getLocale());
         PlayerKickHelper.kickPlayer((EntityPlayerMP) (Object) this, component);
+    }
+
+    @Override
+    public boolean isSleepingIgnored() {
+        return this.sleepingIgnored;
+    }
+
+    @Override
+    public void setSleepingIgnored(boolean sleepingIgnored) {
+        this.sleepingIgnored = sleepingIgnored;
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -44,6 +44,7 @@ import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityPainting;
 import net.minecraft.entity.item.EntityPainting.EnumArt;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.projectile.EntityFishHook;
 import net.minecraft.entity.projectile.EntityPotion;
@@ -140,6 +141,9 @@ import java.util.UUID;
 @NonnullByDefault
 @Mixin(net.minecraft.world.World.class)
 public abstract class MixinWorld implements World, IMixinWorld {
+
+    @Shadow public boolean isRemote;
+    @Shadow public List<EntityPlayer> playerEntities;
 
     private static final Vector3i BLOCK_MIN = new Vector3i(-30000000, 0, -30000000);
     private static final Vector3i BLOCK_MAX = new Vector3i(30000000, 256, 30000000).sub(1, 1, 1);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -31,7 +31,7 @@ import net.minecraft.village.VillageCollection;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldSettings;
-import org.spongepowered.api.entity.living.Human;
+import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.GeneratorType;
 import org.spongepowered.api.world.GeneratorTypes;
@@ -93,7 +93,7 @@ public abstract class MixinWorldServer extends MixinWorld {
             int sleepingPlayers = 0;
             for (EntityPlayer entityPlayer : this.playerEntities) {
                 if (entityPlayer.isSpectator()
-                        || (entityPlayer instanceof Human && ((Human)entityPlayer).isSleepingIgnored())) {
+                        || (entityPlayer instanceof Player && ((Player)entityPlayer).isSleepingIgnored())) {
                     ignoredPlayers++;
                 } else if (entityPlayer.isPlayerSleeping()) {
                     sleepingPlayers++;
@@ -108,7 +108,7 @@ public abstract class MixinWorldServer extends MixinWorld {
     public boolean areAllPlayersAsleep() {
         if ((this.allPlayersSleeping) && (!this.isRemote)) {
             for (EntityPlayer entityPlayer : this.playerEntities) {
-                boolean ignore = entityPlayer instanceof Human && ((Human)entityPlayer).isSleepingIgnored();
+                boolean ignore = entityPlayer instanceof Player && ((Player)entityPlayer).isSleepingIgnored();
                 if (!ignore && (entityPlayer.isSpectator() || !entityPlayer.isPlayerFullyAsleep())) {
                     return false;
                 }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -88,8 +88,7 @@ public abstract class MixinWorldServer extends MixinWorld {
     @Overwrite
     public void updateAllPlayersSleepingFlag() {
         this.allPlayersSleeping = false;
-        if (!this.playerEntities.isEmpty())
-        {
+        if (!this.playerEntities.isEmpty()) {
             int ignoredPlayers = 0;
             int sleepingPlayers = 0;
             for (EntityPlayer entityPlayer : this.playerEntities) {

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -110,7 +110,7 @@ public abstract class MixinWorldServer extends MixinWorld {
         if ((this.allPlayersSleeping) && (!this.isRemote)) {
             for (EntityPlayer entityPlayer : this.playerEntities) {
                 boolean ignore = entityPlayer instanceof Human && ((Human)entityPlayer).isSleepingIgnored();
-                if (ignore || (entityPlayer.isSpectator() || !entityPlayer.isPlayerFullyAsleep())) {
+                if (!ignore && (entityPlayer.isSpectator() || !entityPlayer.isPlayerFullyAsleep())) {
                     return false;
                 }
             }


### PR DESCRIPTION
This PR implements [SpongeAPI #735](https://github.com/SpongePowered/SpongeAPI/pull/735), which adds API methods for ignoring certain `Humans` when determining whether the night should be skipped due to all players being asleep.