### PR TITLE
Implement User, UserStorage and GameProfileResolver

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeBootstrap.java
+++ b/src/main/java/org/spongepowered/common/SpongeBootstrap.java
@@ -36,9 +36,11 @@ import org.spongepowered.api.service.command.CommandService;
 import org.spongepowered.api.service.command.SimpleCommandService;
 import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.service.persistence.SerializationService;
+import org.spongepowered.api.service.profile.GameProfileResolver;
 import org.spongepowered.api.service.rcon.RconService;
 import org.spongepowered.api.service.scheduler.SchedulerService;
 import org.spongepowered.api.service.sql.SqlService;
+import org.spongepowered.api.service.user.UserStorage;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.Dimension;
 import org.spongepowered.api.world.DimensionType;
@@ -47,9 +49,11 @@ import org.spongepowered.common.command.SpongeCommandDisambiguator;
 import org.spongepowered.common.registry.SpongeGameRegistry;
 import org.spongepowered.common.service.pagination.SpongePaginationService;
 import org.spongepowered.common.service.persistence.SpongeSerializationService;
+import org.spongepowered.common.service.profile.SpongeProfileResolver;
 import org.spongepowered.common.service.rcon.MinecraftRconService;
 import org.spongepowered.common.service.scheduler.SpongeScheduler;
 import org.spongepowered.common.service.sql.SqlServiceImpl;
+import org.spongepowered.common.service.user.SpongeUserStorage;
 import org.spongepowered.common.world.DimensionManager;
 import org.spongepowered.common.world.SpongeDimensionType;
 
@@ -66,49 +70,31 @@ public final class SpongeBootstrap {
     private static final org.slf4j.Logger slf4jLogger = new SLF4JLogger((AbstractLogger) Sponge.getLogger(), Sponge.getLogger().getName());
 
     public static void initializeServices() {
-        try {
-            SimpleCommandService commandService = new SimpleCommandService(Sponge.getGame(), slf4jLogger, new SpongeCommandDisambiguator(Sponge.getGame()));
-            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), CommandService.class, commandService);
+        SimpleCommandService commandService = new SimpleCommandService(Sponge.getGame(), slf4jLogger,
+                new SpongeCommandDisambiguator(Sponge.getGame()));
+        if (registerService(CommandService.class, commandService)) {
             commandService.register(Sponge.getPlugin(), CommandSponge.getCommand(), "sponge", "sp");
-        } catch (ProviderExistsException e) {
-            Sponge.getLogger().warn("Non-Sponge CommandService already registered: " + e.getLocalizedMessage());
         }
-
-        try {
-            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), SqlService.class, new SqlServiceImpl());
-        } catch (ProviderExistsException e) {
-            Sponge.getLogger().warn("Non-Sponge SqlService already registered: " + e.getLocalizedMessage());
+        registerService(SqlService.class, new SqlServiceImpl());
+        if (!registerService(SchedulerService.class, SpongeScheduler.getInstance())) {
+            throw new ExceptionInInitializerError("Cannot continue with a Non-Sponge Scheduler!");
         }
-
-        try {
-            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), SchedulerService.class, SpongeScheduler.getInstance());
-        } catch (ProviderExistsException e) {
-            Sponge.getLogger().error("Non-Sponge scheduler has been registered. Cannot continue!");
-            throw new ExceptionInInitializerError(e);
-        }
-
-        try {
-            SerializationService serializationService = new SpongeSerializationService();
-            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), SerializationService.class, serializationService);
-        } catch (ProviderExistsException e2) {
-            Sponge.getLogger().warn("Non-Sponge SerializationService already registered: " + e2.getLocalizedMessage());
-        }
-
-        try {
-            PaginationService paginationService = new SpongePaginationService();
-            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), PaginationService.class, paginationService);
-        } catch (ProviderExistsException e) {
-            Sponge.getLogger().warn("Non-Sponge PaginationService already registered: " + e.getLocalizedMessage());
-
-        }
-
+        registerService(SerializationService.class, new SpongeSerializationService());
+        registerService(PaginationService.class, new SpongePaginationService());
         if (Sponge.getGame().getPlatform().getType() == Platform.Type.SERVER) {
-            try {
-                Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), RconService.class, new MinecraftRconService((DedicatedServer)
-                        MinecraftServer.getServer()));
-            } catch (ProviderExistsException e) {
-                Sponge.getLogger().warn("Non-Sponge Rcon service already registered: " + e.getLocalizedMessage());
-            }
+            registerService(RconService.class, new MinecraftRconService((DedicatedServer) MinecraftServer.getServer()));
+        }
+        registerService(UserStorage.class, new SpongeUserStorage());
+        registerService(GameProfileResolver.class, new SpongeProfileResolver());
+    }
+
+    private static <T> boolean registerService(Class<T> serviceClass, T serviceImpl) {
+        try {
+            Sponge.getGame().getServiceManager().setProvider(Sponge.getPlugin(), serviceClass, serviceImpl);
+            return true;
+        } catch (ProviderExistsException e) {
+            Sponge.getLogger().warn("Non-Sponge {} already registered: {}", serviceClass.getSimpleName(), e.getLocalizedMessage());
+            return false;
         }
     }
 

