### PR TITLE
Implement resource packs.

### DIFF
--- a/src/main/java/org/spongepowered/common/interfaces/IMixinPacketResourcePackSend.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinPacketResourcePackSend.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.interfaces;
+
+import org.spongepowered.api.resourcepack.ResourcePack;
+
+public interface IMixinPacketResourcePackSend {
+
+    ResourcePack getResourcePack();
+
+    void setResourcePack(ResourcePack pack);
+
+    String setFakeHash();
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -38,6 +38,7 @@ import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S02PacketChat;
 import net.minecraft.network.play.server.S29PacketSoundEffect;
+import net.minecraft.network.play.server.S48PacketResourcePackSend;
 import net.minecraft.scoreboard.IScoreObjectiveCriteria;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.FoodStats;
@@ -57,6 +58,7 @@ import org.spongepowered.api.effect.sound.SoundType;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.network.PlayerConnection;
+import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.service.user.UserStorage;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
@@ -82,6 +84,7 @@ import org.spongepowered.common.entity.player.PlayerKickHelper;
 import org.spongepowered.common.interfaces.IMixinCommandSender;
 import org.spongepowered.common.interfaces.IMixinCommandSource;
 import org.spongepowered.common.interfaces.IMixinEntityPlayerMP;
+import org.spongepowered.common.interfaces.IMixinPacketResourcePackSend;
 import org.spongepowered.common.interfaces.IMixinServerScoreboard;
 import org.spongepowered.common.interfaces.IMixinSubject;
 import org.spongepowered.common.interfaces.text.IMixinTitle;
@@ -391,6 +394,13 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     public void playSound(SoundType sound, Vector3d position, double volume, double pitch, double minVolume) {
         this.playerNetServerHandler.sendPacket(new S29PacketSoundEffect(sound.getName(), position.getX(), position.getY(), position.getZ(),
                 (float) Math.max(minVolume, volume), (float) pitch));
+    }
+
+    @Override
+    public void sendResourcePack(ResourcePack pack) {
+        S48PacketResourcePackSend packet = new S48PacketResourcePackSend();
+        ((IMixinPacketResourcePackSend) packet).setResourcePack(pack);
+        this.playerNetServerHandler.sendPacket(packet);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/network/packet/MixinS48PacketResourcePackSend.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/packet/MixinS48PacketResourcePackSend.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.network.packet;
+
+import net.minecraft.network.play.server.S48PacketResourcePackSend;
+import org.spongepowered.api.resourcepack.ResourcePack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.interfaces.IMixinPacketResourcePackSend;
+import org.spongepowered.common.resourcepack.SpongeResourcePack;
+
+import java.net.URISyntaxException;
+
+@Mixin(S48PacketResourcePackSend.class)
+public abstract class MixinS48PacketResourcePackSend implements IMixinPacketResourcePackSend {
+
+    @Shadow private String url;
+    @Shadow private String hash;
+    private ResourcePack pack;
+
+    @Inject(method = "<init>(Ljava/lang/String;Ljava/lang/String;)V", at = @At("RETURN") , remap = false)
+    public void setResourcePack(String url, String hash, CallbackInfo ci) {
+        try {
+            this.pack = SpongeResourcePack.create(url, hash);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public void setResourcePack(ResourcePack pack) {
+        this.pack = pack;
+        this.url = ((SpongeResourcePack) pack).getUrlString();
+        this.hash = pack.getHash().or("");
+    }
+
+    @Override
+    public ResourcePack getResourcePack() {
+        return this.pack;
+    }
+
+    @Override
+    public String setFakeHash() {
+        if (this.hash.length() == 0) {
+            this.hash = this.pack.getId();
+            if (this.hash.length() == SpongeResourcePack.HASH_SIZE) {
+                this.hash += " ";
+            }
+        }
+        return this.hash.trim();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
@@ -61,6 +61,7 @@ import net.minecraft.world.WorldServer;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.WorldInfo;
 import org.apache.logging.log4j.Logger;
+import org.spongepowered.api.Server;
 import org.spongepowered.api.data.manipulator.mutable.entity.RespawnLocationData;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.living.player.Player;
@@ -70,6 +71,7 @@ import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.sink.MessageSink;
 import org.spongepowered.api.text.sink.MessageSinks;
+import org.spongepowered.api.resourcepack.ResourcePack;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.Dimension;
 import org.spongepowered.api.world.Location;
@@ -189,9 +191,12 @@ public abstract class MixinServerConfigurationManager {
         handler.setPlayerLocation(playerIn.posX, playerIn.posY, playerIn.posZ, playerIn.rotationYaw, playerIn.rotationPitch);
         this.updateTimeAndWeatherForPlayer(playerIn, worldserver);
 
-        if (this.mcServer.getResourcePackUrl().length() > 0) {
-            playerIn.loadResourcePack(this.mcServer.getResourcePackUrl(), this.mcServer.getResourcePackHash());
+        // Sponge Start - Use the server's ResourcePack object
+        Optional<ResourcePack> pack = ((Server)this.mcServer).getDefaultResourcePack();
+        if (pack.isPresent()) {
+            ((Player)playerIn).sendResourcePack(pack.get());
         }
+        // Sponge End
 
         playerIn.addSelfToInternalCraftingInventory();
 

--- a/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
@@ -241,6 +241,7 @@ import org.spongepowered.api.potion.PotionEffectBuilder;
 import org.spongepowered.api.potion.PotionEffectType;
 import org.spongepowered.api.potion.PotionEffectTypes;
 import org.spongepowered.api.resourcepack.ResourcePack;
+import org.spongepowered.api.resourcepack.ResourcePacks;
 import org.spongepowered.api.scoreboard.ScoreboardBuilder;
 import org.spongepowered.api.scoreboard.TeamBuilder;
 import org.spongepowered.api.scoreboard.Visibilities;
@@ -454,6 +455,7 @@ import org.spongepowered.common.item.SpongeFireworkBuilder;
 import org.spongepowered.common.item.SpongeItemStackBuilder;
 import org.spongepowered.common.item.merchant.SpongeTradeOfferBuilder;
 import org.spongepowered.common.potion.SpongePotionBuilder;
+import org.spongepowered.common.resourcepack.SpongeResourcePackFactory;
 import org.spongepowered.common.rotation.SpongeRotation;
 import org.spongepowered.common.scoreboard.SpongeDisplaySlot;
 import org.spongepowered.common.scoreboard.SpongeVisibility;
@@ -1331,6 +1333,10 @@ public abstract class SpongeGameRegistry implements GameRegistry {
                 return weather;
             }
         });
+    }
+    
+    private void setResourcePackFactory() {
+        RegistryHelper.setFactory(ResourcePacks.class, new SpongeResourcePackFactory());
     }
 
     private void setTextActionFactory() {
@@ -2346,6 +2352,7 @@ public abstract class SpongeGameRegistry implements GameRegistry {
         setTextColors();
         setRotations();
         setWeathers();
+        setResourcePackFactory();
         setTextActionFactory();
         setTextFactory();
         setSelectors();

--- a/src/main/java/org/spongepowered/common/resourcepack/SpongeResourcePack.java
+++ b/src/main/java/org/spongepowered/common/resourcepack/SpongeResourcePack.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.resourcepack;
+
+import com.google.common.base.Optional;
+import org.spongepowered.api.resourcepack.ResourcePack;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+public abstract class SpongeResourcePack implements ResourcePack {
+
+    private final Optional<String> hash;
+    private final String id = UUID.randomUUID().toString();
+
+    public static final int HASH_SIZE = 40;
+
+    public SpongeResourcePack(@Nullable String hash) {
+        this.hash = Optional.fromNullable(hash);
+    }
+
+    public abstract String getUrlString();
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public Optional<String> getHash() {
+        return this.hash;
+    }
+
+    public static SpongeResourcePack create(String uri, String hash) throws URISyntaxException {
+        if (uri.startsWith(SpongeWorldResourcePack.LEVEL_PACK_PROTOCOL)) {
+            return new SpongeWorldResourcePack(uri, hash);
+        }
+        if (hash != null && hash.length() != HASH_SIZE) {
+            hash = null;
+        }
+        return new SpongeURIResourcePack(uri, hash);
+    }
+
+    public static SpongeResourcePack create(URI uri, String hash) {
+        if (uri.toString().startsWith(SpongeWorldResourcePack.LEVEL_PACK_PROTOCOL)) {
+            return new SpongeWorldResourcePack(uri, hash);
+        }
+        return new SpongeURIResourcePack(uri, hash);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/resourcepack/SpongeResourcePackFactory.java
+++ b/src/main/java/org/spongepowered/common/resourcepack/SpongeResourcePackFactory.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.resourcepack;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import org.spongepowered.api.resourcepack.ResourcePack;
+import org.spongepowered.api.resourcepack.ResourcePackFactory;
+import org.spongepowered.common.world.DimensionManager;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+public final class SpongeResourcePackFactory implements ResourcePackFactory {
+
+    @Override
+    public ResourcePack fromUri(URI uri) throws FileNotFoundException {
+        checkNotNull(uri, "uri");
+        try {
+            Hasher hasher = Hashing.sha1().newHasher();
+            InputStream in = openStream(uri);
+            byte[] buf = new byte[256];
+            while (true) {
+                int read = in.read(buf);
+                if (read <= 0) {
+                    break;
+                }
+                hasher.putBytes(buf, 0, read);
+            }
+            in.close();
+            return SpongeResourcePack.create(uri, hasher.hash().toString());
+        } catch (IOException e) {
+            FileNotFoundException ex = new FileNotFoundException(e.toString());
+            ex.initCause(e);
+            throw ex;
+        }
+    }
+
+    private static InputStream openStream(URI uri) throws IOException {
+        if (uri.toString().startsWith(SpongeWorldResourcePack.LEVEL_PACK_PROTOCOL)) {
+            return new FileInputStream(new File(DimensionManager.getCurrentSaveRootDirectory().getParent(),
+                    uri.toString().substring(SpongeWorldResourcePack.LEVEL_PACK_PROTOCOL.length())));
+        }
+        return uri.toURL().openStream();
+    }
+
+    @Override
+    public ResourcePack fromUriUnchecked(URI uri) {
+        return SpongeResourcePack.create(checkNotNull(uri, "uri"), null);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/resourcepack/SpongeURIResourcePack.java
+++ b/src/main/java/org/spongepowered/common/resourcepack/SpongeURIResourcePack.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.resourcepack;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.annotation.Nullable;
+
+public final class SpongeURIResourcePack extends SpongeResourcePack {
+
+    private final URI uri;
+    private final String name;
+
+    public SpongeURIResourcePack(URI uri, @Nullable String hash) {
+        super(hash);
+        this.uri = uri;
+        this.name = getName0();
+    }
+
+    public SpongeURIResourcePack(String uri, @Nullable String hash) throws URISyntaxException {
+        this(new URI(uri), hash);
+    }
+
+    private String getName0() {
+        String name = this.uri.getPath();
+        name = name.substring(name.lastIndexOf("/") + 1);
+        return name.replaceAll("\\W", "");
+    }
+
+    @Override
+    public String getUrlString() {
+        return this.uri.toString();
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public URI getUri() {
+        return this.uri;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/resourcepack/SpongeWorldResourcePack.java
+++ b/src/main/java/org/spongepowered/common/resourcepack/SpongeWorldResourcePack.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.resourcepack;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+import javax.annotation.Nullable;
+
+public class SpongeWorldResourcePack extends SpongeResourcePack {
+
+    private final String path;
+    private final URI uri;
+    public static final String LEVEL_PACK_PROTOCOL = "level://";
+
+    public SpongeWorldResourcePack(String levelUri, @Nullable String hash) {
+        super(hash);
+        this.path = levelUri.substring(LEVEL_PACK_PROTOCOL.length());
+        try {
+            this.uri = URI.create(LEVEL_PACK_PROTOCOL + URLEncoder.encode(this.path, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public SpongeWorldResourcePack(URI levelUri, @Nullable String hash) {
+        super(hash);
+        String path = levelUri.toString().substring(LEVEL_PACK_PROTOCOL.length());
+        try {
+            this.path = URLDecoder.decode(path, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError(e);
+        }
+        this.uri = levelUri;
+    }
+
+    @Override
+    public String getName() {
+        return "resourceszip";
+    }
+
+    @Override
+    public String getUrlString() {
+        return LEVEL_PACK_PROTOCOL + this.path;
+    }
+
+    @Override
+    public URI getUri() {
+        return this.uri;
+    }
+
+}

--- a/src/main/resources/common_at.cfg
+++ b/src/main/resources/common_at.cfg
@@ -45,8 +45,8 @@ public-f org.spongepowered.api.text.format.TextColors *
 public-f org.spongepowered.api.text.format.TextStyles *
 public-f org.spongepowered.api.text.sink.MessageSinks factory
 public-f org.spongepowered.api.text.translation.locale.Locales *
+public-f org.spongepowered.api.resourcepack.ResourcePacks *
 public-f org.spongepowered.api.util.rotation.Rotations *
-
 public-f org.spongepowered.api.world.biome.BiomeTypes *
 public-f org.spongepowered.api.world.DimensionTypes *
 public-f org.spongepowered.api.world.GeneratorTypes *
@@ -125,6 +125,8 @@ public net.minecraft.world.gen.ChunkProviderServer field_73245_g # loadedChunks
 
 public net.minecraft.network.handshake.client.C00Handshake field_149598_b # ip
 public net.minecraft.network.handshake.client.C00Handshake field_149599_c # port
+
+public net.minecraft.network.play.client.C19PacketResourcePackStatus *
 
 public net.minecraft.network.play.server.S38PacketPlayerListItem field_179769_b # players
 

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -175,6 +175,7 @@
         "item.merchant.MixinMerchantRecipe",
         "network.MixinNetHandlerPlayServer",
         "network.packet.MixinS3BPacketScoreboardObjective",
+        "network.packet.MixinS48PacketResourcePackSend",
         "potion.MixinPotion",
         "potion.MixinPotionEffect",
         "scoreboard.MixinCriterion",


### PR DESCRIPTION
This PR implements the resource pack API. It requires my changes in SpongePowered/SpongeAPI#772.

Note: Although I reverted my split of `URLResourcePack` and `WorldResourcePack` in the API, I felt it would be easier to keep the split in the implementation because of some special casing for `level://` resource packs (Mojang simply puts `"level://"` in front of the relative path).