### PR TITLE
Implement SpongeScheduledExecutor

### DIFF
--- a/src/main/java/org/spongepowered/common/guice/SpongePluginGuiceModule.java
+++ b/src/main/java/org/spongepowered/common/guice/SpongePluginGuiceModule.java
@@ -178,7 +178,7 @@ public class SpongePluginGuiceModule extends AbstractModule {
 
         @Override
         public SpongeExecutorService get() {
-            return this.schedulerService.createSyncExecutor(this.container.getInstance());
+            return this.schedulerService.createSyncExecutor(this.container);
         }
 
     }
@@ -196,7 +196,7 @@ public class SpongePluginGuiceModule extends AbstractModule {
 
         @Override
         public SpongeExecutorService get() {
-            return this.schedulerService.createAsyncExecutor(this.container.getInstance());
+            return this.schedulerService.createAsyncExecutor(this.container);
         }
 
     }

--- a/src/main/java/org/spongepowered/common/service/scheduler/AsyncScheduler.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/AsyncScheduler.java
@@ -57,7 +57,7 @@ public class AsyncScheduler extends SchedulerBase {
 
     private void mainLoop() {
         this.executor = Executors.newCachedThreadPool();
-        this.lastProcessingTimestamp = System.currentTimeMillis();
+        this.lastProcessingTimestamp = System.nanoTime();
         while (true) {
             recalibrateMinimumTimeout();
             this.runTick();
@@ -69,7 +69,7 @@ public class AsyncScheduler extends SchedulerBase {
         try {
             Set<Task> tasks = this.getScheduledTasks();
             this.minimumTimeout = Long.MAX_VALUE;
-            long now = System.currentTimeMillis();
+            long now = System.nanoTime();
             for (Task tmpTask : tasks) {
                 ScheduledTask task = (ScheduledTask) tmpTask;
                 // Recalibrate the wait delay for processing tasks before new
@@ -93,7 +93,7 @@ public class AsyncScheduler extends SchedulerBase {
                 }
             }
             if (!tasks.isEmpty()) {
-                long latency = System.currentTimeMillis() - this.lastProcessingTimestamp;
+                long latency = System.nanoTime() - this.lastProcessingTimestamp;
                 this.minimumTimeout -= (latency <= 0) ? 0 : latency;
                 this.minimumTimeout = (this.minimumTimeout < 0) ? 0 : this.minimumTimeout;
             }
@@ -106,7 +106,7 @@ public class AsyncScheduler extends SchedulerBase {
     protected void preTick() {
         this.lock.lock();
         try {
-            this.condition.await(this.minimumTimeout, TimeUnit.MILLISECONDS);
+            this.condition.await(this.minimumTimeout, TimeUnit.NANOSECONDS);
         } catch (InterruptedException ignored) {
             // The taskMap has been modified; there is work to do.
             // Continue on without handling the Exception.
@@ -117,7 +117,7 @@ public class AsyncScheduler extends SchedulerBase {
 
     @Override
     protected void postTick() {
-        this.lastProcessingTimestamp = System.currentTimeMillis();
+        this.lastProcessingTimestamp = System.nanoTime();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/service/scheduler/ScheduledTask.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/ScheduledTask.java
@@ -30,14 +30,15 @@ import org.spongepowered.api.service.scheduler.Task;
 
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.concurrent.TimeUnit;
 
 /**
  * An internal representation of a {@link Task} created by a plugin.
  */
 public class ScheduledTask implements Task {
 
-    final long offset;
-    final long period;
+    final long offset; //nanoseconds or ticks
+    final long period; //nanoseconds or ticks
     final boolean delayIsTicks;
     final boolean intervalIsTicks;
     private final PluginContainer owner;
@@ -106,12 +107,20 @@ public class ScheduledTask implements Task {
 
     @Override
     public long getDelay() {
-        return this.offset;
+        if (this.delayIsTicks) {
+            return this.offset;
+        } else {
+            return TimeUnit.NANOSECONDS.toMillis(this.offset);
+        }
     }
 
     @Override
     public long getInterval() {
-        return this.period;
+        if (this.intervalIsTicks) {
+            return this.period;
+        } else {
+            return TimeUnit.NANOSECONDS.toMillis(this.period);
+        }
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/service/scheduler/ScheduledTask.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/ScheduledTask.java
@@ -157,6 +157,21 @@ public class ScheduledTask implements Task {
         return this.timestamp;
     }
 
+    /**
+     * Returns a timestamp after which the next execution will take place.
+     * Should only be compared to
+     * {@link SchedulerBase#getTimestamp(ScheduledTask)}.
+     *
+     * @return The next execution timestamp
+     */
+    long nextExecutionTimestamp() {
+        if (this.state.isActive) {
+            return this.timestamp + this.period;
+        } else {
+            return this.timestamp + this.offset;
+        }
+    }
+
     void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
     }

--- a/src/main/java/org/spongepowered/common/service/scheduler/SchedulerBase.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/SchedulerBase.java
@@ -52,14 +52,14 @@ abstract class SchedulerBase {
 
     /**
      * Gets the timestamp to update the timestamp of a task. This method is task
-     * sensitive to support different timestamp types i.e. wall clock and ticks.
+     * sensitive to support different timestamp types i.e. nanotime and ticks.
      *
      * @param task The task
      * @return Timestamp for the task
      */
     protected long getTimestamp(ScheduledTask task) {
-        // Supports wall clock time by default
-        return System.currentTimeMillis();
+        // Supports nanotime by default
+        return System.nanoTime();
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/service/scheduler/SchedulerBase.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/SchedulerBase.java
@@ -52,13 +52,16 @@ abstract class SchedulerBase {
 
     /**
      * Gets the timestamp to update the timestamp of a task. This method is task
-     * sensitive to support different timestamp types i.e. nanotime and ticks.
+     * sensitive to support different timestamp types i.e. real time and ticks.
+     *
+     * <p>Subtracting the result of this method from a previously obtained
+     * result should become a representation of the time that has passed
+     * between those calls.</p>
      *
      * @param task The task
      * @return Timestamp for the task
      */
     protected long getTimestamp(ScheduledTask task) {
-        // Supports nanotime by default
         return System.nanoTime();
     }
 

--- a/src/main/java/org/spongepowered/common/service/scheduler/SpongeScheduler.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/SpongeScheduler.java
@@ -38,13 +38,15 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SpongeScheduler implements SchedulerService {
 
     private static final SpongeScheduler INSTANCE = new SpongeScheduler();
-    public static final int TICK_DURATION = 50;
+    public static final int TICK_DURATION_MS = 50;
+    public static final long TICK_DURATION_NS = TimeUnit.NANOSECONDS.convert(TICK_DURATION_MS, TimeUnit.MILLISECONDS);
 
     private final AsyncScheduler asyncScheduler;
     private final SyncScheduler syncScheduler;
@@ -124,7 +126,7 @@ public class SpongeScheduler implements SchedulerService {
 
     @Override
     public int getPreferredTickInterval() {
-        return TICK_DURATION;
+        return TICK_DURATION_MS;
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/service/scheduler/SpongeScheduler.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/SpongeScheduler.java
@@ -30,6 +30,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.Sets;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.service.scheduler.SchedulerService;
+import org.spongepowered.api.service.scheduler.SpongeExecutorService;
 import org.spongepowered.api.service.scheduler.Task;
 import org.spongepowered.api.service.scheduler.TaskBuilder;
 import org.spongepowered.common.Sponge;
@@ -127,6 +128,16 @@ public class SpongeScheduler implements SchedulerService {
     @Override
     public int getPreferredTickInterval() {
         return TICK_DURATION_MS;
+    }
+
+    @Override
+    public SpongeExecutorService createSyncExecutor(Object plugin) {
+        return new TaskExecutorService(() -> createTaskBuilder(), syncScheduler, checkPluginInstance(plugin).getInstance());
+    }
+
+    @Override
+    public SpongeExecutorService createAsyncExecutor(Object plugin) {
+        return new TaskExecutorService(() -> createTaskBuilder().async(), asyncScheduler, checkPluginInstance(plugin).getInstance());
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/service/scheduler/SpongeScheduler.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/SpongeScheduler.java
@@ -132,12 +132,12 @@ public class SpongeScheduler implements SchedulerService {
 
     @Override
     public SpongeExecutorService createSyncExecutor(Object plugin) {
-        return new TaskExecutorService(() -> createTaskBuilder(), syncScheduler, checkPluginInstance(plugin).getInstance());
+        return new TaskExecutorService(() -> createTaskBuilder(), syncScheduler, checkPluginInstance(plugin));
     }
 
     @Override
     public SpongeExecutorService createAsyncExecutor(Object plugin) {
-        return new TaskExecutorService(() -> createTaskBuilder().async(), asyncScheduler, checkPluginInstance(plugin).getInstance());
+        return new TaskExecutorService(() -> createTaskBuilder().async(), asyncScheduler, checkPluginInstance(plugin));
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/service/scheduler/SpongeTaskBuilder.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/SpongeTaskBuilder.java
@@ -40,8 +40,8 @@ public class SpongeTaskBuilder implements TaskBuilder {
     private Consumer<Task> consumer;
     private ScheduledTask.TaskSynchronicity syncType;
     private String name;
-    private long delay;
-    private long interval;
+    private long delay; //nanoseconds or ticks
+    private long interval; //nanoseconds or ticks
     private boolean delayIsTicks;
     private boolean intervalIsTicks;
 
@@ -64,7 +64,7 @@ public class SpongeTaskBuilder implements TaskBuilder {
     @Override
     public TaskBuilder delay(long delay, TimeUnit unit) {
         checkArgument(delay >= 0, "Delay cannot be negative");
-        this.delay = checkNotNull(unit, "unit").toMillis(delay);
+        this.delay = checkNotNull(unit, "unit").toNanos(delay);
         this.delayIsTicks = false;
         return this;
     }
@@ -80,7 +80,7 @@ public class SpongeTaskBuilder implements TaskBuilder {
     @Override
     public TaskBuilder interval(long interval, TimeUnit unit) {
         checkArgument(interval >= 0, "Interval cannot be negative");
-        this.interval = checkNotNull(unit, "unit").toMillis(interval);
+        this.interval = checkNotNull(unit, "unit").toNanos(interval);
         this.intervalIsTicks = false;
         return this;
     }
@@ -115,8 +115,8 @@ public class SpongeTaskBuilder implements TaskBuilder {
         boolean delayIsTicks = this.delayIsTicks;
         boolean intervalIsTicks = this.intervalIsTicks;
         if (this.syncType == ScheduledTask.TaskSynchronicity.ASYNCHRONOUS) {
-            delay = delayIsTicks ? delay * SpongeScheduler.TICK_DURATION : delay;
-            interval = intervalIsTicks ? interval * SpongeScheduler.TICK_DURATION : interval;
+            delay = delayIsTicks ? delay * SpongeScheduler.TICK_DURATION_NS : delay;
+            interval = intervalIsTicks ? interval * SpongeScheduler.TICK_DURATION_NS : interval;
             delayIsTicks = intervalIsTicks = false;
         }
         ScheduledTask task = new ScheduledTask(this.syncType, this.consumer, name, delay, delayIsTicks, interval, intervalIsTicks, pluginContainer);

--- a/src/main/java/org/spongepowered/common/service/scheduler/TaskExecutorService.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/TaskExecutorService.java
@@ -198,7 +198,7 @@ class TaskExecutorService extends AbstractExecutorService implements SpongeExecu
         public boolean isCancelled() {
             // It might be externally cancelled, the runnable would never
             // run in that case
-            return this.runnable.isCancelled() || this.task.getState() == ScheduledTask.ScheduledTaskState.CANCELED;
+            return this.runnable.isCancelled() || (this.task.getState() == ScheduledTask.ScheduledTaskState.CANCELED && !this.runnable.isDone());
         }
 
         @Override

--- a/src/main/java/org/spongepowered/common/service/scheduler/TaskExecutorService.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/TaskExecutorService.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.service.scheduler;
 
 import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.service.scheduler.SpongeExecutorService;
 import org.spongepowered.api.service.scheduler.Task;
 import org.spongepowered.api.service.scheduler.TaskBuilder;
@@ -45,9 +46,9 @@ class TaskExecutorService extends AbstractExecutorService implements SpongeExecu
 
     private final Supplier<TaskBuilder> taskBuilderProvider;
     private final SchedulerBase scheduler;
-    private final Object plugin;
+    private final PluginContainer plugin;
 
-    protected TaskExecutorService(Supplier<TaskBuilder> taskBuilderProvider, SchedulerBase scheduler, Object plugin) {
+    protected TaskExecutorService(Supplier<TaskBuilder> taskBuilderProvider, SchedulerBase scheduler, PluginContainer plugin) {
         this.taskBuilderProvider = taskBuilderProvider;
         this.scheduler = scheduler;
         this.plugin = plugin;

--- a/src/main/java/org/spongepowered/common/service/scheduler/TaskExecutorService.java
+++ b/src/main/java/org/spongepowered/common/service/scheduler/TaskExecutorService.java
@@ -1,0 +1,257 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.service.scheduler;
+
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.service.scheduler.SpongeExecutorService;
+import org.spongepowered.api.service.scheduler.Task;
+import org.spongepowered.api.service.scheduler.TaskBuilder;
+
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+class TaskExecutorService extends AbstractExecutorService implements SpongeExecutorService {
+
+    private final Supplier<TaskBuilder> taskBuilderProvider;
+    private final SchedulerBase scheduler;
+    private final Object plugin;
+
+    protected TaskExecutorService(Supplier<TaskBuilder> taskBuilderProvider, SchedulerBase scheduler, Object plugin) {
+        this.taskBuilderProvider = taskBuilderProvider;
+        this.scheduler = scheduler;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void shutdown() {
+        // Since this class is delegating its work to SchedulerService
+        // and we have no way to stopping execution without keeping
+        // track of all the submitted tasks, it makes sense that
+        // this ExecutionService cannot be shut down.
+
+        // While it is technically possible to cancel all tasks for
+        // a plugin through the SchedulerService, we have no way to
+        // ensure those tasks were created through this interface.
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return false;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        this.createTask(command).submit(this.plugin);
+    }
+
+    @Override
+    public SpongeFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        final FutureTask<?> runnable = new FutureTask<>(command, null);
+
+        final Task task = this.createTask(runnable)
+                .delay(delay, unit)
+                .submit(this.plugin);
+
+        return new SpongeTaskFuture<>(runnable, (ScheduledTask) task, this.scheduler);
+    }
+
+    @Override
+    public <V> SpongeFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        final FutureTask<V> runnable = new FutureTask<>(callable);
+
+        final Task task = this.createTask(runnable)
+                .delay(delay, unit)
+                .submit(this.plugin);
+
+        return new SpongeTaskFuture<>(runnable, (ScheduledTask) task, this.scheduler);
+    }
+
+    @Override
+    public SpongeFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        final RepeatableFutureTask<?> runnable = new RepeatableFutureTask<>(command);
+
+        final Task task = this.createTask(runnable)
+                .delay(initialDelay, unit)
+                .interval(period, unit)
+                .submit(this.plugin);
+
+        // A repeatable task needs to be able to cancel itself
+        runnable.setTask(task);
+
+        return new SpongeTaskFuture<>(runnable, (ScheduledTask) task, this.scheduler);
+    }
+
+    @Override
+    public SpongeFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        //Since we don't have full control over the execution, the contract needs to be a little broken
+        return this.scheduleAtFixedRate(command, initialDelay, delay, unit);
+    }
+
+    private TaskBuilder createTask(Runnable command) {
+        return this.taskBuilderProvider.get().execute(command);
+    }
+
+    private static class SpongeTaskFuture<V> implements SpongeFuture<V> {
+
+        private final FutureTask<V> runnable;
+        private final ScheduledTask task;
+        private final SchedulerBase scheduler;
+
+        private SpongeTaskFuture(FutureTask<V> runnable, ScheduledTask task, SchedulerBase scheduler) {
+            this.runnable = runnable;
+            this.task = task;
+            this.scheduler = scheduler;
+        }
+
+        @Override
+        public Task getTask() {
+            return this.task;
+        }
+
+        @Override
+        public boolean isPeriodic() {
+            return this.task.getInterval() > 0;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            // Since these tasks are scheduled through
+            // SchedulerExecutionService, they are
+            // always nanotime-based, not tick-based.
+            long elapsedTimeNs = this.scheduler.getTimestamp(this.task) - this.task.getTimestamp();
+            if (this.task.getState() == ScheduledTask.ScheduledTaskState.RUNNING) {
+                //Use the interval to determine the current delay
+                return unit.convert(this.task.period - elapsedTimeNs, TimeUnit.NANOSECONDS);
+            } else {
+                return unit.convert(this.task.offset - elapsedTimeNs, TimeUnit.NANOSECONDS);
+            }
+        }
+
+        @Override
+        public int compareTo(Delayed other) {
+            // Since getDelay may return different values for each call,
+            // this check is required to correctly implement Comparable
+            if (other == this) {
+                return 0;
+            }
+            return Long.compare(this.getDelay(TimeUnit.NANOSECONDS), other.getDelay(TimeUnit.NANOSECONDS));
+        }
+
+        @Override
+        public void run() {
+            this.runnable.run();
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            this.task.cancel(); //Ensure Sponge is not going to try to run a cancelled task.
+            return this.runnable.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            // It might be externally cancelled, the runnable would never
+            // run in that case
+            return this.runnable.isCancelled() || this.task.getState() == ScheduledTask.ScheduledTaskState.CANCELED;
+        }
+
+        @Override
+        public boolean isDone() {
+            return this.runnable.isDone();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return this.runnable.get();
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return this.runnable.get(timeout, unit);
+        }
+    }
+
+    /**
+     * An extension of the JREs FutureTask that can be repeatedly executed,
+     * required for scheduling on an interval.
+     */
+    private static class RepeatableFutureTask<V> extends FutureTask<V> {
+
+        @Nullable private Task owningTask = null;
+
+        protected RepeatableFutureTask(Runnable runnable) {
+            super(runnable, null);
+        }
+
+        protected void setTask(Task task) {
+            this.owningTask = task;
+
+            // Since it is set after being scheduled, it might have thrown
+            // an exception already
+            if (isDone() && !isCancelled()) {
+                this.owningTask.cancel();
+            }
+        }
+
+        @Override
+        protected void done() {
+            // A repeating task that is done but hasn't been cancelled has
+            // failed exceptionally. Following the contract of
+            // ScheduledExecutorService, this means the task has to be stopped.
+            if (!isCancelled() && this.owningTask != null) {
+                this.owningTask.cancel();
+            }
+        }
+
+        @Override
+        public void run() {
+            super.runAndReset();
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in the API PR (https://github.com/SpongePowered/SpongeAPI/pull/871), this PR updates a commit from the old `java8` branch to the `master` branch.

The old PR for this feature can be found at #151
Binding annotations are implemented in #163 

Besides implementing the new ExecutorService interface, this commit also changes the internal time tracking mechanism from `System.currentTimeMillis()` to `System.nanoTime()` which is not affected by system clock changes.