### PR TITLE
Stop :uploadArchive from uploading non-existent files

### DIFF
--- a/gradle/implementation.gradle
+++ b/gradle/implementation.gradle
@@ -151,10 +151,11 @@ task sdkZip(type: Zip) {
            ])
         }
     }
-    onlyIf { project.file("sdk").exists() }
 }
 
 artifacts {
     archives deobfJar
-    archives sdkZip
+    if (project.file("sdk").exists()) {
+        archives sdkZip
+    }
 }


### PR DESCRIPTION
For some reason :uploadArchive keeps trying to upload sdkZip in SpongeVanilla, even where it doesn't exist. This patch forces gradle to check that sdkZip actually executed before adding it to the archives artifacts.

There might be a better way of doing this?