### PR TITLE
Notify clients of SignData changes. Fixes #88.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/tileentity/SpongeSignDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/tileentity/SpongeSignDataProcessor.java
@@ -97,6 +97,7 @@ public class SpongeSignDataProcessor implements SpongeDataProcessor<SignData> {
                     ((TileEntitySign) dataHolder).signText[i] = SpongeTexts.toComponent(manipulator.getLine(i));
                 }
                 ((TileEntitySign) dataHolder).markDirty();
+                ((TileEntitySign) dataHolder).getWorld().markBlockForUpdate(((TileEntitySign) dataHolder).getPos());
                 builder.result(DataTransactionResult.Type.SUCCESS);
                 return builder.build();
             }

--- a/src/main/java/org/spongepowered/common/data/processor/tileentity/SpongeSignDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/tileentity/SpongeSignDataProcessor.java
@@ -96,6 +96,7 @@ public class SpongeSignDataProcessor implements SpongeDataProcessor<SignData> {
                 for (int i = 0; i < 4; i++) {
                     ((TileEntitySign) dataHolder).signText[i] = SpongeTexts.toComponent(manipulator.getLine(i));
                 }
+                ((TileEntitySign) dataHolder).markDirty();
                 builder.result(DataTransactionResult.Type.SUCCESS);
                 return builder.build();
             }


### PR DESCRIPTION
This pull request fixes #88 by marking signs as dirty when new `SignData` is offered to them.