--- a/src/main/java/org/spongepowered/common/entity/player/SpongeUser.java
+++ b/src/main/java/org/spongepowered/common/entity/player/SpongeUser.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.entity.player;
+
+import com.google.common.base.Optional;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.nbt.NBTTagCompound;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataQuery;
+import org.spongepowered.api.data.DataSerializable;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.entity.ArmorEquipable;
+import org.spongepowered.api.entity.Tamer;
+import org.spongepowered.api.item.inventory.Carrier;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+import org.spongepowered.api.item.inventory.type.CarriedInventory;
+
+import java.util.UUID;
+
+/**
+ * Implements things that are not implemented by mixins into this class. <p>This
+ * class is concrete in order to create instances of User.</p>
+ *
+ * <p>List of mixins mixing into this class: <ul>
+ * <li>MixinSpongeUser</li><li>MixinDataHolder</li><li>MixinSubject</li> </ul>
+ *
+ * TODO Future note about data: The following data manipulators are always
+ * applicable to User: BanData, WhitelistData, JoinData, RespawnLocationData
+ */
+public class SpongeUser implements ArmorEquipable, Tamer, DataSerializable, Carrier {
+
+    private final GameProfile profile;
+
+    public SpongeUser(GameProfile profile) {
+        this.profile = profile;
+    }
+
+    public void readFromNbt(NBTTagCompound compound) {
+        // TODO Read: inventory, spawn locations, any other data that should be
+        // available through data manipulators.
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        return this.profile.getId();
+    }
+
+    @Override
+    public String getName() {
+        return this.profile.getName();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        // TODO More data
+        return new MemoryDataContainer()
+                .set(DataQuery.of("UUID"), this.profile.getId())
+                .set(DataQuery.of("name"), this.profile.getName());
+    }
+
+    @Override
+    public boolean canEquip(EquipmentType type) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public boolean canEquip(EquipmentType type, ItemStack equipment) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public Optional<ItemStack> getEquipped(EquipmentType type) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public boolean equip(EquipmentType type, ItemStack equipment) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public CarriedInventory<? extends Carrier> getInventory() {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public Optional<ItemStack> getHelmet() {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public void setHelmet(ItemStack helmet) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public Optional<ItemStack> getChestplate() {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public void setChestplate(ItemStack chestplate) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public Optional<ItemStack> getLeggings() {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public void setLeggings(ItemStack leggings) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public Optional<ItemStack> getBoots() {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public void setBoots(ItemStack boots) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public Optional<ItemStack> getItemInHand() {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+    @Override
+    public void setItemInHand(ItemStack itemInHand) {
+        throw new UnsupportedOperationException(); // TODO Inventory API
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayerMP.java
@@ -24,10 +24,14 @@
  */
 package org.spongepowered.common.interfaces;
 
+import org.spongepowered.api.entity.player.User;
 
 public interface IMixinEntityPlayerMP {
 
     void reset();
 
     boolean usesCustomClient();
+
+    User getUserObject();
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
@@ -30,6 +30,7 @@ import net.minecraft.command.server.CommandBlockLogic;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.rcon.RConConsoleSource;
 import net.minecraft.server.MinecraftServer;
+import org.spongepowered.api.entity.player.User;
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
@@ -45,6 +46,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.command.MinecraftCommandWrapper;
+import org.spongepowered.common.entity.player.SpongeUser;
 import org.spongepowered.common.interfaces.IMixinSubject;
 import org.spongepowered.common.service.permission.SubjectSettingCallback;
 
@@ -58,7 +60,7 @@ import javax.annotation.Nullable;
  * Mixin to provide a common implementation of subject that refers to the installed permissions service for a subject.
  */
 @NonnullByDefault
-@Mixin(value = {EntityPlayerMP.class, CommandBlockLogic.class, MinecraftServer.class, RConConsoleSource.class},
+@Mixin(value = {EntityPlayerMP.class, CommandBlockLogic.class, MinecraftServer.class, RConConsoleSource.class, SpongeUser.class},
         targets = "net/minecraft/tileentity/TileEntitySign$2")
 public abstract class MixinSubject implements CommandSource, ICommandSender, IMixinSubject {
 
@@ -90,6 +92,9 @@ public abstract class MixinSubject implements CommandSource, ICommandSender, IMi
 
     @Override
     public Optional<CommandSource> getCommandSource() {
+        if (this instanceof User && !((User) this).isOnline()) {
+            return Optional.absent();
+        }
         return Optional.<CommandSource>of(this);
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/data/MixinDataHolder.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/data/MixinDataHolder.java
@@ -40,10 +40,11 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.common.data.DataTransactionBuilder;
 import org.spongepowered.common.data.SpongeDataProcessor;
 import org.spongepowered.common.data.SpongeManipulatorRegistry;
+import org.spongepowered.common.entity.player.SpongeUser;
 
 import java.util.Collection;
 
-@Mixin(value = {TileEntity.class, Entity.class, ItemStack.class, PotionEffect.class}, priority = 999)
+@Mixin(value = {TileEntity.class, Entity.class, ItemStack.class, PotionEffect.class, SpongeUser.class}, priority = 999)
 public abstract class MixinDataHolder implements DataHolder {
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinSpongeUser.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinSpongeUser.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.entity.player;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.api.GameProfile;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.manipulator.entity.AchievementData;
+import org.spongepowered.api.data.manipulator.entity.BanData;
+import org.spongepowered.api.data.manipulator.entity.StatisticData;
+import org.spongepowered.api.entity.player.Player;
+import org.spongepowered.api.entity.player.User;
+import org.spongepowered.api.service.permission.PermissionService;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.api.util.Tristate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.entity.player.SpongeUser;
+import org.spongepowered.common.interfaces.IMixinSubject;
+
+@Mixin(value = SpongeUser.class, remap = false)
+public abstract class MixinSpongeUser implements User, IMixinSubject {
+
+    @Shadow private com.mojang.authlib.GameProfile profile;
+
+    @Override
+    public GameProfile getProfile() {
+        return (GameProfile) this.profile;
+    }
+
+    @Override
+    public boolean isOnline() {
+        return this.getPlayer().isPresent();
+    }
+
+    @Override
+    public Optional<Player> getPlayer() {
+        return Optional.fromNullable((Player) MinecraftServer.getServer().getConfigurationManager().getPlayerByUUID(this.profile.getId()));
+    }
+
+    @Override
+    public AchievementData getAchievementData() {
+        throw new UnsupportedOperationException(); // TODO Achievement Data
+    }
+
+    @Override
+    public StatisticData getStatisticData() {
+        throw new UnsupportedOperationException(); // TODO Statistic Data
+    }
+
+    @Override
+    public BanData getBanData() {
+        throw new UnsupportedOperationException(); // TODO Ban Data
+    }
+
+    @Override
+    public boolean validateRawData(DataContainer container) {
+        throw new UnsupportedOperationException(); // TODO Data API
+    }
+
+    @Override
+    public void setRawData(DataContainer container) throws InvalidDataException {
+        throw new UnsupportedOperationException(); // TODO Data API
+    }
+
+    @Override
+    public String getSubjectCollectionIdentifier() {
+        return PermissionService.SUBJECTS_USER;
+    }
+
+    @Override
+    public Tristate permDefault(String permission) {
+        return Tristate.FALSE;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return this.profile.getId().toString();
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("isOnline", this.isOnline())
+                .add("profile", this.getProfile())
+                .toString();
+    }
+}

--- a/src/main/java/org/spongepowered/common/service/permission/UserCollection.java
+++ b/src/main/java/org/spongepowered/common/service/permission/UserCollection.java
@@ -24,27 +24,20 @@
  */
 package org.spongepowered.common.service.permission;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.mojang.authlib.GameProfile;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.management.PlayerProfileCache;
-import net.minecraft.server.management.UserListOpsEntry;
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.service.permission.base.SpongeSubjectCollection;
+import org.spongepowered.common.service.profile.SpongeProfileResolver;
 
 import java.util.UUID;
-
-import javax.annotation.Nullable;
-
 
 /**
  * User collection keeping track of opped users.
  */
 public class UserCollection extends SpongeSubjectCollection {
+
     private final SpongePermissionService service;
 
     public UserCollection(SpongePermissionService service) {
@@ -66,16 +59,7 @@ public class UserCollection extends SpongeSubjectCollection {
     }
 
     private GameProfile uuidToGameProfile(UUID uid) {
-        PlayerProfileCache cache = MinecraftServer.getServer().getPlayerProfileCache();
-        GameProfile profile = cache.getProfileByUUID(uid); // Get already cached profile by uuid
-        if (profile == null) {
-            profile = MinecraftServer.getServer().getMinecraftSessionService().fillProfileProperties(new GameProfile(uid, null), false);
-            if (profile.getName() != null) {
-                cache.addEntry(profile); // Cache newly looked up profile
-                cache.save(); // Save
-            }
-        }
-        return profile;
+        return (GameProfile) SpongeProfileResolver.getProfile(uid, true);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/service/profile/SpongeProfileResolver.java
+++ b/src/main/java/org/spongepowered/common/service/profile/SpongeProfileResolver.java
@@ -1,0 +1,260 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.service.profile;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.mojang.authlib.Agent;
+import com.mojang.authlib.ProfileLookupCallback;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerProfileCache;
+import org.spongepowered.api.GameProfile;
+import org.spongepowered.api.service.profile.GameProfileResolver;
+import org.spongepowered.api.service.profile.ProfileNotFoundException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+
+public class SpongeProfileResolver implements GameProfileResolver {
+
+    private static abstract class Query<V> implements Callable<V> {
+
+        private final boolean useCache;
+        protected final MinecraftServer server = MinecraftServer.getServer();
+        protected final PlayerProfileCache cache = this.server.getPlayerProfileCache();
+
+        public Query(boolean useCache) {
+            this.useCache = useCache;
+        }
+
+        protected GameProfile fromId(UUID id) throws Exception {
+            if (this.useCache) {
+                GameProfile profile = (GameProfile) this.cache.getProfileByUUID(id);
+                if (profile != null) {
+                    return profile;
+                }
+            }
+            // TODO Possibly use UUID -> Name History
+            // (http://wiki.vg/Mojang_API#UUID_-.3E_Name_history)
+            com.mojang.authlib.GameProfile profile =
+                    this.server.getMinecraftSessionService().fillProfileProperties(new com.mojang.authlib.GameProfile(id, null), false);
+            if (profile == null || !profile.isComplete()) {
+                throw new ProfileNotFoundException("Profile: " + profile);
+            }
+            return (GameProfile) profile;
+        }
+
+        protected List<GameProfile> fromNames(List<String> names) throws Exception {
+            final List<GameProfile> profiles = Lists.newArrayList();
+            Set<String> cachedNames = Sets.newHashSet(this.cache.getUsernames());
+            if (this.useCache) {
+                for (int i = 0; i < names.size(); i++) {
+                    GameProfile profile = null;
+                    if (cachedNames.contains(names.get(i).toLowerCase(Locale.ROOT))) {
+                        profile = (GameProfile) this.cache.getGameProfileForUsername(names.get(i));
+                    }
+                    if (profile != null) {
+                        profiles.add(profile);
+                        names.remove(i--);
+                    }
+                }
+            }
+            if (names.isEmpty()) {
+                return profiles;
+            }
+            final ProfileNotFoundException[] thrown = new ProfileNotFoundException[1];
+            this.server.getGameProfileRepository().findProfilesByNames(names.toArray(new String[0]), Agent.MINECRAFT, new ProfileLookupCallback() {
+
+                @Override
+                public void onProfileLookupSucceeded(com.mojang.authlib.GameProfile profile) {
+                    Query.this.cache.addEntry(profile);
+                    if (thrown[0] == null) {
+                        profiles.add((GameProfile) profile);
+                    }
+                }
+
+                @Override
+                public void onProfileLookupFailed(com.mojang.authlib.GameProfile profile, Exception exception) {
+                    thrown[0] = new ProfileNotFoundException("Profile: " + profile, exception);
+                }
+            });
+            this.cache.save();
+            if (thrown[0] != null) {
+                throw thrown[0];
+            }
+            return profiles;
+        }
+
+    }
+
+    private static class SingleQuery extends Query<GameProfile> {
+
+        private final UUID id;
+        private final String name;
+
+        public SingleQuery(UUID uniqueId, boolean useCache) {
+            super(useCache);
+            this.id = uniqueId;
+            this.name = null;
+        }
+
+        public SingleQuery(String name, boolean useCache) {
+            super(useCache);
+            this.name = name;
+            this.id = null;
+        }
+
+        @Override
+        public GameProfile call() throws Exception {
+            if (this.id != null) {
+                return this.fromId(this.id);
+            } else if (this.name != null) {
+                return this.fromNames(Lists.newArrayList(this.name)).get(0);
+            }
+            throw new IllegalStateException("Impossible! The query if not for a name or a uuid.");
+        }
+
+    }
+
+    private static class MultiQuery extends Query<Collection<GameProfile>> {
+
+        private final Iterator<?> iterator;
+
+        public MultiQuery(Iterable<?> iterable, boolean useCache) {
+            super(useCache);
+            this.iterator = iterable.iterator();
+        }
+
+        @Override
+        public Collection<GameProfile> call() throws Exception {
+            if (!this.iterator.hasNext()) {
+                return Collections.emptyList();
+            }
+            Object first = null; // Isn't type erasure great?!
+            do {
+                first = this.iterator.next();
+            } while (first == null && this.iterator.hasNext());
+            if (first instanceof String) {
+                @SuppressWarnings("unchecked")
+                List<String> names = Lists.newArrayList((Iterator<String>) this.iterator);
+                names.add((String) first);
+                return this.fromNames(names);
+            } else if (first instanceof UUID) {
+                return this.iterateUuids((UUID) first);
+            }
+            return Collections.emptyList();
+        }
+
+        private Collection<GameProfile> iterateUuids(UUID first) throws Exception {
+            Collection<GameProfile> profiles = Lists.newArrayList(this.fromId(first));
+            while (this.iterator.hasNext()) {
+                profiles.add(this.fromId((UUID) this.iterator.next()));
+            }
+            return profiles;
+        }
+    }
+
+    private final ListeningExecutorService executor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+
+    @Override
+    public ListenableFuture<GameProfile> get(UUID uniqueId) {
+        return this.get(uniqueId, true);
+    }
+
+    @Override
+    public ListenableFuture<GameProfile> get(UUID uniqueId, final boolean useCache) {
+        return this.executor.submit(new SingleQuery(checkNotNull(uniqueId, "uniqueId"), useCache));
+    }
+
+    @Override
+    public ListenableFuture<GameProfile> get(String name) {
+        return this.get(name, true);
+    }
+
+    @Override
+    public ListenableFuture<GameProfile> get(String name, boolean useCache) {
+        return this.executor.submit(new SingleQuery(checkNotNull(name, "name"), useCache));
+    }
+
+    @Override
+    public ListenableFuture<Collection<GameProfile>> getAllByName(Iterable<String> names, boolean useCache) {
+        return this.executor.submit(new MultiQuery(checkNotNull(names, "names"), useCache));
+    }
+
+    @Override
+    public ListenableFuture<Collection<GameProfile>> getAllById(Iterable<UUID> uniqueIds, boolean useCache) {
+        return this.executor.submit(new MultiQuery(checkNotNull(uniqueIds, "uniqueIds"), useCache));
+    }
+
+    @Override
+    public Collection<GameProfile> getCachedProfiles() {
+        PlayerProfileCache cache = MinecraftServer.getServer().getPlayerProfileCache();
+        Collection<GameProfile> profiles = Lists.newArrayList();
+        for (String name : cache.getUsernames()) {
+            if (name != null) {
+                GameProfile profile = (GameProfile) cache.getGameProfileForUsername(name);
+                if (profile != null) {
+                    profiles.add(profile);
+                }
+            }
+        }
+        return profiles;
+    }
+
+    @Override
+    public Collection<GameProfile> match(String lastKnownName) {
+        lastKnownName = checkNotNull(lastKnownName, "lastKnownName").toLowerCase(Locale.ROOT);
+        Collection<GameProfile> allProfiles = this.getCachedProfiles();
+        Collection<org.spongepowered.api.GameProfile> matching = Sets.newHashSet();
+        for (GameProfile profile : allProfiles) {
+            if (profile.getName().startsWith(lastKnownName)) {
+                matching.add(profile);
+            }
+        }
+        return matching;
+    }
+
+    // Internal. Get the profile from the UUID and block until a result
+    public static GameProfile getProfile(UUID uniqueId, boolean useCache) {
+        try {
+            return new SingleQuery(uniqueId, useCache).call();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/service/user/SpongeUserStorage.java
+++ b/src/main/java/org/spongepowered/common/service/user/SpongeUserStorage.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.service.user;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Sets;
+import org.spongepowered.api.GameProfile;
+import org.spongepowered.api.entity.player.User;
+import org.spongepowered.api.service.user.UserStorage;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.UUID;
+
+public class SpongeUserStorage implements UserStorage {
+
+    @Override
+    public Optional<User> get(UUID uniqueId) {
+        return Optional.fromNullable(UserDiscoverer.findByUuid(checkNotNull(uniqueId, "uniqueId")));
+    }
+
+    @Override
+    public Optional<User> get(String lastKnownName) {
+        checkNotNull(lastKnownName, "lastKnownName");
+        checkArgument(lastKnownName.length() >= 3 && lastKnownName.length() <= 16, "Invalid username %s", lastKnownName);
+        return Optional.fromNullable(UserDiscoverer.findByUsername(lastKnownName));
+    }
+
+    @Override
+    public Optional<User> get(GameProfile profile) {
+        return Optional.fromNullable(UserDiscoverer.findByUuid(checkNotNull(profile, "profile").getUniqueId()));
+    }
+
+    @Override
+    public User getOrCreate(GameProfile profile) {
+        Optional<User> user = get(profile);
+        if (user.isPresent()) {
+            return user.get();
+        }
+        return UserDiscoverer.create((com.mojang.authlib.GameProfile) profile);
+    }
+
+    @Override
+    public Collection<GameProfile> getAll() {
+        return UserDiscoverer.getAllProfiles();
+    }
+
+    @Override
+    public boolean delete(GameProfile profile) {
+        return UserDiscoverer.delete(checkNotNull(profile, "profile").getUniqueId());
+    }
+
+    @Override
+    public boolean delete(User user) {
+        return UserDiscoverer.delete(checkNotNull(user, "user").getUniqueId());
+    }
+
+    @Override
+    public Collection<GameProfile> match(String lastKnownName) {
+        lastKnownName = checkNotNull(lastKnownName, "lastKnownName").toLowerCase(Locale.ROOT);
+        Collection<org.spongepowered.api.GameProfile> allProfiles = UserDiscoverer.getAllProfiles();
+        Collection<org.spongepowered.api.GameProfile> matching = Sets.newHashSet();
+        for (org.spongepowered.api.GameProfile profile : allProfiles) {
+            if (profile.getName().startsWith(lastKnownName)) {
+                matching.add(profile);
+            }
+        }
+        return matching;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/service/user/UserDiscoverer.java
+++ b/src/main/java/org/spongepowered/common/service/user/UserDiscoverer.java
@@ -1,0 +1,247 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.service.user;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.BanEntry;
+import net.minecraft.server.management.PlayerProfileCache;
+import net.minecraft.server.management.UserListBans;
+import net.minecraft.server.management.UserListBansEntry;
+import net.minecraft.server.management.UserListWhitelist;
+import net.minecraft.server.management.UserListWhitelistEntry;
+import net.minecraft.world.storage.SaveHandler;
+import org.spongepowered.api.entity.player.User;
+import org.spongepowered.common.entity.player.SpongeUser;
+import org.spongepowered.common.interfaces.IMixinEntityPlayerMP;
+import org.spongepowered.common.util.SpongeHooks;
+import org.spongepowered.common.world.DimensionManager;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+class UserDiscoverer {
+
+    private static final Map<UUID, User> userCache = Maps.newHashMap();
+
+    static User create(com.mojang.authlib.GameProfile profile) {
+        User user = (User) new SpongeUser(profile);
+        userCache.put(profile.getId(), user);
+        return user;
+    }
+
+    /**
+     * Searches for user data from a variety of places, in order of preference.
+     * A user that has data in sponge may not necessarily have been online
+     * before. A user added to the ban/whitelist that has not been on the server
+     * before should be discover-able.
+     *
+     * @param uniqueId The user's UUID
+     * @return The user data, or null if not found
+     */
+    static User findByUuid(UUID uniqueId) {
+        User user = userCache.get(uniqueId);
+        if (user != null) {
+            return user;
+        }
+        user = getOnlinePlayer(uniqueId);
+        if (user != null) {
+            return user;
+        }
+        user = getFromStoredData(uniqueId);
+        if (user != null) {
+            return user;
+        }
+        user = getFromWhitelist(uniqueId);
+        if (user != null) {
+            return user;
+        }
+        user = getFromBanlist(uniqueId);
+        return user;
+    }
+
+    static User findByUsername(String username) {
+        PlayerProfileCache cache = MinecraftServer.getServer().getPlayerProfileCache();
+        HashSet<String> names = Sets.newHashSet(cache.getUsernames());
+        if (names.contains(username.toLowerCase(Locale.ROOT))) {
+            GameProfile profile = cache.getGameProfileForUsername(username);
+            if (profile != null) {
+                return findByUuid(profile.getId());
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    static Collection<org.spongepowered.api.GameProfile> getAllProfiles() {
+        Set<org.spongepowered.api.GameProfile> profiles = Sets.newHashSet();
+
+        // Add all cached profiles
+        for (User user : userCache.values()) {
+            profiles.add(user.getProfile());
+        }
+
+        // Add all known profiles from the data files
+        SaveHandler saveHandler = (SaveHandler) DimensionManager.getWorldFromDimId(0).getSaveHandler();
+        String[] uuids = saveHandler.getAvailablePlayerDat();
+        for (String playerUuid : uuids) {
+            GameProfile profile = MinecraftServer.getServer().getPlayerProfileCache().getProfileByUUID(UUID.fromString(playerUuid));
+            if (profile != null) {
+                profiles.add((org.spongepowered.api.GameProfile) profile);
+            }
+        }
+
+        // Add all whitelisted users
+        UserListWhitelist whiteList = MinecraftServer.getServer().getConfigurationManager().getWhitelistedPlayers();
+        for (UserListWhitelistEntry entry : (Collection<UserListWhitelistEntry>) whiteList.getValues().values()) {
+            profiles.add((org.spongepowered.api.GameProfile) entry.value);
+        }
+
+        // Add all banned users
+        UserListBans banList = MinecraftServer.getServer().getConfigurationManager().getBannedPlayers();
+        for (BanEntry entry : (Collection<BanEntry>) banList.getValues().values()) {
+            if (entry instanceof UserListBansEntry) {
+                profiles.add((org.spongepowered.api.GameProfile) entry.value);
+            }
+        }
+        return profiles;
+    }
+
+    static boolean delete(UUID uniqueId) {
+        if (getOnlinePlayer(uniqueId) != null) {
+            // Don't delete online player's data
+            return false;
+        }
+        boolean success = deleteStoredPlayerData(uniqueId);
+        success = success && deleteWhitelistEntry(uniqueId);
+        success = success && deleteBanlistEntry(uniqueId);
+        return success;
+    }
+
+    private static User getOnlinePlayer(UUID uniqueId) {
+        // Although the player itself could be returned here (as Player extends
+        // User), a plugin is more likely to cache the User object and we don't
+        // want the player entity to be cached.
+        IMixinEntityPlayerMP player = (IMixinEntityPlayerMP) MinecraftServer.getServer().getConfigurationManager().getPlayerByUUID(uniqueId);
+        if (player != null) {
+            return player.getUserObject();
+        }
+        return null;
+    }
+
+    private static User getFromStoredData(UUID uniqueId) {
+        // Note: Uses the overworld's player data
+        File dataFile = getPlayerDataFile(uniqueId);
+        if (dataFile == null) {
+            return null;
+        }
+        GameProfile profile = MinecraftServer.getServer().getPlayerProfileCache().getProfileByUUID(uniqueId);
+        if (profile != null) {
+            User user = create(profile);
+            try {
+                ((SpongeUser) user).readFromNbt(CompressedStreamTools.readCompressed(new FileInputStream(dataFile)));
+            } catch (IOException e) {
+                SpongeHooks.logWarning("Corrupt user file {}. {}", dataFile, e);
+            }
+            return user;
+        } else {
+            return null;
+        }
+    }
+
+    private static User getFromWhitelist(UUID uniqueId) {
+        GameProfile profile = null;
+        UserListWhitelist whiteList = MinecraftServer.getServer().getConfigurationManager().getWhitelistedPlayers();
+        UserListWhitelistEntry whiteListData = (UserListWhitelistEntry) whiteList.getEntry(new GameProfile(uniqueId, ""));
+        if (whiteListData != null) {
+            profile = (GameProfile) whiteListData.value;
+        }
+        if (profile != null) {
+            return create(profile);
+        }
+        return null;
+    }
+
+    private static User getFromBanlist(UUID uniqueId) {
+        GameProfile profile = null;
+        UserListBans banList = MinecraftServer.getServer().getConfigurationManager().getBannedPlayers();
+        BanEntry banData = (BanEntry) banList.getEntry(new GameProfile(uniqueId, ""));
+        if (banData instanceof UserListBansEntry) {
+            profile = (GameProfile) banData.value;
+        }
+        if (profile != null) {
+            return create(profile);
+        }
+        return null;
+    }
+
+    private static File getPlayerDataFile(UUID uniqueId) {
+        // Note: Uses the overworld's player data
+        SaveHandler saveHandler = (SaveHandler) DimensionManager.getWorldFromDimId(0).getSaveHandler();
+        String[] uuids = saveHandler.getAvailablePlayerDat();
+        for (String playerUuid : uuids) {
+            if (uniqueId.toString().equals(playerUuid)) {
+                return new File(saveHandler.playersDirectory, playerUuid + ".dat");
+            }
+        }
+        return null;
+    }
+
+    private static boolean deleteStoredPlayerData(UUID uniqueId) {
+        File dataFile = getPlayerDataFile(uniqueId);
+        if (dataFile != null) {
+            try {
+                return dataFile.delete();
+            } catch (SecurityException e) {
+                SpongeHooks.logWarning("Unable to delete file {} due to a security error. {}", dataFile, e);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean deleteWhitelistEntry(UUID uniqueId) {
+        UserListWhitelist whiteList = MinecraftServer.getServer().getConfigurationManager().getWhitelistedPlayers();
+        whiteList.removeEntry(new GameProfile(uniqueId, ""));
+        return true;
+    }
+
+    private static boolean deleteBanlistEntry(UUID uniqueId) {
+        UserListBans banList = MinecraftServer.getServer().getConfigurationManager().getBannedPlayers();
+        banList.removeEntry(new GameProfile(uniqueId, ""));
+        return true;
+    }
+
+}

--- a/src/main/resources/common_at.cfg
+++ b/src/main/resources/common_at.cfg
@@ -136,3 +136,5 @@ public net.minecraft.scoreboard.ScorePlayerTeam *
 public net.minecraft.scoreboard.ScoreObjective *
 
 public net.minecraft.command.PlayerSelector func_82381_h(Ljava/lang/String;)Ljava/util/Map; # getArgumentMap
+
+public net.minecraft.world.storage.SaveHandler field_75771_c # playersDirectory

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -114,6 +114,7 @@
         "entity.living.villager.MixinEntityVillager",
         "entity.player.MixinEntityPlayer",
         "entity.player.MixinEntityPlayerMP",
+        "entity.player.MixinSpongeUser",
         "entity.projectile.MixinEntityArrow",
         "entity.projectile.MixinEntityEgg",
         "entity.projectile.MixinEntityEnderEye",


### PR DESCRIPTION
This implements the 3 interfaces as stated in the title.

Parts of the implementation of `User` was influenced from the discussion on SpongePowered/Sponge#122
Because `Player` extends `User` but `User` is not an `Entity`, there needs to be a separate new class which represents `User`, this is the `SpongeUser`.
Methods in `Player` that are defined and only defined in `User` are proxied to the underlying user object, this avoids duplication of code.

You may look at `SpongeUser` an go, "hang on, it doesn't implement `User`". Yes, this is intentional, it's to avoid making SpongeUser a massive collection of copied methods from various places (I experimented with that idea too, it was a mess).
Instead, it utilizes the power of mixins to mix into `SpongeUser` from existing mixins, thus avoids duplication. The actual implementation of `User` is done in `MixinSpongeUser`.

The second part of this PR is implementing a way to obtain `User` objects through `UserStorage`.
The vanilla layout of storing user data is such that there's a variety of places the data could be.
There's the `world/playerdata/{uuid}.dat`, `whitelist.json` and `banned-players.json`.
`UserDiscoverer` is a "binding" of these locations so `User` objects can be accessed uniformly.

Finally, I have implemented `GameProfileResolver` as a bonus treat :)

Closes SpongePowered/Sponge#122
