### PR TITLE
Fix event-related casts failing on the client side.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/living/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/living/MixinEntityLiving.java
@@ -34,7 +34,6 @@ import org.objectweb.asm.Opcodes;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.living.Agent;
-import org.spongepowered.api.entity.player.Player;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.entity.EntityLeashEvent;
 import org.spongepowered.api.event.entity.EntityUnleashEvent;
@@ -94,7 +93,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
 
     @Inject(method = "interactFirst", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLiving;setLeashedToEntity(Lnet/minecraft/entity/Entity;Z)V"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
     public void callLeashEvent(EntityPlayer playerIn, CallbackInfoReturnable<Boolean> ci, ItemStack itemstack) {
-        final EntityLeashEvent event = SpongeEventFactory.createEntityLeash(Sponge.getGame(), this, (Player)playerIn);
+        final EntityLeashEvent event = SpongeEventFactory.createEntityLeash(Sponge.getGame(), this, (Entity)playerIn);
         Sponge.getGame().getEventManager().post(event);
         if(event.isCancelled()) {
             ci.cancel();

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemFishingRod.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemFishingRod.java
@@ -54,10 +54,12 @@ public abstract class MixinItemFishingRod extends Item {
             player.fishEntity.handleHookRetraction();
         } else {
             EntityFishHook fishHook = new EntityFishHook(world, player);
-            if (!Sponge.getGame().getEventManager()
+            if (world.isRemote || !Sponge.getGame().getEventManager()
                     .post(SpongeEventFactory.createPlayerCastFishingLineEvent(Sponge.getGame(), (Player) player, (FishHook) fishHook))) {
                 world.playSoundAtEntity(player, "random.bow", 0.5F, 0.4F / (itemRand.nextFloat() * 0.4F + 0.8F));
-                world.spawnEntityInWorld(fishHook);
+                if (!world.isRemote) {
+                    world.spawnEntityInWorld(fishHook);
+                }
 
                 player.swingItem();
                 player.triggerAchievement(StatList.objectUseStats[Item.getIdFromItem(this)]);


### PR DESCRIPTION
Fixes SpongePowered/Sponge#311 by not firing the event on the client thread
Fixes SpongePowered/Sponge#312 by only casting to `Entity`, not `Player`