### PR TITLE
Restore Pre-1.8 Server Spawn Protection Behavior closes #15

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
@@ -26,9 +26,12 @@ package org.spongepowered.common.mixin.core.server;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.management.UserListOps;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.io.File;
 import java.net.Proxy;
@@ -53,6 +56,20 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
     public void setGuiEnabled() {
         //MinecraftServerGui.createServerGui(this);
         this.guiIsEnabled = false;
+    }
+
+    /**
+     * @author ryantheleach
+     *
+     * Purpose: This disables the new check in minecraft 1.8 that checks the OP list to check if there is no operators
+     * Reasoning: There has been complaints about 1.8 breaking spawn protection see: https://github.com/SpongePowered/SpongeCommon/issues/15
+     * UserList.hasEntries() is named incorrectly in MCP, it should be isEmpty
+     * The logic at time of writing is if OPList is empty, disable spawn protection. This has been replaced with if(false) disable spawn protection
+     */
+
+    @Redirect(method = "isBlockProtected", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/management/UserListOps;hasEntries()Z"))
+    public boolean ignoreEmptyOPList(UserListOps server){
+        return false;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
@@ -66,7 +66,6 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
      * UserList.hasEntries() is named incorrectly in MCP, it should be isEmpty
      * The logic at time of writing is if OPList is empty, disable spawn protection. This has been replaced with if(false) disable spawn protection
      */
-
     @Redirect(method = "isBlockProtected", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/management/UserListOps;hasEntries()Z"))
     public boolean ignoreEmptyOPList(UserListOps server){
         return false;


### PR DESCRIPTION
@Zidane commented on 29 Apr https://github.com/SpongePowered/SpongeCommon/issues/15
>As some may know, in 1.8 the server disables spawn point protection if the server has no known OPs. In my opinion, this is an incredibly stupid design decision and, as evidenced by looking at various forum posts, many server admins were under a false impression that spawn protection broke.
>Put simply, you shouldn't HAVE to have an OP specified for spawn protection work.

Simple fix in case this is the solution you want to go with, Has been tested in a dev environment only.

I didn't add a configuration option because you can just disable the spawn protection anyway by setting spawn-protection in server.properties below 0.

At this stage it just comes down to whatever avoids the most confusion, having a default spawn protection, or not having it. Having it based on the number of OP's is just plain weird.