### PR TITLE
[WIP] Multi Processor Registration

### DIFF
--- a/src/main/java/org/spongepowered/common/data/BlockDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/BlockDataProcessor.java
@@ -30,21 +30,22 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 
 public interface BlockDataProcessor<T extends ImmutableDataManipulator<T, ?>> {
 
+    int getPriority();
+
     Optional<T> fromBlockPos(World world, BlockPos blockPos);
 
-    DataTransactionResult setData(World world, BlockPos blockPos, T manipulator);
+    Optional<T> createFrom(IBlockState blockState);
 
     Optional<BlockState> withData(IBlockState blockState, T manipulator);
 
-    boolean remove(World world, BlockPos blockPos);
+    DataTransactionResult setData(World world, BlockPos blockPos, T manipulator);
 
     Optional<BlockState> removeFrom(IBlockState blockState);
 
-    Optional<T> createFrom(IBlockState blockState);
+    boolean remove(World world, BlockPos blockPos);
 
 }

--- a/src/main/java/org/spongepowered/common/data/BlockValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/BlockValueProcessor.java
@@ -24,19 +24,17 @@
  */
 package org.spongepowered.common.data;
 
+import com.google.common.base.Optional;
 import net.minecraft.block.state.IBlockState;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.data.value.BaseValue;
 
 public interface BlockValueProcessor<E, V extends BaseValue<E>> {
 
-    E getValueForBlockState(IBlockState blockState);
+    Optional<E> getValueForBlockState(IBlockState blockState);
 
-    V getApiValueForBlockState(IBlockState blockState);
+    Optional<V> getApiValueForBlockState(IBlockState blockState);
 
-    IBlockState offerValue(V baseValue);
-
-
-
-
+    Optional<BlockState> offerValue(IBlockState blockState, V baseValue);
 
 }

