### PR TITLE
Updates for Dispatcher and Disambiguator.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SpongeAPI"]
 	path = SpongeAPI
-	url = https://github.com/SpongePowered/SpongeAPI.git
+	url = https://github.com/JBYoshi/SpongeAPI.git

--- a/src/main/java/org/spongepowered/common/command/SpongeCommandDisambiguator.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandDisambiguator.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 public class SpongeCommandDisambiguator implements Disambiguator {
     private final Game game;
 
@@ -56,7 +58,7 @@ public class SpongeCommandDisambiguator implements Disambiguator {
 
     @Override
     @NonnullByDefault
-    public Optional<CommandMapping> disambiguate(CommandSource source, String aliasUsed, List<CommandMapping> availableOptions) {
+    public Optional<CommandMapping> disambiguate(@Nullable CommandSource source, String aliasUsed, List<CommandMapping> availableOptions) {
         if (availableOptions.size() > 1) {
             final String chosenPlugin = Sponge.getGlobalConfig().getConfig().getCommands().getAliases().get(aliasUsed.toLowerCase());
             if (chosenPlugin != null) {

--- a/src/main/java/org/spongepowered/common/command/SpongeHelpCommand.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeHelpCommand.java
@@ -64,7 +64,7 @@ public class SpongeHelpCommand {
             .executor((src, args) -> {
                 Optional<String> command = args.getOne("command");
                 if (command.isPresent()) {
-                    Optional<? extends CommandMapping> mapping = Sponge.getGame().getCommandDispatcher().get(command.get());
+                    Optional<? extends CommandMapping> mapping = Sponge.getGame().getCommandDispatcher().get(command.get(), src);
                     if (mapping.isPresent()) {
                         CommandCallable callable = mapping.get().getCallable();
                         Optional<? extends Text> desc = callable.getHelp(src);


### PR DESCRIPTION
Update `/help` to use `Dispatcher.get(String, CommandSource)`.
Updates for `@Nullable` `CommandSource` parameter in `Disambiguator`.

Requires SpongePowered/SpongeAPI#851
Fixes SpongePowered/Sponge#320