### PR TITLE
Implement PlayingData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
@@ -59,6 +59,7 @@ import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableHealthDa
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableHorseData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableIgniteableData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableMovementSpeedData;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePlayingData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableScreamingData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSneakingData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableVelocityData;
@@ -83,6 +84,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
 import org.spongepowered.api.data.manipulator.mutable.entity.HorseData;
 import org.spongepowered.api.data.manipulator.mutable.entity.IgniteableData;
 import org.spongepowered.api.data.manipulator.mutable.entity.MovementSpeedData;
+import org.spongepowered.api.data.manipulator.mutable.entity.PlayingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ScreamingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.SneakingData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VelocityData;
@@ -138,6 +140,7 @@ import org.spongepowered.common.data.builder.manipulator.mutable.entity.HealthDa
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.HorseDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.IgniteableDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.MovementSpeedDataBuilder;
+import org.spongepowered.common.data.builder.manipulator.mutable.entity.PlayingDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.ScreamingDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.SneakingDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.mutable.entity.VelocityDataBuilder;
@@ -164,6 +167,7 @@ import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpong
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeHorseData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeIgniteableData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeMovementSpeedData;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongePlayingData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeScreamingData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSneakingData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeVelocityData;
@@ -188,6 +192,7 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHealthData
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHorseData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeIgniteableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeMovementSpeedData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongePlayingData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeScreamingData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSneakingData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVelocityData;
@@ -212,6 +217,7 @@ import org.spongepowered.common.data.processor.data.entity.HealthDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.HorseDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.IgniteableDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.MovementSpeedDataProcessor;
+import org.spongepowered.common.data.processor.data.entity.PlayingDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.ScreamingDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.SneakingDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.VelocityDataProcessor;
@@ -245,6 +251,7 @@ import org.spongepowered.common.data.processor.value.entity.HorseVariantValuePro
 import org.spongepowered.common.data.processor.value.entity.IsFlyingValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.MaxAirValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.MaxHealthValueProcessor;
+import org.spongepowered.common.data.processor.value.entity.PlayingValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.RemainingAirValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.ScreamingValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.SneakingValueProcessor;
@@ -435,7 +442,7 @@ public class SpongeSerializationRegistry {
         final ItemAuthorDataBuilder itemAuthorDataBuilder = new ItemAuthorDataBuilder();
         service.registerBuilder(AuthorData.class, itemAuthorDataBuilder);
         dataRegistry.registerDataProcessorAndImplBuilder(AuthorData.class, SpongeAuthorData.class, ImmutableAuthorData.class,
-                                                  ImmutableSpongeAuthorData.class, itemAuthorDataProcessor, itemAuthorDataBuilder);
+                ImmutableSpongeAuthorData.class, itemAuthorDataProcessor, itemAuthorDataBuilder);
 
         final BreakableDataProcessor breakableDataProcessor = new BreakableDataProcessor();
         final BreakableDataBuilder breakableDataBuilder = new BreakableDataBuilder();
