### PR TITLE
Remove un-needed interface in MixinSubject.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
@@ -45,7 +45,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.entity.player.SpongeUser;
 import org.spongepowered.common.interfaces.IMixinCommandSender;
-import org.spongepowered.common.interfaces.IMixinCommandSource;
 import org.spongepowered.common.interfaces.IMixinSubject;
 import org.spongepowered.common.service.permission.SubjectSettingCallback;
 
@@ -62,7 +61,7 @@ import javax.annotation.Nullable;
 @NonnullByDefault
 @Mixin(value = {EntityPlayerMP.class, TileEntityCommandBlock.class, EntityMinecartCommandBlock.class, MinecraftServer.class, RConConsoleSource.class,
         SpongeUser.class}, targets = IMixinCommandSender.SIGN_CLICK_SENDER)
-public abstract class MixinSubject implements Subject, IMixinCommandSource, IMixinSubject {
+public abstract class MixinSubject implements Subject, IMixinSubject {
 
     @Nullable
     private Subject thisSubject;


### PR DESCRIPTION
`MixinSubject` implements `IMixinCommandSource`. However, it doesn't implement or use any of the methods from it.