### PR TITLE
Implement SlimeData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
@@ -60,6 +60,7 @@ import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableHorseDat
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableIgniteableData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableMovementSpeedData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableScreamingData;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSlimeData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSneakingData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableVelocityData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutableAuthorData;
@@ -84,6 +85,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.HorseData;
 import org.spongepowered.api.data.manipulator.mutable.entity.IgniteableData;
 import org.spongepowered.api.data.manipulator.mutable.entity.MovementSpeedData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ScreamingData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SlimeData;
 import org.spongepowered.api.data.manipulator.mutable.entity.SneakingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VelocityData;
 import org.spongepowered.api.data.manipulator.mutable.item.AuthorData;
@@ -139,6 +141,7 @@ import org.spongepowered.common.data.builder.manipulator.mutable.entity.HorseDat
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.IgniteableDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.MovementSpeedDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.ScreamingDataBuilder;
+import org.spongepowered.common.data.builder.manipulator.mutable.entity.SlimeDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.SneakingDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.VelocityDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.item.BreakableDataBuilder;
@@ -165,6 +168,7 @@ import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpong
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeIgniteableData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeMovementSpeedData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeScreamingData;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSlimeData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSneakingData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeVelocityData;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeAuthorData;
@@ -189,6 +193,7 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHorseData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeIgniteableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeMovementSpeedData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeScreamingData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSlimeData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSneakingData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVelocityData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeAuthorData;
@@ -213,6 +218,7 @@ import org.spongepowered.common.data.processor.data.entity.HorseDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.IgniteableDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.MovementSpeedDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.ScreamingDataProcessor;
+import org.spongepowered.common.data.processor.data.entity.SlimeDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.SneakingDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.VelocityDataProcessor;
 import org.spongepowered.common.data.processor.data.item.BreakableDataProcessor;
@@ -247,6 +253,7 @@ import org.spongepowered.common.data.processor.value.entity.MaxAirValueProcessor
 import org.spongepowered.common.data.processor.value.entity.MaxHealthValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.RemainingAirValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.ScreamingValueProcessor;
+import org.spongepowered.common.data.processor.value.entity.SlimeSizeValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.SneakingValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.TotalExperienceValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.VelocityValueProcessor;
@@ -435,7 +442,7 @@ public class SpongeSerializationRegistry {
         final ItemAuthorDataBuilder itemAuthorDataBuilder = new ItemAuthorDataBuilder();
         service.registerBuilder(AuthorData.class, itemAuthorDataBuilder);
         dataRegistry.registerDataProcessorAndImplBuilder(AuthorData.class, SpongeAuthorData.class, ImmutableAuthorData.class,
-                                                  ImmutableSpongeAuthorData.class, itemAuthorDataProcessor, itemAuthorDataBuilder);
+                ImmutableSpongeAuthorData.class, itemAuthorDataProcessor, itemAuthorDataBuilder);
 
         final BreakableDataProcessor breakableDataProcessor = new BreakableDataProcessor();
         final BreakableDataBuilder breakableDataBuilder = new BreakableDataBuilder();