--- a/src/main/java/org/spongepowered/common/data/DataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/DataProcessor.java
@@ -38,6 +38,20 @@ import org.spongepowered.api.service.persistence.DataBuilder;
 
 public interface DataProcessor<M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>> extends DataBuilder<M>,
                                                                                                                         DataManipulatorBuilder<M, I> {
+    /**
+     * Gets the priority of this processor. A single {@link Key} can have
+     * multiple {@link DataProcessor}s such that mods introducing
+     * changes to the game can provide their own {@link DataProcessor}s
+     * for specific cases. The notion is that the higher the priority, the
+     * earlier the processor is used. If for any reason a processor's method
+     * is returning an {@link Optional#absent()} or
+     * {@link DataTransactionResult} with a failure, the next processor in
+     * line will be used. By default, all Sponge processors are with a
+     * priority of 100.
+     *
+     * @return The priority of the processor
+     */
+    int getPriority();
 
     boolean supports(DataHolder dataHolder);
 

--- a/src/main/java/org/spongepowered/common/data/ValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/ValueProcessor.java
@@ -57,6 +57,21 @@ public interface ValueProcessor<E, V extends BaseValue<E>> {
     Key<? extends BaseValue<E>> getKey();
 
     /**
+     * Gets the priority of this processor. A single {@link Key} can have
+     * multiple {@link ValueProcessor}s such that mods introducing
+     * changes to the game can provide their own {@link ValueProcessor}s
+     * for specific cases. The notion is that the higher the priority, the
+     * earlier the processor is used. If for any reason a processor's method
+     * is returning an {@link Optional#absent()} or
+     * {@link DataTransactionResult} with a failure, the next processor in
+     * line will be used. By default, all Sponge processors are with a
+     * priority of 100.
+     *
+     * @return The priority of the processor
+     */
+    int getPriority();
+
+    /**
      * Gets the underlying value as an {@link Optional}. This is the direct
      * implementation of {@link ValueContainer#get(Key)}. As well, since the
      * return type is {@link Optional}, this method too is applicable for

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeCommandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeCommandData.java
@@ -101,4 +101,9 @@ public class ImmutableSpongeCommandData extends AbstractImmutableData<ImmutableC
     public int compareTo(ImmutableCommandData o) {
         return 0;
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeDisplayNameData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeDisplayNameData.java
@@ -36,6 +36,7 @@ import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeDisplayNameData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.util.GetterFunction;
 
 public class ImmutableSpongeDisplayNameData extends AbstractImmutableData<ImmutableDisplayNameData, DisplayNameData> implements ImmutableDisplayNameData {
 
@@ -78,5 +79,43 @@ public class ImmutableSpongeDisplayNameData extends AbstractImmutableData<Immuta
         return new MemoryDataContainer()
             .set(Keys.DISPLAY_NAME.getQuery(), Texts.json().to(this.displayName))
             .set(Keys.SHOWS_DISPLAY_NAME, this.displays);
+    }
+
+    public Text getDisplayName() {
+        return this.displayName;
+    }
+
+    public boolean isDisplays() {
+        return this.displays;
+    }
+
+    @Override
+    protected void registerStuff() {
+        registerFieldGetter(Keys.DISPLAY_NAME, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getDisplayName();
+            }
+        });
+        registerKeyValue(Keys.DISPLAY_NAME, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return displayName();
+            }
+        });
+
+        registerFieldGetter(Keys.SHOWS_DISPLAY_NAME, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return isDisplays();
+            }
+        });
+
+        registerKeyValue(Keys.SHOWS_DISPLAY_NAME, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return customNameVisible();
+            }
+        });
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeFireworkData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeFireworkData.java
@@ -84,4 +84,9 @@ public class ImmutableSpongeFireworkData extends AbstractImmutableData<Immutable
             .set(Keys.FIREWORK_EFFECTS, this.fireworkEffects)
             .set(Keys.FIREWORK_FLIGHT_MODIFIER, this.modifier);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeMobSpawnerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeMobSpawnerData.java
@@ -150,4 +150,9 @@ public class ImmutableSpongeMobSpawnerData extends AbstractImmutableData<Immutab
             .set(Keys.SPAWNER_NEXT_ENTITY_TO_SPAWN, this.nextToSpawn)
             .set(Keys.SPAWNER_ENTITIES, this.entitiesToSpawn);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeOwnableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeOwnableData.java
@@ -71,4 +71,9 @@ public class ImmutableSpongeOwnableData extends AbstractImmutableData<ImmutableO
         return new MemoryDataContainer()
             .set(Keys.OWNED_BY_PROFILE, this.profile);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongePotionEffectData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongePotionEffectData.java
@@ -72,4 +72,9 @@ public class ImmutableSpongePotionEffectData extends AbstractImmutableData<Immut
         return new MemoryDataContainer()
             .set(Keys.POTION_EFFECTS, this.effects);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedItemData.java
@@ -46,18 +46,6 @@ public class ImmutableSpongeRepresentedItemData extends AbstractImmutableData<Im
     public ImmutableSpongeRepresentedItemData(ItemStack itemStack) {
         super(ImmutableRepresentedItemData.class);
         this.itemStack = checkNotNull(itemStack).copy();
-        registerFieldGetter(Keys.REPRESENTED_ITEM, new GetterFunction<Object>() {
-            @Override
-            public Object get() {
-                return getItemStack();
-            }
-        });
-        registerKeyValue(Keys.REPRESENTED_ITEM, new GetterFunction<ImmutableValue<?>>() {
-            @Override
-            public ImmutableValue<?> get() {
-                return item();
-            }
-        });
     }
 
     @Override
@@ -88,5 +76,21 @@ public class ImmutableSpongeRepresentedItemData extends AbstractImmutableData<Im
 
     public ItemStack getItemStack() {
         return this.itemStack.copy();
+    }
+
+    @Override
+    protected void registerStuff() {
+        registerFieldGetter(Keys.REPRESENTED_ITEM, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getItemStack();
+            }
+        });
+        registerKeyValue(Keys.REPRESENTED_ITEM, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return item();
+            }
+        });
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeAttachedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeAttachedData.java
@@ -31,18 +31,11 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeAttachedData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
-import org.spongepowered.common.util.GetterFunction;
 
 public class ImmutableSpongeAttachedData extends AbstractImmutableBooleanData<ImmutableAttachedData, AttachedData> implements ImmutableAttachedData {
 
     public ImmutableSpongeAttachedData(boolean attached) {
         super(ImmutableAttachedData.class, attached, Keys.ATTACHED, SpongeAttachedData.class);
-        registerKeyValue(Keys.ATTACHED, new GetterFunction<ImmutableValue<?>>() {
-            @Override
-            public ImmutableValue<?> get() {
-                return attached();
-            }
-        });
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeConnectedDirectionData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeConnectedDirectionData.java
@@ -100,4 +100,9 @@ public class ImmutableSpongeConnectedDirectionData extends AbstractImmutableData
             .set(Keys.CONNECTED_EAST.getQuery(), this.directions.contains(Direction.EAST))
             .set(Keys.CONNECTED_WEST.getQuery(), this.directions.contains(Direction.WEST));
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeWireAttachmentData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeWireAttachmentData.java
@@ -108,4 +108,9 @@ public class ImmutableSpongeWireAttachmentData extends AbstractImmutableData<Imm
             .set(Keys.WIRE_ATTACHMENT_SOUTH.getQuery(), this.wireAttachmentMap.get(Direction.SOUTH).getId())
             .set(Keys.WIRE_ATTACHMENT_WEST.getQuery(), this.wireAttachmentMap.get(Direction.WEST).getId());
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableData.java
@@ -95,6 +95,7 @@ public abstract class AbstractImmutableData<I extends ImmutableDataManipulator<I
 
     protected AbstractImmutableData(Class<I> immutableClass) {
         this.immutableClass = checkNotNull(immutableClass);
+        registerStuff();
     }
 
     /**
@@ -128,6 +129,8 @@ public abstract class AbstractImmutableData<I extends ImmutableDataManipulator<I
     protected final void registerFieldGetter(Key<?> key, GetterFunction<?> function) {
         this.keyFieldGetterMap.put(checkNotNull(key), checkNotNull(function));
     }
+
+    protected abstract void registerStuff();
 
     @Override
     public <E> Optional<I> with(Key<? extends BaseValue<E>> key, E value) {

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleData.java
@@ -47,18 +47,6 @@ public abstract class AbstractImmutableSingleData<T, I extends ImmutableDataMani
         super(immutableClass);
         this.value = checkNotNull(value);
         this.usedKey = checkNotNull(usedKey);
-        registerFieldGetter(this.usedKey, new GetterFunction<Object>() {
-            @Override
-            public Object get() {
-                return getValue();
-            }
-        });
-        registerKeyValue(this.usedKey, new GetterFunction<ImmutableValue<?>>() {
-            @Override
-            public ImmutableValue<?> get() {
-                return getValueGetter();
-            }
-        });
     }
 
     protected abstract ImmutableValue<?> getValueGetter();
@@ -79,6 +67,22 @@ public abstract class AbstractImmutableSingleData<T, I extends ImmutableDataMani
     @Override
     public DataContainer toContainer() {
         return new MemoryDataContainer();
+    }
+
+    @Override
+    protected void registerStuff() {
+        registerFieldGetter(this.usedKey, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getValue();
+            }
+        });
+        registerKeyValue(this.usedKey, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return getValueGetter();
+            }
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeBreathingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeBreathingData.java
@@ -31,10 +31,12 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableBreathingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.BreathingData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeBreathingData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.util.GetterFunction;
 
 public class ImmutableSpongeBreathingData extends AbstractImmutableData<ImmutableBreathingData, BreathingData> implements ImmutableBreathingData {
 
@@ -82,4 +84,44 @@ public class ImmutableSpongeBreathingData extends AbstractImmutableData<Immutabl
         return ImmutableDataCachingUtil.getValue(ImmutableSpongeBoundedValue.class, Keys.MAX_AIR, this.maxAir, this.maxAir);
     }
 
+    public int getMaxAir() {
+        return this.maxAir;
+    }
+
+    public int getRemainingAir() {
+        return this.remainingAir;
+    }
+
+    @Override
+    protected void registerStuff() {
+        registerFieldGetter(Keys.MAX_AIR, new GetterFunction<Object>() {
+
+            @Override
+            public Object get() {
+                return getMaxAir();
+            }
+        });
+        registerKeyValue(Keys.MAX_AIR, new GetterFunction<ImmutableValue<?>>() {
+
+            @Override
+            public ImmutableValue<?> get() {
+                return maxAir();
+            }
+        });
+
+        registerFieldGetter(Keys.REMAINING_AIR, new GetterFunction<Object>() {
+
+            @Override
+            public Object get() {
+                return getRemainingAir();
+            }
+        });
+        registerKeyValue(Keys.REMAINING_AIR, new GetterFunction<ImmutableValue<?>>() {
+
+            @Override
+            public ImmutableValue<?> get() {
+                return remainingAir();
+            }
+        });
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeCareerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeCareerData.java
@@ -37,6 +37,7 @@ public class ImmutableSpongeCareerData extends AbstractImmutableSingleCatalogDat
     public ImmutableSpongeCareerData(Career value) {
         super(ImmutableCareerData.class, value, Keys.CAREER, SpongeCareerData.class);
     }
+
     @Override
     public ImmutableValue<Career> career() {
         return type();

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeEyeLocationData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeEyeLocationData.java
@@ -93,4 +93,8 @@ public class ImmutableSpongeEyeLocationData extends AbstractImmutableData<Immuta
         return entityLocation;
     }
 
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFoodData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFoodData.java
@@ -31,10 +31,12 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableFoodData;
 import org.spongepowered.api.data.manipulator.mutable.entity.FoodData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeFoodData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.util.GetterFunction;
 
 public class ImmutableSpongeFoodData extends AbstractImmutableData<ImmutableFoodData, FoodData> implements ImmutableFoodData {
 
@@ -90,6 +92,61 @@ public class ImmutableSpongeFoodData extends AbstractImmutableData<ImmutableFood
     @Override
     public ImmutableBoundedValue<Double> saturation() {
         return ImmutableDataCachingUtil.getValue(ImmutableSpongeBoundedValue.class, Keys.SATURATION, (double) this.foodSaturationLevel,
-                (double) this.foodSaturationLevel);
+                                                 (double) this.foodSaturationLevel);
+    }
+
+    public int getFood() {
+        return this.foodLevel;
+    }
+
+    public double getExhaustion() {
+        return this.foodExhaustionLevel;
+    }
+
+    public double getSaturation() {
+        return this.foodSaturationLevel;
+    }
+
+    @Override
+    protected void registerStuff() {
+        registerFieldGetter(Keys.FOOD_LEVEL, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getFood();
+            }
+        });
+        registerKeyValue(Keys.FOOD_LEVEL, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return foodLevel();
+            }
+        });
+
+        registerFieldGetter(Keys.EXHAUSTION, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getExhaustion();
+            }
+        });
+        registerKeyValue(Keys.EXHAUSTION, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return exhaustion();
+            }
+        });
+
+        registerFieldGetter(Keys.SATURATION, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getSaturation();
+            }
+        });
+        registerKeyValue(Keys.SATURATION, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return saturation();
+            }
+        });
+
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeHealthData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeHealthData.java
@@ -33,10 +33,12 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableHealthData;
 import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHealthData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.util.GetterFunction;
 
 public class ImmutableSpongeHealthData extends AbstractImmutableData<ImmutableHealthData, HealthData> implements ImmutableHealthData {
 
@@ -84,4 +86,40 @@ public class ImmutableSpongeHealthData extends AbstractImmutableData<ImmutableHe
             .set(Keys.MAX_HEALTH.getQuery(), this.maxHealth);
     }
 
+    @Override
+    protected void registerStuff() {
+        registerFieldGetter(Keys.HEALTH, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getHealth();
+            }
+        });
+        registerKeyValue(Keys.HEALTH, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return health();
+            }
+        });
+
+        registerFieldGetter(Keys.MAX_HEALTH, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getMaxHealth();
+            }
+        });
+        registerKeyValue(Keys.MAX_HEALTH, new GetterFunction<ImmutableValue<?>>() {
+            @Override
+            public ImmutableValue<?> get() {
+                return maxHealth();
+            }
+        });
+    }
+
+    public double getHealth() {
+        return this.health;
+    }
+
+    public double getMaxHealth() {
+        return this.maxHealth;
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeTradeOfferData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeTradeOfferData.java
@@ -74,4 +74,9 @@ public class ImmutableSpongeTradeOfferData extends AbstractImmutableData<Immutab
     public int compareTo(ImmutableTradeOfferData o) {
         return 0;
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/tileentity/ImmutableSpongeSignData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/tileentity/ImmutableSpongeSignData.java
@@ -79,4 +79,9 @@ public class ImmutableSpongeSignData extends AbstractImmutableData<ImmutableSign
     public int compareTo(ImmutableSignData o) {
         return 0;
     }
+
+    @Override
+    protected void registerStuff() {
+
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeCommandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeCommandData.java
@@ -56,7 +56,6 @@ public class SpongeCommandData extends AbstractData<CommandData, ImmutableComman
 
     public SpongeCommandData() {
         super(CommandData.class);
-        registerStuff();
     }
 
     @Override
@@ -156,7 +155,8 @@ public class SpongeCommandData extends AbstractData<CommandData, ImmutableComman
     }
 
     // Beware, all ye to enter here
-    private void registerStuff() {
+    @Override
+    protected void registerStuff() {
         // Keys.COMMAND
         registerFieldGetter(Keys.COMMAND, new GetterFunction<Object>() {
             @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeDisplayNameData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeDisplayNameData.java
@@ -58,7 +58,6 @@ public class SpongeDisplayNameData extends AbstractData<DisplayNameData, Immutab
         super(DisplayNameData.class);
         this.displayName = checkNotNull(displayName);
         this.displays = renders;
-        registerStuff();
     }
 
     @Override
@@ -114,7 +113,8 @@ public class SpongeDisplayNameData extends AbstractData<DisplayNameData, Immutab
         return this;
     }
 
-    private void registerStuff() {
+    @Override
+    protected void registerStuff() {
         registerFieldGetter(Keys.DISPLAY_NAME, new GetterFunction<Object>() {
             @Override
             public Object get() {

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeFireworkData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeFireworkData.java
@@ -96,4 +96,9 @@ public class SpongeFireworkData extends AbstractData<FireworkData, ImmutableFire
                 .set(Keys.FIREWORK_EFFECTS.getQuery(), this.fireworkEffects)
                 .set(Keys.FIREWORK_FLIGHT_MODIFIER.getQuery(), this.flightModifier);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeMobSpawnerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeMobSpawnerData.java
@@ -159,4 +159,9 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
             .set(Keys.SPAWNER_ENTITIES.getQuery(), this.entities);
 
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeOwnableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeOwnableData.java
@@ -75,4 +75,9 @@ public class SpongeOwnableData extends AbstractData<OwnableData, ImmutableOwnabl
         return new MemoryDataContainer()
             .set(Keys.OWNED_BY_PROFILE.getQuery(), this.profile);
     }
+
+    @Override
+    protected void registerStuff() {
+
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongePotionEffectData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongePotionEffectData.java
@@ -72,4 +72,9 @@ public class SpongePotionEffectData extends AbstractData<PotionEffectData, Immut
         return new MemoryDataContainer()
             .set(Keys.POTION_EFFECTS.getQuery(), this.effects);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeRepresentedItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeRepresentedItemData.java
@@ -72,4 +72,9 @@ public class SpongeRepresentedItemData extends AbstractData<RepresentedItemData,
         return new MemoryDataContainer()
             .set(Keys.REPRESENTED_ITEM.getQuery(), this.itemStack);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeTradeOfferData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeTradeOfferData.java
@@ -98,4 +98,9 @@ public class SpongeTradeOfferData extends AbstractData<TradeOfferData, Immutable
     public ListValue<TradeOffer> tradeOffers() {
         return new SpongeListValue<TradeOffer>(Keys.TRADE_OFFERS, this.offers);
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeAxisData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeAxisData.java
@@ -46,17 +46,12 @@ public class SpongeAxisData extends AbstractSingleEnumData<Axis, AxisData, Immut
     }
 
     @Override
-    public Value<Axis> axis() {
-        return new SpongeValue<Axis>(Keys.AXIS, getValue());
-    }
-
-    @Override
     protected Value<?> getValueGetter() {
-        return axis();
+        return type();
     }
 
     @Override
     public Value<Axis> type() {
-        return axis();
+        return new SpongeValue<Axis>(Keys.AXIS, getValue());
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeConnectedDirectionData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeConnectedDirectionData.java
@@ -93,4 +93,9 @@ public class SpongeConnectedDirectionData extends AbstractData<ConnectedDirectio
     public DataContainer toContainer() {
         return new MemoryDataContainer(); // todo
     }
+
+    @Override
+    protected void registerStuff() {
+        // TODO
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeWireAttachementData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeWireAttachementData.java
@@ -108,8 +108,8 @@ public class SpongeWireAttachementData extends AbstractData<WireAttachmentData, 
             .set(Keys.WIRE_ATTACHMENT_WEST.getQuery(), this.wireAttachmentMap.get(Direction.WEST).getId());
     }
 
-
-    private void registerStuff() {
+    @Override
+    protected void registerStuff() {
         // north
         // TODO register things
     }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractData.java
@@ -103,6 +103,7 @@ public abstract class AbstractData<M extends DataManipulator<M, I>, I extends Im
 
     protected AbstractData(Class<M> manipulatorClass) {
         this.manipulatorClass = checkNotNull(manipulatorClass);
+        registerStuff();
     }
 
     /**
@@ -152,6 +153,8 @@ public abstract class AbstractData<M extends DataManipulator<M, I>, I extends Im
     protected final void registerFieldSetter(Key<?> key, SetterFunction<Object> function) {
         this.keyFieldSetterMap.put(checkNotNull(key), checkNotNull(function));
     }
+
+    protected abstract void registerStuff();
 
     // ---------------
     // Note! These fill methods return NEW instances!

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractSingleData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractSingleData.java
@@ -28,7 +28,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
-
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
@@ -59,6 +58,10 @@ public abstract class AbstractSingleData<T, M extends DataManipulator<M, I>, I e
         super(manipulatorClass);
         this.value = checkNotNull(value);
         this.usedKey = checkNotNull(usedKey);
+    }
+
+    @Override
+    protected void registerStuff() {
         registerFieldGetter(usedKey, new GetterFunction<Object>() {
             @Override
             public Object get() {

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeBreathingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeBreathingData.java
@@ -107,7 +107,8 @@ public class SpongeBreathingData extends AbstractData<BreathingData, ImmutableBr
         this.remainingAir = remainingAir;
     }
 
-    private void registerStuff() {
+    @Override
+    protected void registerStuff() {
         registerFieldGetter(Keys.MAX_AIR, new GetterFunction<Object>() {
 
             @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeEyeLocationData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeEyeLocationData.java
@@ -112,7 +112,8 @@ public class SpongeEyeLocationData extends AbstractData<EyeLocationData, Immutab
         return this;
     }
 
-    private void registerStuff() {
+    @Override
+    protected void registerStuff() {
         registerFieldGetter(Keys.EYE_HEIGHT, new GetterFunction<Object>() {
             @Override
             public Object get() {

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFoodData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFoodData.java
@@ -126,7 +126,7 @@ public class SpongeFoodData extends AbstractData<FoodData, ImmutableFoodData> im
         this.foodExhaustionLevel = (float) foodExhaustionLevel;
     }
 
-    private void registerStuff() {
+    protected void registerStuff() {
         registerFieldGetter(Keys.FOOD_LEVEL, new GetterFunction<Object>() {
 
             @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeHealthData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeHealthData.java
@@ -111,7 +111,7 @@ public class SpongeHealthData extends AbstractData<HealthData, ImmutableHealthDa
         return this;
     }
 
-    private void registerStuff() {
+    protected void registerStuff() {
         registerFieldGetter(Keys.HEALTH, new GetterFunction<Object>() {
             @Override
             public Object get() {

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/package-info.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/package-info.java
@@ -22,24 +22,4 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.data.manipulator.mutable.entity;
-
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableCareerData;
-import org.spongepowered.api.data.manipulator.mutable.entity.CareerData;
-import org.spongepowered.api.data.type.Career;
-import org.spongepowered.api.data.type.Careers;
-import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeCareerData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleCatalogData;
-
-public class SpongeCareerData extends AbstractSingleCatalogData<Career, CareerData, ImmutableCareerData> implements CareerData {
-
-    public SpongeCareerData(Career value) {
-        super(CareerData.class, value, Keys.CAREER, ImmutableSpongeCareerData.class);
-    }
-
-    public SpongeCareerData() {
-        this(Careers.ARMORER);
-    }
-
-}
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.data.manipulator.mutable.entity;

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeSignData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeSignData.java
@@ -26,7 +26,6 @@ package org.spongepowered.common.data.manipulator.mutable.tileentity;
 
 import com.google.common.collect.Lists;
 import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableSignData;
@@ -55,25 +54,6 @@ public class SpongeSignData extends AbstractData<SignData, ImmutableSignData> im
     public SpongeSignData(List<Text> lines) {
         super(SignData.class);
         this.lines = lines;
-        registerFieldGetter(Keys.SIGN_LINES, new GetterFunction<Object>() {
-            @Override
-            public Object get() {
-                return getLines();
-            }
-        });
-        registerFieldSetter(Keys.SIGN_LINES, new SetterFunction<Object>() {
-            @SuppressWarnings("unchecked")
-            @Override
-            public void set(Object value) {
-                setLines((List<Text>) value);
-            }
-        });
-        registerKeyValue(Keys.SIGN_LINES, new GetterFunction<Value<?>>() {
-            @Override
-            public Value<?> get() {
-                return lines();
-            }
-        });
     }
 
     @Override
@@ -113,5 +93,28 @@ public class SpongeSignData extends AbstractData<SignData, ImmutableSignData> im
         for (int i = 0; i < 4; i++) {
             this.lines.set(i, lines.get(i));
         }
+    }
+
+    @Override
+    protected void registerStuff() {
+        registerFieldGetter(Keys.SIGN_LINES, new GetterFunction<Object>() {
+            @Override
+            public Object get() {
+                return getLines();
+            }
+        });
+        registerFieldSetter(Keys.SIGN_LINES, new SetterFunction<Object>() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public void set(Object value) {
+                setLines((List<Text>) value);
+            }
+        });
+        registerKeyValue(Keys.SIGN_LINES, new GetterFunction<Value<?>>() {
+            @Override
+            public Value<?> get() {
+                return lines();
+            }
+        });
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeDataProcessor.java
@@ -1,7 +1,7 @@
 /*
- * This file is part of Sponge, licensed under the MIT License (MIT).
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
  *
- * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
  * Copyright (c) contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,24 +22,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.data.manipulator.mutable.entity;
 
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableCareerData;
-import org.spongepowered.api.data.manipulator.mutable.entity.CareerData;
-import org.spongepowered.api.data.type.Career;
-import org.spongepowered.api.data.type.Careers;
-import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeCareerData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleCatalogData;
+package org.spongepowered.common.data.processor.common;
 
-public class SpongeCareerData extends AbstractSingleCatalogData<Career, CareerData, ImmutableCareerData> implements CareerData {
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.common.data.DataProcessor;
 
-    public SpongeCareerData(Career value) {
-        super(CareerData.class, value, Keys.CAREER, ImmutableSpongeCareerData.class);
+public abstract class AbstractSpongeDataProcessor<M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>> implements DataProcessor<M, I> {
+
+    @Override
+    public int getPriority() {
+        return 100;
     }
-
-    public SpongeCareerData() {
-        this(Careers.ARMORER);
-    }
-
 }

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeValueProcessor.java
@@ -22,24 +22,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.data.manipulator.mutable.entity;
+package org.spongepowered.common.data.processor.common;
 
-import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableCareerData;
-import org.spongepowered.api.data.manipulator.mutable.entity.CareerData;
-import org.spongepowered.api.data.type.Career;
-import org.spongepowered.api.data.type.Careers;
-import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeCareerData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleCatalogData;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-public class SpongeCareerData extends AbstractSingleCatalogData<Career, CareerData, ImmutableCareerData> implements CareerData {
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.common.data.ValueProcessor;
 
-    public SpongeCareerData(Career value) {
-        super(CareerData.class, value, Keys.CAREER, ImmutableSpongeCareerData.class);
+public abstract class AbstractSpongeValueProcessor<E, V extends BaseValue<E>> implements ValueProcessor<E, V> {
+
+    private final Key<V> key;
+
+    protected AbstractSpongeValueProcessor(Key<V> key) {
+        this.key = checkNotNull(key, "The key is null!");
     }
 
-    public SpongeCareerData() {
-        this(Careers.ARMORER);
+    @Override
+    public final Key<? extends BaseValue<E>> getKey() {
+        return this.key;
     }
 
+    @Override
+    public int getPriority() {
+        return 100;
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/DisplayNameDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/DisplayNameDataProcessor.java
@@ -47,13 +47,13 @@ import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.Sponge;
-import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeDisplayNameData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeDisplayNameData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.util.DataUtil;
 
 @SuppressWarnings("deprecation")
-public class DisplayNameDataProcessor implements DataProcessor<DisplayNameData, ImmutableDisplayNameData> {
+public class DisplayNameDataProcessor extends AbstractSpongeDataProcessor<DisplayNameData, ImmutableDisplayNameData> {
 
     @Override
     public boolean supports(DataHolder dataHolder) {

--- a/src/main/java/org/spongepowered/common/data/processor/data/SkullDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/SkullDataProcessor.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.data.processor.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spongepowered.common.data.util.DataUtil.getData;
 
 import com.google.common.base.Optional;
 import net.minecraft.item.ItemStack;
@@ -44,15 +43,15 @@ import org.spongepowered.api.data.type.SkullType;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.common.Sponge;
-import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeSkullData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeSkullData;
 import org.spongepowered.common.data.processor.common.SkullUtils;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.type.SpongeSkullType;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
-public class SkullDataProcessor implements DataProcessor<SkullData, ImmutableSkullData> {
+public class SkullDataProcessor extends AbstractSpongeDataProcessor<SkullData, ImmutableSkullData> {
 
     @Override
     public boolean supports(DataHolder dataHolder) {

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/BreathingDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/BreathingDataProcessor.java
@@ -45,10 +45,11 @@ import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeBreathingData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeBreathingData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.interfaces.entity.IMixinEntityLivingBase;
 
-public class BreathingDataProcessor implements DataProcessor<BreathingData, ImmutableBreathingData> {
+public class BreathingDataProcessor extends AbstractSpongeDataProcessor<BreathingData, ImmutableBreathingData> {
 
     @Override
     public Optional<BreathingData> build(DataView container) throws InvalidDataException {

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/CareerDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/CareerDataProcessor.java
@@ -46,11 +46,12 @@ import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeCareerData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeCareerData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.interfaces.entity.IMixinVillager;
 
-public class CareerDataProcessor implements DataProcessor<CareerData, ImmutableCareerData> {
+public class CareerDataProcessor extends AbstractSpongeDataProcessor<CareerData, ImmutableCareerData> {
 
     @Override
     public boolean supports(DataHolder dataHolder) {
@@ -77,7 +78,7 @@ public class CareerDataProcessor implements DataProcessor<CareerData, ImmutableC
     public Optional<CareerData> fill(DataHolder dataHolder, CareerData manipulator, MergeFunction overlap) {
         if (dataHolder instanceof IMixinVillager) {
             final CareerData original = from(dataHolder).get();
-            return Optional.of(manipulator.set(Keys.CAREER, overlap.merge(manipulator, original).career().get()));
+            return Optional.of(manipulator.set(Keys.CAREER, overlap.merge(manipulator, original).type().get()));
         }
         return Optional.absent();
     }
@@ -96,9 +97,9 @@ public class CareerDataProcessor implements DataProcessor<CareerData, ImmutableC
     public DataTransactionResult set(DataHolder dataHolder, CareerData manipulator) {
         if (dataHolder instanceof IMixinVillager) {
             final Career oldCareer = ((IMixinVillager) dataHolder).getCareer();
-            final ImmutableValue<Career> newCareer = manipulator.career().asImmutable();
+            final ImmutableValue<Career> newCareer = manipulator.type().asImmutable();
             try {
-                ((IMixinVillager) dataHolder).setCareer(manipulator.career().get());
+                ((IMixinVillager) dataHolder).setCareer(manipulator.type().get());
                 return DataTransactionBuilder.builder()
                     .replace(ImmutableDataCachingUtil.getWildValue(ImmutableSpongeValue.class, Keys.CAREER, oldCareer, oldCareer))
                     .success(newCareer)
@@ -116,7 +117,7 @@ public class CareerDataProcessor implements DataProcessor<CareerData, ImmutableC
         if (dataHolder instanceof IMixinVillager) {
             final Career oldCareer = ((IMixinVillager) dataHolder).getCareer();
             final CareerData oldData = from(dataHolder).get();
-            final ImmutableValue<Career> newCareer = function.merge(oldData, manipulator).career().asImmutable();
+            final ImmutableValue<Career> newCareer = function.merge(oldData, manipulator).type().asImmutable();
             try {
                 ((IMixinVillager) dataHolder).setCareer(newCareer.get());
                 return DataTransactionBuilder.builder()

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/EyeLocationDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/EyeLocationDataProcessor.java
@@ -43,12 +43,13 @@ import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeEyeLocationData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeEyeLocationData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.interfaces.IMixinEntity;
 import org.spongepowered.common.util.VecHelper;
 
 @SuppressWarnings("ConstantConditions")
-public class EyeLocationDataProcessor implements DataProcessor<EyeLocationData, ImmutableEyeLocationData> {
+public class EyeLocationDataProcessor extends AbstractSpongeDataProcessor<EyeLocationData, ImmutableEyeLocationData> {
 
     @Override
     public boolean supports(DataHolder dataHolder) {

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/FoodDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/FoodDataProcessor.java
@@ -45,9 +45,10 @@ import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeFoodData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeFoodData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.util.DataUtil;
 
-public class FoodDataProcessor implements DataProcessor<FoodData, ImmutableFoodData> {
+public class FoodDataProcessor extends AbstractSpongeDataProcessor<FoodData, ImmutableFoodData> {
 
     @Override
     public Optional<FoodData> build(DataView container) throws InvalidDataException {

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthDataProcessor.java
@@ -29,11 +29,9 @@ import static org.spongepowered.common.data.util.ComparatorUtil.doubleComparator
 import static org.spongepowered.common.data.util.DataUtil.getData;
 
 import com.google.common.base.Optional;
-
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.item.ItemStack;
-
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionBuilder;
@@ -49,9 +47,10 @@ import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeHealthData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHealthData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
-public class HealthDataProcessor implements DataProcessor<HealthData, ImmutableHealthData> {
+public class HealthDataProcessor extends AbstractSpongeDataProcessor<HealthData, ImmutableHealthData> {
 
     @Override
     public boolean supports(DataHolder dataHolder) {

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/VelocityDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/VelocityDataProcessor.java
@@ -48,8 +48,9 @@ import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeVelocityData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVelocityData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 
-public class VelocityDataProcessor implements DataProcessor<VelocityData, ImmutableVelocityData> {
+public class VelocityDataProcessor extends AbstractSpongeDataProcessor<VelocityData, ImmutableVelocityData> {
 
     @Override
     public boolean supports(DataHolder dataHolder) {

--- a/src/main/java/org/spongepowered/common/data/processor/data/tileentity/SignDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/tileentity/SignDataProcessor.java
@@ -47,9 +47,9 @@ import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
-import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeSignData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeSignData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.text.SpongeTexts;
@@ -57,7 +57,7 @@ import org.spongepowered.common.text.SpongeTexts;
 import java.util.List;
 
 @SuppressWarnings("deprecation")
-public class SignDataProcessor implements DataProcessor<SignData, ImmutableSignData> {
+public class SignDataProcessor extends AbstractSpongeDataProcessor<SignData, ImmutableSignData> {
 
     @Override
     public boolean supports(DataHolder dataHolder) {

--- a/src/main/java/org/spongepowered/common/data/processor/value/DisplayNameValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/DisplayNameValueProcessor.java
@@ -36,7 +36,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.IWorldNameable;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
@@ -44,17 +43,16 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.Sponge;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.interfaces.data.IMixinCustomNameable;
 
 @SuppressWarnings("deprecation")
-public class DisplayNameValueProcessor implements ValueProcessor<Text, Value<Text>> {
+public class DisplayNameValueProcessor extends AbstractSpongeValueProcessor<Text, Value<Text>> {
 
-    @Override
-    public Key<? extends BaseValue<Text>> getKey() {
-        return Keys.DISPLAY_NAME;
+    public DisplayNameValueProcessor() {
+        super(Keys.DISPLAY_NAME);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/DisplayNameVisibleValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/DisplayNameVisibleValueProcessor.java
@@ -33,21 +33,19 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.IWorldNameable;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
-public class DisplayNameVisibleValueProcessor implements ValueProcessor<Boolean, Value<Boolean>> {
+public class DisplayNameVisibleValueProcessor extends AbstractSpongeValueProcessor<Boolean, Value<Boolean>> {
 
-    @Override
-    public Key<? extends BaseValue<Boolean>> getKey() {
-        return Keys.SHOWS_DISPLAY_NAME;
+    public DisplayNameVisibleValueProcessor() {
+        super(Keys.SHOWS_DISPLAY_NAME);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/SkullValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/SkullValueProcessor.java
@@ -32,7 +32,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntitySkull;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.type.SkullType;
 import org.spongepowered.api.data.type.SkullTypes;
@@ -40,16 +39,15 @@ import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.processor.common.SkullUtils;
 import org.spongepowered.common.data.type.SpongeSkullType;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
-public class SkullValueProcessor implements ValueProcessor<SkullType, Value<SkullType>> {
+public class SkullValueProcessor extends AbstractSpongeValueProcessor<SkullType, Value<SkullType>> {
 
-    @Override
-    public Key<? extends BaseValue<SkullType>> getKey() {
-        return Keys.SKULL_TYPE;
+    public SkullValueProcessor() {
+        super(Keys.SKULL_TYPE);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/CareerValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/CareerValueProcessor.java
@@ -30,7 +30,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.type.Career;
 import org.spongepowered.api.data.type.Careers;
@@ -39,16 +38,15 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.interfaces.entity.IMixinVillager;
 
-public class CareerValueProcessor implements ValueProcessor<Career, Value<Career>> {
+public class CareerValueProcessor extends AbstractSpongeValueProcessor<Career, Value<Career>> {
 
-    @Override
-    public Key<? extends BaseValue<Career>> getKey() {
-        return Keys.CAREER;
+    public CareerValueProcessor() {
+        super(Keys.CAREER);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/EyeHeightValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/EyeHeightValueProcessor.java
@@ -29,22 +29,20 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.Entity;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.interfaces.IMixinEntity;
 
 @SuppressWarnings("ConstantConditions")
-public class EyeHeightValueProcessor implements ValueProcessor<Double, Value<Double>> {
+public class EyeHeightValueProcessor extends AbstractSpongeValueProcessor<Double, Value<Double>> {
 
-    @Override
-    public Key<? extends BaseValue<Double>> getKey() {
-        return Keys.EYE_HEIGHT;
+    public EyeHeightValueProcessor() {
+        super(Keys.EYE_HEIGHT);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/EyeLocationValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/EyeLocationValueProcessor.java
@@ -30,22 +30,20 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.Entity;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.interfaces.IMixinEntity;
 
 @SuppressWarnings("ConstantConditions")
-public class EyeLocationValueProcessor implements ValueProcessor<Vector3d, Value<Vector3d>> {
+public class EyeLocationValueProcessor extends AbstractSpongeValueProcessor<Vector3d, Value<Vector3d>> {
 
-    @Override
-    public Key<? extends BaseValue<Vector3d>> getKey() {
-        return Keys.EYE_LOCATION;
+    public EyeLocationValueProcessor() {
+        super(Keys.EYE_LOCATION);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodExhaustionValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodExhaustionValueProcessor.java
@@ -31,20 +31,18 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.player.EntityPlayer;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 
-public class FoodExhaustionValueProcessor implements ValueProcessor<Double, MutableBoundedValue<Double>> {
+public class FoodExhaustionValueProcessor extends AbstractSpongeValueProcessor<Double, MutableBoundedValue<Double>> {
 
-    @Override
-    public Key<? extends BaseValue<Double>> getKey() {
-        return Keys.EXHAUSTION;
+    public FoodExhaustionValueProcessor() {
+        super(Keys.EXHAUSTION);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodLevelValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodLevelValueProcessor.java
@@ -31,20 +31,18 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.player.EntityPlayer;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 
-public class FoodLevelValueProcessor implements ValueProcessor<Integer, MutableBoundedValue<Integer>> {
+public class FoodLevelValueProcessor extends AbstractSpongeValueProcessor<Integer, MutableBoundedValue<Integer>> {
 
-    @Override
-    public Key<? extends BaseValue<Integer>> getKey() {
-        return Keys.FOOD_LEVEL;
+    public FoodLevelValueProcessor() {
+        super(Keys.FOOD_LEVEL);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodSaturationValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodSaturationValueProcessor.java
@@ -31,20 +31,18 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.player.EntityPlayer;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 
-public class FoodSaturationValueProcessor implements ValueProcessor<Double, MutableBoundedValue<Double>> {
+public class FoodSaturationValueProcessor extends AbstractSpongeValueProcessor<Double, MutableBoundedValue<Double>> {
 
-    @Override
-    public Key<? extends BaseValue<Double>> getKey() {
-        return Keys.SATURATION;
+    public FoodSaturationValueProcessor() {
+        super(Keys.SATURATION);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/HealthValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/HealthValueProcessor.java
@@ -32,22 +32,20 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.EntityLivingBase;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
-public class HealthValueProcessor implements ValueProcessor<Double, MutableBoundedValue<Double>> {
+public class HealthValueProcessor extends AbstractSpongeValueProcessor<Double, MutableBoundedValue<Double>> {
 
-    @Override
-    public Key<? extends BaseValue<Double>> getKey() {
-        return Keys.HEALTH;
+    public HealthValueProcessor() {
+        super(Keys.HEALTH);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/MaxAirValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/MaxAirValueProcessor.java
@@ -31,21 +31,19 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.EntityLivingBase;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 import org.spongepowered.common.interfaces.entity.IMixinEntityLivingBase;
 
-public class MaxAirValueProcessor implements ValueProcessor<Integer, MutableBoundedValue<Integer>> {
+public class MaxAirValueProcessor extends AbstractSpongeValueProcessor<Integer, MutableBoundedValue<Integer>> {
 
-    @Override
-    public Key<? extends BaseValue<Integer>> getKey() {
-        return Keys.MAX_AIR;
+    public MaxAirValueProcessor() {
+        super(Keys.MAX_AIR);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/MaxHealthValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/MaxHealthValueProcessor.java
@@ -33,22 +33,20 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
-public class MaxHealthValueProcessor implements ValueProcessor<Double, MutableBoundedValue<Double>> {
+public class MaxHealthValueProcessor extends AbstractSpongeValueProcessor<Double, MutableBoundedValue<Double>> {
 
-    @Override
-    public Key<? extends BaseValue<Double>> getKey() {
-        return Keys.MAX_HEALTH;
+    public MaxHealthValueProcessor() {
+        super(Keys.MAX_HEALTH);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/RemainingAirValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/RemainingAirValueProcessor.java
@@ -31,20 +31,18 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.EntityLivingBase;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 
-public class RemainingAirValueProcessor implements ValueProcessor<Integer, MutableBoundedValue<Integer>> {
+public class RemainingAirValueProcessor extends AbstractSpongeValueProcessor<Integer, MutableBoundedValue<Integer>> {
 
-    @Override
-    public Key<? extends BaseValue<Integer>> getKey() {
-        return Keys.REMAINING_AIR;
+    public RemainingAirValueProcessor() {
+        super(Keys.REMAINING_AIR);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/VelocityValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/VelocityValueProcessor.java
@@ -32,21 +32,19 @@ import com.google.common.base.Optional;
 import net.minecraft.entity.Entity;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.common.data.ValueProcessor;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
-public class VelocityValueProcessor implements ValueProcessor<Vector3d, Value<Vector3d>> {
+public class VelocityValueProcessor extends AbstractSpongeValueProcessor<Vector3d, Value<Vector3d>> {
 
-    @Override
-    public Key<? extends BaseValue<Vector3d>> getKey() {
-        return Keys.VELOCITY;
+    public VelocityValueProcessor() {
+        super(Keys.VELOCITY);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/SignLinesValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/SignLinesValueProcessor.java
@@ -36,7 +36,6 @@ import net.minecraft.util.IChatComponent;
 import org.spongepowered.api.block.tileentity.Sign;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.SignData;
 import org.spongepowered.api.data.value.BaseValue;
@@ -45,8 +44,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
-import org.spongepowered.common.data.ValueProcessor;
-import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeSignData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 import org.spongepowered.common.data.value.mutable.SpongeListValue;
@@ -55,11 +53,10 @@ import org.spongepowered.common.text.SpongeTexts;
 import java.util.List;
 
 @SuppressWarnings("deprecation")
-public class SignLinesValueProcessor implements ValueProcessor<List<Text>, ListValue<Text>> {
+public class SignLinesValueProcessor extends AbstractSpongeValueProcessor<List<Text>, ListValue<Text>> {
 
-    @Override
-    public Key<? extends BaseValue<List<Text>>> getKey() {
-        return Keys.SIGN_LINES;
+    public SignLinesValueProcessor() {
+        super(Keys.SIGN_LINES);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/util/BlockDataProcessorDelegate.java
+++ b/src/main/java/org/spongepowered/common/data/util/BlockDataProcessorDelegate.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.common.data.util;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.common.data.BlockDataProcessor;
+
+public final class BlockDataProcessorDelegate<I extends ImmutableDataManipulator<I, ?>> implements BlockDataProcessor<I> {
+
+    private final ImmutableList<BlockDataProcessor<I>> processors;
+
+    public BlockDataProcessorDelegate(ImmutableList<BlockDataProcessor<I>> processors) {
+        this.processors = processors;
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public Optional<I> fromBlockPos(World world, BlockPos blockPos) {
+        for (BlockDataProcessor<I> processor : this.processors) {
+            final Optional<I> optional = processor.fromBlockPos(world, blockPos);
+            if (optional.isPresent()) {
+                return optional;
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<I> createFrom(IBlockState blockState) {
+        for (BlockDataProcessor<I> processor : this.processors) {
+            final Optional<I> optional = processor.createFrom(blockState);
+            if (optional.isPresent()) {
+                return optional;
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<BlockState> withData(IBlockState blockState, I manipulator) {
+        for (BlockDataProcessor<I> processor : this.processors) {
+            final Optional<BlockState> optional = processor.withData(blockState, manipulator);
+            if (optional.isPresent()) {
+                return optional;
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public DataTransactionResult setData(World world, BlockPos blockPos, I manipulator) {
+        for (BlockDataProcessor<I> processor : this.processors) {
+            final DataTransactionResult result = processor.setData(world, blockPos, manipulator);
+            if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                return result;
+            }
+        }
+        return DataTransactionBuilder.failResult(manipulator.getValues());
+    }
+
+    @Override
+    public Optional<BlockState> removeFrom(IBlockState blockState) {
+        for (BlockDataProcessor<I> processor : this.processors) {
+            final Optional<BlockState> optional = processor.removeFrom(blockState);
+            if (optional.isPresent()) {
+                return optional;
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public boolean remove(World world, BlockPos blockPos) {
+        for (BlockDataProcessor<I> processor : this.processors) {
+            final boolean optional = processor.remove(world, blockPos);
+            if (optional) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/util/ComparatorUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/ComparatorUtil.java
@@ -24,9 +24,30 @@
  */
 package org.spongepowered.common.data.util;
 
+import org.spongepowered.common.data.DataProcessor;
+import org.spongepowered.common.data.ValueProcessor;
+
 import java.util.Comparator;
 
 public class ComparatorUtil {
+
+    /**
+     * This will compare two {@link ValueProcessor}s where the higher priority
+     * will compare opposite to the lower prioirty.
+     */
+    public static final Comparator<ValueProcessor<?, ?>> VALUE_PROCESSOR_COMPARATOR = new Comparator<ValueProcessor<?, ?>>() {
+        @Override
+        public int compare(ValueProcessor<?, ?> o1, ValueProcessor<?, ?> o2) {
+            return intComparator().compare(o2.getPriority(), o1.getPriority()); // We want the higher number to be higher priority
+        }
+    };
+
+    public static final Comparator<DataProcessor<?, ?>> DATA_PROCESSOR_COMPARATOR = new Comparator<DataProcessor<?, ?>>() {
+        @Override
+        public int compare(DataProcessor<?, ?> o1, DataProcessor<?, ?> o2) {
+            return intComparator().compare(o2.getPriority(), o1.getPriority());
+        }
+    };
 
     public static Comparator<Integer> intComparator() {
         return new Comparator<Integer>() {

--- a/src/main/java/org/spongepowered/common/data/util/DataProcessorDelegate.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataProcessorDelegate.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of SpongeAPI, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered.org <http://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.spongepowered.common.data.util;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.common.data.DataProcessor;
+
+public final class DataProcessorDelegate<M extends DataManipulator<M, I>, I extends ImmutableDataManipulator<I, M>> implements DataProcessor<M, I> {
+
+    private final ImmutableList<DataProcessor<M, I>> processors;
+
+    public DataProcessorDelegate(ImmutableList<DataProcessor<M, I>> processors) {
+        this.processors = processors;
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public boolean supports(DataHolder dataHolder) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Optional<M> from(DataHolder dataHolder) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                final Optional<M> optional = processor.from(dataHolder);
+                if (optional.isPresent()) {
+                    return optional;
+                }
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<M> fill(DataHolder dataHolder, M manipulator) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                final Optional<M> optional = processor.fill(dataHolder, manipulator);
+                if (optional.isPresent()) {
+                    return optional;
+                }
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<M> fill(DataHolder dataHolder, M manipulator, MergeFunction overlap) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                final Optional<M> optional = processor.fill(dataHolder, manipulator, overlap);
+                if (optional.isPresent()) {
+                    return optional;
+                }
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<M> fill(DataContainer container, M m) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            final Optional<M> optional = processor.fill(container, m);
+            if (optional.isPresent()) {
+                return optional;
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public DataTransactionResult set(DataHolder dataHolder, M manipulator) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                final DataTransactionResult result = processor.set(dataHolder, manipulator);
+                if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                    return result;
+                }
+            }
+        }
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult set(DataHolder dataHolder, M manipulator, MergeFunction function) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                final DataTransactionResult result = processor.set(dataHolder, manipulator, function);
+                if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                    return result;
+                }
+            }
+        }
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    public Optional<I> with(Key<? extends BaseValue<?>> key, Object value, I immutable) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            final Optional<I> optional = processor.with(key, value, immutable);
+            if (optional.isPresent()) {
+                return optional;
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                final DataTransactionResult result = processor.remove(dataHolder);
+                if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                    return result;
+                }
+            }
+        }
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    public M create() {
+        return this.processors.get(0).create();
+    }
+
+    @Override
+    public I createImmutable() {
+        return this.processors.get(0).createImmutable();
+    }
+
+    @Override
+    public Optional<M> createFrom(DataHolder dataHolder) {
+        for (DataProcessor<M, I> processor : this.processors) {
+            if (processor.supports(dataHolder)) {
+                final Optional<M> optional = processor.createFrom(dataHolder);
+                if (optional.isPresent()) {
+                    return optional;
+                }
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<M> build(DataView container) throws InvalidDataException {
+        for (DataProcessor<M, I> processor : this.processors) {
+            final Optional<M> optional = processor.build(container);
+            if (optional.isPresent()) {
+                return optional;
+            }
+        }
+        return Optional.absent();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/util/DataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataUtil.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.data.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Optional;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.DataTransactionBuilder;
@@ -39,8 +40,6 @@ import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.service.persistence.InvalidDataException;
 import org.spongepowered.common.data.DataProcessor;
 import org.spongepowered.common.data.SpongeDataRegistry;
-
-import com.google.common.base.Optional;
 
 @SuppressWarnings("unchecked")
 public class DataUtil {

--- a/src/main/java/org/spongepowered/common/data/util/ValueProcessorDelegate.java
+++ b/src/main/java/org/spongepowered/common/data/util/ValueProcessorDelegate.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.util;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.common.data.ValueProcessor;
+
+/**
+ * This is really just a lazy class to handle processing on multiple
+ * {@link ValueProcessor} registrations.
+ *
+ * @param <E>
+ * @param <V>
+ */
+public final class ValueProcessorDelegate<E, V extends BaseValue<E>> implements ValueProcessor<E, V> {
+
+    private final Key<V> key;
+    private final ImmutableList<ValueProcessor<E, V>> processors;
+
+    public ValueProcessorDelegate(Key<V> key, ImmutableList<ValueProcessor<E, V>> processors) {
+        this.key = key;
+        this.processors = processors;
+    }
+
+    @Override
+    public Key<? extends BaseValue<E>> getKey() {
+        return this.key;
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public Optional<E> getValueFromContainer(ValueContainer<?> container) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                final Optional<E> optional = processor.getValueFromContainer(container);
+                if (optional.isPresent()) {
+                    return optional;
+                }
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<V> getApiValueFromContainer(ValueContainer<?> container) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                final Optional<V> optional = processor.getApiValueFromContainer(container);
+                if (optional.isPresent()) {
+                    return optional;
+                }
+            }
+        }
+        return Optional.absent();
+    }
+
+    @Override
+    public boolean supports(ValueContainer<?> container) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public DataTransactionResult transform(ValueContainer<?> container, Function<E, E> function) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                final DataTransactionResult result = processor.transform(container, function);
+                if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                    return result;
+                }
+            }
+        }
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult offerToStore(ValueContainer<?> container, BaseValue<?> value) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                final DataTransactionResult result = processor.offerToStore(container, value);
+                if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                    return result;
+                }
+            }
+        }
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult offerToStore(ValueContainer<?> container, E value) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                final DataTransactionResult result = processor.offerToStore(container, value);
+                if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                    return result;
+                }
+            }
+        }
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        for (ValueProcessor<E, V> processor : this.processors) {
+            if (processor.supports(container)) {
+                final DataTransactionResult result = processor.removeFrom(container);
+                if (!result.getType().equals(DataTransactionResult.Type.FAILURE)) {
+                    return result;
+                }
+            }
+        }
+        return DataTransactionBuilder.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/value/mutable/common/SpongeEntityValue.java
+++ b/src/main/java/org/spongepowered/common/data/value/mutable/common/SpongeEntityValue.java
@@ -29,7 +29,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
-
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.KeyFactory;
 import org.spongepowered.api.data.value.BaseValue;


### PR DESCRIPTION
Currently, all of the various Processors, both `DataProcessor` and `ValueProcessor` (and incidentally, `BlockDataProcessor` etc.) are all first come first serve. An issue that this raises is when a mod introduces drastic changes to the base game that the "vanilla" processors no longer apply to the same logic, in which case, we need to allow mods to be able to register their own `ValueProcessor`s etc. as a *higher* priority, just as if they were Mixins. 

What this aims to introduce is the following:
 - `ValueProcessor`s gain a new method: `getPriority()`
 - `ValueProcessorDelegate` is quite literally a delegate for multi-processor registration that handles short circuiting the higher priority `ValueProcessor`s to return valid values instead of processing over each processor that *may* not provide the correct data
 - SpongeDataRegistry now has a `finalizeRegistration()` to sort and build these `ValueProcessorDelegate`s as necessary
 - No changes to any of the `DataHolder` logic since the `ValueProcessorDelegate` IS a `ValueProcessor` in disguise

Of course, this is still a WIP and if successful, this will be used for `DataProcessor`s and `BlockDataProcessor`s and `PropertyStore`s.

@SpongePowered/developers, I wish to hear your thoughts on this.