@@ -454,6 +461,12 @@ public class SpongeSerializationRegistry {
         service.registerBuilder(MovementSpeedData.class, movementSpeedDataBuilder);
         dataRegistry.registerDataProcessorAndImplBuilder(MovementSpeedData.class, SpongeMovementSpeedData.class, ImmutableMovementSpeedData.class,
                 ImmutableSpongeMovementSpeedData.class, movementSpeedDataProcessor, movementSpeedDataBuilder);
+
+        final PlayingDataProcessor playingDataProcessor = new PlayingDataProcessor();
+        final PlayingDataBuilder playingDataBuilder = new PlayingDataBuilder();
+        service.registerBuilder(PlayingData.class, playingDataBuilder);
+        dataRegistry.registerDataProcessorAndImplBuilder(PlayingData.class, SpongePlayingData.class, ImmutablePlayingData.class,
+                ImmutableSpongePlayingData.class, playingDataProcessor, playingDataBuilder);
 
         // Values
         dataRegistry.registerValueProcessor(Keys.HEALTH, new HealthValueProcessor());
@@ -495,6 +508,7 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerValueProcessor(Keys.PLACEABLE_BLOCKS, new PlaceableValueProcessor());
         dataRegistry.registerValueProcessor(Keys.WALKING_SPEED, new WalkingSpeedValueProcessor());
         dataRegistry.registerValueProcessor(Keys.FLYING_SPEED, new FlyingSpeedValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.IS_PLAYING, new PlayingValueProcessor());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/builder/manipulator/mutable/entity/PlayingDataBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/builder/manipulator/mutable/entity/PlayingDataBuilder.java
@@ -1,0 +1,46 @@
+package org.spongepowered.common.data.builder.manipulator.mutable.entity;
+
+import static org.spongepowered.common.data.util.DataUtil.getData;
+import net.minecraft.entity.passive.EntityVillager;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.DataManipulatorBuilder;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePlayingData;
+import org.spongepowered.api.data.manipulator.mutable.entity.PlayingData;
+import org.spongepowered.api.service.persistence.InvalidDataException;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongePlayingData;
+
+import java.util.Optional;
+
+public class PlayingDataBuilder implements DataManipulatorBuilder<PlayingData, ImmutablePlayingData> {
+
+    public boolean supports(DataHolder dataHolder) {
+        return dataHolder instanceof EntityVillager;
+    }
+
+    @Override
+    public PlayingData create() {
+        return new SpongePlayingData();
+    }
+
+    @Override
+    public Optional<PlayingData> createFrom(DataHolder dataHolder) {
+        final boolean isPlaying;
+        if(supports(dataHolder)) {
+            isPlaying = ((EntityVillager) dataHolder).isPlaying();
+            return Optional.of(new SpongePlayingData(isPlaying));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<PlayingData> build(DataView container) throws InvalidDataException {
+        if(container.contains(Keys.IS_PLAYING.getQuery())) {
+            PlayingData playingData = create();
+            playingData.set(Keys.IS_PLAYING, getData(container, Keys.IS_PLAYING));
+            return Optional.of(playingData);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/builder/manipulator/mutable/entity/PlayingDataBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/builder/manipulator/mutable/entity/PlayingDataBuilder.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.data.builder.manipulator.mutable.entity;
 
 import static org.spongepowered.common.data.util.DataUtil.getData;
@@ -26,9 +50,8 @@ public class PlayingDataBuilder implements DataManipulatorBuilder<PlayingData, I
 
     @Override
     public Optional<PlayingData> createFrom(DataHolder dataHolder) {
-        final boolean isPlaying;
-        if(supports(dataHolder)) {
-            isPlaying = ((EntityVillager) dataHolder).isPlaying();
+        if (supports(dataHolder)) {
+            final boolean isPlaying = ((EntityVillager) dataHolder).isPlaying();
             return Optional.of(new SpongePlayingData(isPlaying));
         }
         return Optional.empty();
@@ -36,7 +59,7 @@ public class PlayingDataBuilder implements DataManipulatorBuilder<PlayingData, I
 
     @Override
     public Optional<PlayingData> build(DataView container) throws InvalidDataException {
-        if(container.contains(Keys.IS_PLAYING.getQuery())) {
+        if (container.contains(Keys.IS_PLAYING.getQuery())) {
             PlayingData playingData = create();
             playingData.set(Keys.IS_PLAYING, getData(container, Keys.IS_PLAYING));
             return Optional.of(playingData);

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -148,6 +148,8 @@ public class KeyRegistry {
         keyMap.put("placeable_blocks", makeSetKey(BlockType.class, of("CanPlaceOn")));
         keyMap.put("walking_speed", makeSingleKey(Double.class, Value.class, of("WalkingSpeed")));
         keyMap.put("flying_speed", makeSingleKey(Double.class, Value.class, of("FlyingSpeed")));
+        keyMap.put("is_playing", makeSingleKey(Boolean.class, Value.class, of("IsPlaying")));
+
 
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePlayingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePlayingData.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
 import org.spongepowered.api.data.key.Keys;

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePlayingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePlayingData.java
@@ -1,0 +1,27 @@
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePlayingData;
+import org.spongepowered.api.data.manipulator.mutable.entity.PlayingData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongePlayingData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+public class ImmutableSpongePlayingData extends AbstractImmutableBooleanData<ImmutablePlayingData, PlayingData> implements ImmutablePlayingData {
+
+    public ImmutableSpongePlayingData(boolean value) {
+        super(ImmutablePlayingData.class, value, Keys.IS_PLAYING, SpongePlayingData.class);
+    }
+
+    @Override
+    protected ImmutableValue<?> getValueGetter() {
+        return playing();
+    }
+
+    @Override
+    public ImmutableValue<Boolean> playing() {
+        return ImmutableSpongeValue.cachedOf(Keys.IS_PLAYING, false, this.value);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePlayingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePlayingData.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.data.manipulator.mutable.entity;
 
 import org.spongepowered.api.data.key.Keys;

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePlayingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePlayingData.java
@@ -1,0 +1,31 @@
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePlayingData;
+import org.spongepowered.api.data.manipulator.mutable.entity.PlayingData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongePlayingData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+public class SpongePlayingData extends AbstractBooleanData<PlayingData, ImmutablePlayingData> implements PlayingData {
+
+    public SpongePlayingData(boolean value) {
+        super(PlayingData.class, value, Keys.IS_PLAYING, ImmutableSpongePlayingData.class);
+    }
+
+    public SpongePlayingData() {
+        this(false);
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return playing();
+    }
+
+    @Override
+    public Value<Boolean> playing() {
+        return new SpongeValue<>(Keys.IS_PLAYING, false, this.getValue());
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/PlayingDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/PlayingDataProcessor.java
@@ -1,0 +1,51 @@
+package org.spongepowered.common.data.processor.data.entity;
+
+
+import net.minecraft.entity.passive.EntityVillager;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutablePlayingData;
+import org.spongepowered.api.data.manipulator.mutable.entity.PlayingData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongePlayingData;
+import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+import java.util.Optional;
+
+public class PlayingDataProcessor extends AbstractEntitySingleDataProcessor<EntityVillager, Boolean, Value<Boolean>, PlayingData, ImmutablePlayingData> {
+
+    public PlayingDataProcessor() {
+        super(EntityVillager.class, Keys.IS_PLAYING);
+    }
+
+    @Override
+    protected boolean set(EntityVillager entity, Boolean value) {
+        entity.setPlaying(value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Boolean> getVal(EntityVillager entity) {
+        return Optional.of(entity.isPlaying());
+    }
+
+    @Override
+    protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
+        return ImmutableSpongeValue.cachedOf(key, false, value);
+    }
+
+    @Override
+    protected PlayingData createManipulator() {
+        return new SpongePlayingData();
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionBuilder.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/PlayingDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/PlayingDataProcessor.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.data.processor.data.entity;
 
 

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/PlayingValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/PlayingValueProcessor.java
@@ -1,0 +1,48 @@
+package org.spongepowered.common.data.processor.value.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.EntityVillager;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+import java.util.Optional;
+
+public class PlayingValueProcessor extends AbstractSpongeValueProcessor<EntityVillager, Boolean, Value<Boolean>> {
+
+    public PlayingValueProcessor() {
+        super(EntityVillager.class, Keys.IS_PLAYING);
+    }
+
+    @Override
+    protected Value<Boolean> constructValue(Boolean value) {
+        return new SpongeValue<>(getKey(), false, value);
+    }
+
+    @Override
+    protected boolean set(EntityVillager container, Boolean value) {
+        container.setPlaying(value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Boolean> getVal(EntityVillager container) {
+        return Optional.of(container.isPlaying());
+    }
+
+    @Override
+    protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
+        return ImmutableSpongeValue.cachedOf(getKey(), false, value);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/PlayingValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/PlayingValueProcessor.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.data.processor.value.entity;
 
 import net.minecraft.entity.Entity;


### PR DESCRIPTION
Implementation of `REPLACE_WITH_DATA_MANIPULATOR`.
- [x] Registration of field getters and setters
- [x] Accurately used the appropriate `AbstractData` implementation

Implementation of `REPLACE_WITH_IMMUTABLE_MANIPULATOR`
- [x] Accurately extended the appropriate `AbstractImmutableData` implementation
- [x] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [x] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

Implementation of the `DATA_MANIPULATOR_BUILDER`
- [x] In the `build()` method, checked if the container contained the keys required, if it doesn't, return `Optional.empty()`

Implementation of the `VALUE_PROCESSOR`(s):
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [x] Registered the `Key` correctly by `FIELD_NAME` in the `KeyRegistry`
- [x] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `SpongeSerializationRegistry`
- [x] Registered the `ValueProcessor`s in the `SpongeSerializationRegistry`