@@ -454,6 +461,12 @@ public class SpongeSerializationRegistry {
         service.registerBuilder(MovementSpeedData.class, movementSpeedDataBuilder);
         dataRegistry.registerDataProcessorAndImplBuilder(MovementSpeedData.class, SpongeMovementSpeedData.class, ImmutableMovementSpeedData.class,
                 ImmutableSpongeMovementSpeedData.class, movementSpeedDataProcessor, movementSpeedDataBuilder);
+
+        final SlimeDataProcessor slimeDataProcessor = new SlimeDataProcessor();
+        final SlimeDataBuilder slimeDataBuilder = new SlimeDataBuilder();
+        service.registerBuilder(SlimeData.class, slimeDataBuilder);
+        dataRegistry.registerDataProcessorAndImplBuilder(SlimeData.class, SpongeSlimeData.class, ImmutableSlimeData.class,
+                ImmutableSpongeSlimeData.class, slimeDataProcessor, slimeDataBuilder);
 
         // Values
         dataRegistry.registerValueProcessor(Keys.HEALTH, new HealthValueProcessor());
@@ -495,6 +508,7 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerValueProcessor(Keys.PLACEABLE_BLOCKS, new PlaceableValueProcessor());
         dataRegistry.registerValueProcessor(Keys.WALKING_SPEED, new WalkingSpeedValueProcessor());
         dataRegistry.registerValueProcessor(Keys.FLYING_SPEED, new FlyingSpeedValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.SLIME_SIZE, new SlimeSizeValueProcessor());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/builder/manipulator/mutable/entity/SlimeDataBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/builder/manipulator/mutable/entity/SlimeDataBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.builder.manipulator.mutable.entity;
+
+import static org.spongepowered.common.data.util.DataUtil.getData;
+import net.minecraft.entity.monster.EntitySlime;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulatorBuilder;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSlimeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SlimeData;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSlimeData;
+
+import java.util.Optional;
+
+public class SlimeDataBuilder implements DataManipulatorBuilder<SlimeData, ImmutableSlimeData> {
+
+    public boolean supports(DataHolder dataHolder) {
+        return dataHolder instanceof EntitySlime;
+    }
+
+    @Override
+    public SlimeData create() {
+        return new SpongeSlimeData();
+    }
+
+    @Override
+    public Optional<SlimeData> createFrom(DataHolder dataHolder) {
+        if (supports(dataHolder)) {
+            final int slimeSize = ((EntitySlime) dataHolder).getSlimeSize();
+            return Optional.<SlimeData>of(new SpongeSlimeData(slimeSize));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<SlimeData> build(DataView container) throws InvalidDataException {
+        if (container.contains(Keys.SLIME_SIZE.getQuery())) {
+            int slimeSize = getData(container, Keys.SLIME_SIZE);
+            SpongeSlimeData spongeSlimeData = new SpongeSlimeData(slimeSize);
+            return Optional.of(spongeSlimeData);
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -148,6 +148,7 @@ public class KeyRegistry {
         keyMap.put("placeable_blocks", makeSetKey(BlockType.class, of("CanPlaceOn")));
         keyMap.put("walking_speed", makeSingleKey(Double.class, Value.class, of("WalkingSpeed")));
         keyMap.put("flying_speed", makeSingleKey(Double.class, Value.class, of("FlyingSpeed")));
+        keyMap.put("slime_size", makeSingleKey(Integer.class, MutableBoundedValue.class, of("SlimeSize")));
 
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSlimeData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSlimeData.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSlimeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SlimeData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSlimeData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+public class ImmutableSpongeSlimeData extends AbstractImmutableSingleData<Integer, ImmutableSlimeData, SlimeData> implements ImmutableSlimeData {
+
+    public ImmutableSpongeSlimeData(Integer value) {
+        super(ImmutableSlimeData.class, value, Keys.SLIME_SIZE);
+    }
+
+    @Override
+    protected ImmutableValue<?> getValueGetter() {
+        return size();
+    }
+
+    @Override
+    public SlimeData asMutable() {
+        return new SpongeSlimeData(this.value);
+    }
+
+    @Override
+    public ImmutableValue<Integer> size() {
+        return new ImmutableSpongeValue<>(Keys.SLIME_SIZE, 1, this.value);
+    }
+
+    @Override
+    public int compareTo(ImmutableSlimeData o) {
+        return o.size().get().compareTo(this.value);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSlimeData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSlimeData.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSlimeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SlimeData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSlimeData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+public class SpongeSlimeData extends AbstractSingleData<Integer, SlimeData, ImmutableSlimeData> implements SlimeData {
+
+    public SpongeSlimeData(Integer value) {
+        super(SlimeData.class, value, Keys.SLIME_SIZE);
+    }
+
+    public SpongeSlimeData() {
+        this(1);
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return size();
+    }
+
+    @Override
+    public SlimeData copy() {
+        return new SpongeSlimeData(getValue());
+    }
+
+    @Override
+    public ImmutableSlimeData asImmutable() {
+        return new ImmutableSpongeSlimeData(getValue());
+    }
+
+    @Override
+    public int compareTo(SlimeData o) {
+        return o.size().get().compareTo(this.getValue());
+    }
+
+    @Override
+    public Value<Integer> size() {
+        return new SpongeValue<>(Keys.SLIME_SIZE, 1, this.getValue());
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer()
+                .set(Keys.SLIME_SIZE, this.getValue());
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/SlimeDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/SlimeDataProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.entity;
+
+import net.minecraft.entity.monster.EntitySlime;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSlimeData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SlimeData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSlimeData;
+import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+import java.util.Optional;
+
+public class SlimeDataProcessor extends AbstractEntitySingleDataProcessor<EntitySlime, Integer, MutableBoundedValue<Integer>, SlimeData, ImmutableSlimeData> {
+
+    public SlimeDataProcessor() {
+        super(EntitySlime.class, Keys.SLIME_SIZE);
+    }
+
+    @Override
+    protected boolean set(EntitySlime entity, Integer value) {
+        entity.setSlimeSize(value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Integer> getVal(EntitySlime entity) {
+        return Optional.of(entity.getSlimeSize());
+    }
+
+    @Override
+    protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
+        return ImmutableSpongeValue.cachedOf(this.key, 1, value);
+    }
+
+    @Override
+    protected SlimeData createManipulator() {
+        return new SpongeSlimeData();
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionBuilder.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/SlimeSizeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/SlimeSizeValueProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.entity;
+
+import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
+import net.minecraft.entity.monster.EntitySlime;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
+
+import java.util.Optional;
+
+public class SlimeSizeValueProcessor extends AbstractSpongeValueProcessor<EntitySlime, Integer, MutableBoundedValue<Integer>> {
+
+    protected SlimeSizeValueProcessor() {
+        super(EntitySlime.class, Keys.SLIME_SIZE);
+    }
+
+    @Override
+    protected MutableBoundedValue<Integer> constructValue(Integer defaultValue) {
+        return new SpongeBoundedValue<>(this.getKey(), 1, intComparator(), 1, Integer.MAX_VALUE, defaultValue);
+    }
+
+    @Override
+    protected boolean set(EntitySlime container, Integer value) {
+        container.setSlimeSize(value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Integer> getVal(EntitySlime container) {
+        return Optional.of(container.getSlimeSize());
+    }
+
+    @Override
+    protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
+        return new ImmutableSpongeBoundedValue<>(this.getKey(), value, 1, intComparator(), 1, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData();
+    }
+
+}

--- a/src/main/resources/common_at.cfg
+++ b/src/main/resources/common_at.cfg
@@ -167,3 +167,5 @@ public net.minecraft.util.DamageSource func_76361_j()Lnet/minecraft/util/DamageS
 
 public net.minecraft.entity.player.PlayerCapabilities field_75096_f # flySpeed
 public net.minecraft.entity.player.PlayerCapabilities field_75097_g # walkSpeed
+
+public net.minecraft.entity.monster.EntitySlime func_70799_a(I)V # setSlimeSize


### PR DESCRIPTION
Implementation of `REPLACE_WITH_DATA_MANIPULATOR`.
- [x] Registration of field getters and setters
- [x] Accurately used the appropriate `AbstractData` implementation

Implementation of `REPLACE_WITH_IMMUTABLE_MANIPULATOR`
- [x] Accurately extended the appropriate `AbstractImmutableData` implementation
- [x] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [x] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

Implementation of the `DATA_MANIPULATOR_BUILDER`
- [x] In the `build()` method, checked if the container contained the keys required, if it doesn't, return `Optional.empty()`

Implementation of the `VALUE_PROCESSOR`(s):
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [x] Registered the `Key` correctly by `FIELD_NAME` in the `KeyRegistry`
- [x] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `SpongeSerializationRegistry`
- [x] Registered the `ValueProcessor`s in the `SpongeSerializationRegistry`