### PR TITLE
Implement ColoredData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
@@ -460,6 +460,7 @@ import org.spongepowered.common.data.processor.value.item.CoalValueProcessor;
 import org.spongepowered.common.data.processor.value.item.CookedFishValueProcessor;
 import org.spongepowered.common.data.processor.value.item.FishValueProcessor;
 import org.spongepowered.common.data.processor.value.item.GoldenAppleValueProcessor;
+import org.spongepowered.common.data.processor.value.item.ItemColorValueProcessor;
 import org.spongepowered.common.data.processor.value.item.ItemDisplayNameValueProcessor;
 import org.spongepowered.common.data.processor.value.item.ItemLoreValueProcessor;
 import org.spongepowered.common.data.processor.value.item.ItemSkullRepresentedPlayerValueProcessor;
@@ -861,6 +862,7 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerValueProcessor(Keys.DOUBLE_PLANT_TYPE, new DoublePlantTypeValueProcessor());
         dataRegistry.registerValueProcessor(Keys.BIG_MUSHROOM_TYPE, new BigMushroomTypeValueProcessor());
         dataRegistry.registerValueProcessor(Keys.DISGUISED_BLOCK_TYPE, new DisguisedBlockTypeValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.COLOR, new ItemColorValueProcessor());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
@@ -45,6 +45,7 @@ import org.spongepowered.api.block.tileentity.carrier.Dropper;
 import org.spongepowered.api.block.tileentity.carrier.Furnace;
 import org.spongepowered.api.block.tileentity.carrier.Hopper;
 import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableColoredData;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableDisplayNameData;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableRepresentedItemData;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableRepresentedPlayerData;
@@ -107,6 +108,7 @@ import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePlaceableD
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableBrewingStandData;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableFurnaceData;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableSignData;
+import org.spongepowered.api.data.manipulator.mutable.ColoredData;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedItemData;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedPlayerData;
@@ -200,6 +202,7 @@ import org.spongepowered.common.data.builder.item.SpongeItemStackSnapshotBuilder
 import org.spongepowered.common.data.builder.manipulator.immutable.block.ImmutableSpongeTreeDataBuilder;
 import org.spongepowered.common.data.builder.manipulator.immutable.item.ImmutableItemEnchantmentDataBuilder;
 import org.spongepowered.common.data.key.KeyRegistry;
+import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeColoredData;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeDisplayNameData;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeRepresentedItemData;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeRepresentedPlayerData;
@@ -262,6 +265,7 @@ import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeP
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeBrewingStandData;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeFurnaceData;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeSignData;
+import org.spongepowered.common.data.manipulator.mutable.SpongeColoredData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeDisplayNameData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeRepresentedItemData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeRepresentedPlayerData;
@@ -324,6 +328,7 @@ import org.spongepowered.common.data.manipulator.mutable.item.SpongePlaceableDat
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeBrewingStandData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeFurnaceData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeSignData;
+import org.spongepowered.common.data.processor.data.ColoredDataProcessor;
 import org.spongepowered.common.data.processor.data.DisplayNameDataProcessor;
 import org.spongepowered.common.data.processor.data.RepresentedItemDataProcessor;
 import org.spongepowered.common.data.processor.data.SkullDataProcessor;
@@ -527,6 +532,10 @@ public class SpongeSerializationRegistry {
         final DisplayNameDataProcessor displayNameDataProcessor = new DisplayNameDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(DisplayNameData.class, SpongeDisplayNameData.class,
                 ImmutableDisplayNameData.class, ImmutableSpongeDisplayNameData.class, displayNameDataProcessor);
+
+        final ColoredDataProcessor coloredDataProcessor = new ColoredDataProcessor();
+        dataRegistry.registerDataProcessorAndImpl(ColoredData.class, SpongeColoredData.class,
+                ImmutableColoredData.class, ImmutableSpongeColoredData.class, coloredDataProcessor);
 
         final CareerDataProcessor careerDataProcessor = new CareerDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(CareerData.class, SpongeCareerData.class, ImmutableCareerData.class,

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeColoredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeColoredData.java
@@ -22,57 +22,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.data.manipulator.mutable;
+package org.spongepowered.common.data.manipulator.immutable;
 
-import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableColoredData;
 import org.spongepowered.api.data.manipulator.mutable.ColoredData;
-import org.spongepowered.api.data.value.mutable.Value;
-import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeColoredData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.mutable.SpongeColoredData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 import java.awt.Color;
 
-public class SpongeColoredData extends AbstractSingleData<Color, ColoredData, ImmutableColoredData> implements ColoredData {
+public class ImmutableSpongeColoredData extends AbstractImmutableSingleData<Color, ImmutableColoredData, ColoredData> implements ImmutableColoredData {
 
-    public SpongeColoredData() {
-        this(Color.BLACK);
-    }
-
-    public SpongeColoredData(Color value) {
-        super(ColoredData.class, value, Keys.COLOR);
+    public ImmutableSpongeColoredData(Color value) {
+        super(ImmutableColoredData.class, value, Keys.COLOR);
     }
 
     @Override
-    public ColoredData copy() {
-        return new SpongeColoredData(this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
+    protected ImmutableValue<?> getValueGetter() {
         return color();
     }
 
     @Override
-    public ImmutableColoredData asImmutable() {
-        return new ImmutableSpongeColoredData(getValue());
+    public ColoredData asMutable() {
+        return new SpongeColoredData(this.getValue());
     }
 
     @Override
-    public int compareTo(ColoredData o) {
-        return o.get(Keys.COLOR).get().getRGB() - this.getValue().getRGB();
+    public ImmutableValue<Color> color() {
+        return ImmutableSpongeValue.cachedOf(Keys.COLOR, Color.BLACK, this.value);
     }
 
     @Override
-    public DataContainer toContainer() {
-        return new MemoryDataContainer().set(Keys.COLOR.getQuery(), this.getValue().getRGB());
-    }
-
-    @Override
-    public Value<Color> color() {
-        return new SpongeValue<>(Keys.COLOR, Color.BLACK, getValue());
+    public int compareTo(ImmutableColoredData o) {
+        return o.get(this.usedKey).get().getRGB() - this.getValue().getRGB();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
@@ -47,16 +47,16 @@ import net.minecraft.item.ItemStack;
 public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color, Value<Color>, ColoredData, ImmutableColoredData> {
 
     public ColoredDataProcessor() {
-        super(stack -> ColorUtil.getItemStackColor(stack).isPresent(), Keys.COLOR);
+        super(ColorUtil::hasColor, Keys.COLOR);
     }
 
     @Override
     public DataTransactionResult remove(DataHolder dataHolder) {
         if (dataHolder instanceof ItemStack) {
-            final DataTransactionBuilder builder = DataTransactionBuilder.builder();
             final Optional<ColoredData> optional = from(dataHolder);
             final ItemStack stack = (ItemStack) dataHolder;
-            if (ColorUtil.hasItemStackColor(stack) && optional.isPresent()) {
+            if (ColorUtil.hasNbtColor(stack) && optional.isPresent()) {
+                final DataTransactionBuilder builder = DataTransactionBuilder.builder();
                 try {
                     NbtDataUtil.removeColorFromNBT(stack);
                     return builder.replace(optional.get().getValues()).result(DataTransactionResult.Type.SUCCESS).build();
@@ -65,7 +65,7 @@ public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color,
                     return builder.result(DataTransactionResult.Type.ERROR).build();
                 }
             } else {
-                return builder.result(DataTransactionResult.Type.SUCCESS).build();
+                return DataTransactionBuilder.successNoData();
             }
         }
         return DataTransactionBuilder.failNoData();

--- a/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
@@ -28,6 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.awt.Color;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
@@ -39,63 +40,25 @@ import org.spongepowered.api.data.manipulator.immutable.ImmutableColoredData;
 import org.spongepowered.api.data.manipulator.mutable.ColoredData;
 import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeColoredData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeColoredData;
+import org.spongepowered.common.data.processor.common.AbstractItemSingleDataProcessor;
 import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.util.ColorUtil;
 
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 
-public class ColoredDataProcessor extends AbstractSpongeDataProcessor<ColoredData, ImmutableColoredData> {
+public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color, Value<Color>, ColoredData, ImmutableColoredData> {
 
-    @Override
-    public boolean supports(DataHolder dataHolder) {
-        return dataHolder instanceof ItemStack;
-    }
-
-    @Override
-    public Optional<ColoredData> from(DataHolder dataHolder) {
-        if (dataHolder instanceof ItemStack) {
-            final ItemStack stack = (ItemStack) dataHolder;
-            return ColorUtil.getItemStackColor(stack).map(SpongeColoredData::new);
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<ColoredData> fill(DataHolder dataHolder, ColoredData manipulator, MergeFunction overlap) {
-        if (supports(dataHolder)) {
-            final ColoredData data = from(dataHolder).orElse(null);
-            final ColoredData newData = checkNotNull(overlap.merge(checkNotNull(manipulator), data));
-            final Color color = newData.color().get();
-            return Optional.of(manipulator.set(Keys.COLOR, color));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<ColoredData> fill(DataContainer container, ColoredData colorData) {
-        if (container.contains(Keys.COLOR.getQuery())) {
-            final Color color = DataUtil.getData(container, Keys.COLOR, Color.class);
-            return Optional.of(colorData.set(Keys.COLOR, color));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public DataTransactionResult set(DataHolder dataHolder, ColoredData manipulator, MergeFunction function) {
-        return DataTransactionBuilder.failResult(manipulator.getValues());
-    }
-
-    @Override
-    public Optional<ImmutableColoredData> with(Key<? extends BaseValue<?>> key, Object value, ImmutableColoredData immutable) {
-        if (key == Keys.COLOR) {
-            return Optional.of(new ImmutableSpongeColoredData((Color) value));
-        }
-        return Optional.empty();
+    protected ColoredDataProcessor() {
+        super(stack -> ColorUtil.getItemStackColor(stack).isPresent(), Keys.COLOR);
     }
 
     @Override
@@ -120,8 +83,25 @@ public class ColoredDataProcessor extends AbstractSpongeDataProcessor<ColoredDat
     }
 
     @Override
-    public Optional<ColoredData> createFrom(DataHolder dataHolder) {
-        return from(dataHolder);
+    protected boolean set(ItemStack itemStack, Color value) {
+        ColorUtil.setItemStackColor(itemStack, value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Color> getVal(ItemStack itemStack) {
+        return ColorUtil.getItemStackColor(itemStack);
+    }
+
+    @Override
+    protected ImmutableValue<Color> constructImmutableValue(Color value) {
+        return null;
+    }
+
+    @Override
+    protected ColoredData createManipulator() {
+        // TODO Auto-generated method stub
+        return null;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
@@ -78,8 +78,11 @@ public class ColoredDataProcessor extends AbstractSpongeDataProcessor<ColoredDat
 
     @Override
     public Optional<ColoredData> fill(DataContainer container, ColoredData colorData) {
-        final Color color = DataUtil.getData(container, Keys.COLOR, Color.class);
-        return Optional.of(colorData.set(Keys.COLOR, color));
+        if (container.contains(Keys.COLOR.getQuery())) {
+            final Color color = DataUtil.getData(container, Keys.COLOR, Color.class);
+            return Optional.of(colorData.set(Keys.COLOR, color));
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.awt.Color;
+import java.util.Optional;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableColoredData;
+import org.spongepowered.api.data.manipulator.mutable.ColoredData;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeColoredData;
+import org.spongepowered.common.data.manipulator.mutable.SpongeColoredData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
+import org.spongepowered.common.data.util.DataUtil;
+import org.spongepowered.common.data.util.NbtDataUtil;
+import org.spongepowered.common.util.ColorUtil;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.EntitySheep;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.IWorldNameable;
+
+public class ColoredDataProcessor extends AbstractSpongeDataProcessor<ColoredData, ImmutableColoredData> {
+
+    @Override
+    public boolean supports(DataHolder dataHolder) {
+        return dataHolder instanceof EntitySheep || dataHolder instanceof ItemStack || dataHolder instanceof IWorldNameable;
+    }
+
+    @Override
+    public Optional<ColoredData> from(DataHolder dataHolder) {
+        Color color = null;
+        if (dataHolder instanceof EntitySheep) {
+            color = ColorUtil.colorFromDyeColor(((EntitySheep) dataHolder).getFleeceColor());
+        } else if (dataHolder instanceof ItemStack) {
+            final ItemStack stack = (ItemStack) dataHolder;
+            final Item item = stack.getItem();
+            final int meta = stack.getItemDamage();
+            if (item == Items.dye) {
+                // Interpret dyes via "dye damage"
+                color = ColorUtil.colorFromDyeColor(EnumDyeColor.byDyeDamage(meta));
+            } else if (item instanceof ItemBlock) {
+                final Block block = ((ItemBlock) item).getBlock();
+                if (block == Blocks.wool) {
+                    // Interpret wools via metadata
+                    color = ColorUtil.colorFromDyeColor(EnumDyeColor.byMetadata(meta));
+                }
+            } else if (item instanceof ItemArmor) {
+                color = new Color(((ItemArmor) item).getColor(stack));
+            } else if (stack.hasTagCompound()) {
+                final NBTTagCompound tag = stack.getTagCompound();
+                if (tag.hasKey("display", NbtDataUtil.TAG_COMPOUND)) {
+                    final NBTTagCompound display = tag.getCompoundTag("display");
+                    if (display.hasKey("color", NbtDataUtil.TAG_INT)) {
+                        color = new Color(display.getInteger("color"));
+                    }
+                }
+            }
+        }
+        return Optional.ofNullable(color).map(SpongeColoredData::new);
+    }
+
+    @Override
+    public Optional<ColoredData> fill(DataHolder dataHolder, ColoredData manipulator, MergeFunction overlap) {
+        if (supports(dataHolder)) {
+            final ColoredData data = from(dataHolder).orElse(null);
+            final ColoredData newData = checkNotNull(overlap.merge(checkNotNull(manipulator), data));
+            final Color color = newData.color().get();
+            return Optional.of(manipulator.set(Keys.COLOR, color));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ColoredData> fill(DataContainer container, ColoredData colorData) {
+        final Color color = DataUtil.getData(container, Keys.COLOR, Color.class);
+        return Optional.of(colorData.set(Keys.COLOR, color));
+    }
+
+    @Override
+    public DataTransactionResult set(DataHolder dataHolder, ColoredData manipulator, MergeFunction function) {
+        return DataTransactionBuilder.failResult(manipulator.getValues());
+    }
+
+    @Override
+    public Optional<ImmutableColoredData> with(Key<? extends BaseValue<?>> key, Object value, ImmutableColoredData immutable) {
+        if (key == Keys.COLOR) {
+            return Optional.of(new ImmutableSpongeColoredData((Color) value));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        // color cannot be removed
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    public Optional<ColoredData> createFrom(DataHolder dataHolder) {
+        return from(dataHolder);
+    }
+
+    @Override
+    public boolean supports(EntityType entityType) {
+        return Entity.class.isAssignableFrom(entityType.getEntityClass());
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
@@ -24,40 +24,29 @@
  */
 package org.spongepowered.common.data.processor.data;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.awt.Color;
 import java.util.Optional;
-import java.util.function.Predicate;
 
-import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableColoredData;
 import org.spongepowered.api.data.manipulator.mutable.ColoredData;
-import org.spongepowered.api.data.merge.MergeFunction;
-import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.Sponge;
-import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeColoredData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeColoredData;
 import org.spongepowered.common.data.processor.common.AbstractItemSingleDataProcessor;
-import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
-import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.util.NbtDataUtil;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.util.ColorUtil;
 
-import net.minecraft.init.Items;
-import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 
 public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color, Value<Color>, ColoredData, ImmutableColoredData> {
 
-    protected ColoredDataProcessor() {
+    public ColoredDataProcessor() {
         super(stack -> ColorUtil.getItemStackColor(stack).isPresent(), Keys.COLOR);
     }
 
@@ -95,13 +84,12 @@ public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color,
 
     @Override
     protected ImmutableValue<Color> constructImmutableValue(Color value) {
-        return null;
+        return new ImmutableSpongeValue<>(Keys.COLOR, value);
     }
 
     @Override
     protected ColoredData createManipulator() {
-        // TODO Auto-generated method stub
-        return null;
+        return new SpongeColoredData();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/ColoredDataProcessor.java
@@ -24,9 +24,7 @@
  */
 package org.spongepowered.common.data.processor.data;
 
-import java.awt.Color;
-import java.util.Optional;
-
+import net.minecraft.item.ItemStack;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
@@ -42,7 +40,8 @@ import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.util.ColorUtil;
 
-import net.minecraft.item.ItemStack;
+import java.awt.Color;
+import java.util.Optional;
 
 public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color, Value<Color>, ColoredData, ImmutableColoredData> {
 
@@ -51,11 +50,16 @@ public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color,
     }
 
     @Override
+    protected boolean supports(ItemStack stack) {
+        return ColorUtil.hasColor(stack);
+    }
+
+    @Override
     public DataTransactionResult remove(DataHolder dataHolder) {
-        if (dataHolder instanceof ItemStack) {
+        if (supports(dataHolder)) {
             final Optional<ColoredData> optional = from(dataHolder);
             final ItemStack stack = (ItemStack) dataHolder;
-            if (ColorUtil.hasNbtColor(stack) && optional.isPresent()) {
+            if (ColorUtil.hasColorInNbt(stack) && optional.isPresent()) {
                 final DataTransactionBuilder builder = DataTransactionBuilder.builder();
                 try {
                     NbtDataUtil.removeColorFromNBT(stack);
@@ -65,7 +69,7 @@ public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color,
                     return builder.result(DataTransactionResult.Type.ERROR).build();
                 }
             } else {
-                return DataTransactionBuilder.successNoData();
+                return DataTransactionBuilder.failNoData();
             }
         }
         return DataTransactionBuilder.failNoData();
@@ -73,12 +77,18 @@ public class ColoredDataProcessor extends AbstractItemSingleDataProcessor<Color,
 
     @Override
     protected boolean set(ItemStack itemStack, Color value) {
+        if (!this.supports(itemStack)) {
+            return false;
+        }
         ColorUtil.setItemStackColor(itemStack, value);
         return true;
     }
 
     @Override
     protected Optional<Color> getVal(ItemStack itemStack) {
+        if (!this.supports(itemStack)) {
+            return Optional.empty();
+        }
         return ColorUtil.getItemStackColor(itemStack);
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/value/ColorValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/ColorValueProcessor.java
@@ -22,41 +22,50 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.data.manipulator.immutable;
+package org.spongepowered.common.data.processor.value;
 
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.data.manipulator.immutable.ImmutableColoredData;
-import org.spongepowered.api.data.manipulator.mutable.ColoredData;
+import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
-import org.spongepowered.common.data.manipulator.mutable.SpongeColoredData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 
-import java.awt.Color;
+import java.util.Optional;
 
-public class ImmutableSpongeColorData extends AbstractImmutableSingleData<Color, ImmutableColoredData, ColoredData> implements ImmutableColoredData {
+public class ColorValueProcessor extends AbstractSpongeValueProcessor<Entity, Boolean, Value<Boolean>> {
 
-    public ImmutableSpongeColorData(Color value) {
-        super(ImmutableColoredData.class, value, Keys.COLOR);
+    public ColorValueProcessor() {
+        super(Entity.class, Keys.SHOWS_DISPLAY_NAME);
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return color();
+    public Value<Boolean> constructValue(Boolean defaultValue) {
+        return new SpongeValue<>(Keys.SHOWS_DISPLAY_NAME, false, defaultValue);
     }
 
     @Override
-    public ColoredData asMutable() {
-        return new SpongeColoredData(this.getValue());
+    protected boolean set(Entity container, Boolean value) {
+        container.setAlwaysRenderNameTag(value);
+        return true;
     }
 
     @Override
-    public ImmutableValue<Color> color() {
-        return ImmutableSpongeValue.cachedOf(Keys.COLOR, Color.BLACK, this.value);
+    protected Optional<Boolean> getVal(Entity container) {
+        return Optional.of(container.getAlwaysRenderNameTag());
     }
 
     @Override
-    public int compareTo(ImmutableColoredData o) {
-        return o.get(this.usedKey).get().getRGB() - this.getValue().getRGB();
+    protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
+        return ImmutableSpongeValue.cachedOf(Keys.SHOWS_DISPLAY_NAME, false, value);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/ItemColorValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/ItemColorValueProcessor.java
@@ -42,9 +42,9 @@ import org.spongepowered.common.util.ColorUtil;
 
 import net.minecraft.item.ItemStack;
 
-public class ColorValueProcessor extends AbstractSpongeValueProcessor<ItemStack, Color, Value<Color>> {
+public class ItemColorValueProcessor extends AbstractSpongeValueProcessor<ItemStack, Color, Value<Color>> {
 
-    public ColorValueProcessor() {
+    public ItemColorValueProcessor() {
         super(ItemStack.class, Keys.COLOR);
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/ItemColorValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/ItemColorValueProcessor.java
@@ -75,7 +75,7 @@ public class ItemColorValueProcessor extends AbstractSpongeValueProcessor<ItemSt
             final ItemStack stack = (ItemStack) container;
             final DataTransactionBuilder builder = DataTransactionBuilder.builder();
             final Optional<Color> optional = getVal(stack);
-            if (ColorUtil.hasItemStackColor(stack) && optional.isPresent()) {
+            if (ColorUtil.hasNbtColor(stack) && optional.isPresent()) {
                 try {
                     NbtDataUtil.removeColorFromNBT(stack);
                     return builder.replace(new ImmutableSpongeValue<>(Keys.COLOR, optional.get())).result(DataTransactionResult.Type.SUCCESS).build();

--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -218,7 +218,7 @@ public class NbtDataUtil {
         stack.getSubCompound(ITEM_DISPLAY, false).removeTag(ITEM_COLOR);
     }
 
-    public static void setColorToNBT(ItemStack stack, Color color) {
+    public static void setColorToNbt(ItemStack stack, Color color) {
         final int iColor = color.getRGB();
         stack.getSubCompound(ITEM_DISPLAY, true).setInteger(ITEM_COLOR, iColor);
     }

--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -199,9 +199,9 @@ public class NbtDataUtil {
     }
 
     public static boolean hasColorFromNBT(ItemStack stack) {
-        return !stack.hasTagCompound() ||
-                !stack.getTagCompound().hasKey(ITEM_DISPLAY) ||
-                !stack.getTagCompound().getCompoundTag(ITEM_DISPLAY).hasKey(ITEM_COLOR);
+        return stack.hasTagCompound() &&
+                stack.getTagCompound().hasKey(ITEM_DISPLAY) &&
+                stack.getTagCompound().getCompoundTag(ITEM_DISPLAY).hasKey(ITEM_COLOR);
     }
 
     public static Optional<Color> getColorFromNBT(NBTTagCompound subCompound) {

--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -24,21 +24,24 @@
  */
 package org.spongepowered.common.data.util;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import org.spongepowered.api.data.meta.ItemEnchantment;
-import org.spongepowered.api.item.Enchantment;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.common.text.SpongeTexts;
-
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import org.spongepowered.api.data.meta.ItemEnchantment;
+import org.spongepowered.api.item.Enchantment;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.common.text.SpongeTexts;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 
 /**
  * A standard utility class for interacting and manipulating {@link ItemStack}s
@@ -65,6 +68,7 @@ public class NbtDataUtil {
     public static final String ITEM_DISPLAY = "display";
     public static final String ITEM_DISPLAY_NAME = "name";
     public static final String ITEM_LORE = "Lore";
+    public static final String ITEM_COLOR = "color";
 
     public static final String ITEM_BOOK_PAGES = "pages";
     public static final String ITEM_BOOK_TITLE = "title";
@@ -194,6 +198,31 @@ public class NbtDataUtil {
     public static void setLoreToNBT(ItemStack stack, List<Text> lore) {
         final NBTTagList list =  SpongeTexts.asLegacy(lore);
         stack.getSubCompound(ITEM_DISPLAY, true).setTag(ITEM_LORE, list);
+    }
+
+    public static boolean hasColorFromNBT(ItemStack stack) {
+        return !stack.hasTagCompound() ||
+                !stack.getTagCompound().hasKey(ITEM_DISPLAY) ||
+                !stack.getTagCompound().getCompoundTag(ITEM_DISPLAY).hasKey(ITEM_COLOR);
+    }
+
+    public static Optional<Color> getColorFromNBT(NBTTagCompound subCompound) {
+        if (!subCompound.hasKey(ITEM_COLOR)) {
+            return Optional.empty();
+        }
+        return Optional.of(new Color(subCompound.getInteger(ITEM_COLOR)));
+    }
+
+    public static void removeColorFromNBT(ItemStack stack) {
+        if(stack.getSubCompound(ITEM_DISPLAY, false) == null) {
+            return;
+        }
+        stack.getSubCompound(ITEM_DISPLAY, false).removeTag(ITEM_COLOR);
+    }
+
+    public static void setColorToNBT(ItemStack stack, Color color) {
+        final int iColor = color.getRGB();
+        stack.getSubCompound(ITEM_DISPLAY, true).setInteger(ITEM_COLOR, iColor);
     }
 
     public static List<Text> getPagesFromNBT(NBTTagCompound compound) {

--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -24,24 +24,22 @@
  */
 package org.spongepowered.common.data.util;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import org.spongepowered.api.data.meta.ItemEnchantment;
+import org.spongepowered.api.item.Enchantment;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.common.text.SpongeTexts;
+
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import org.spongepowered.api.data.meta.ItemEnchantment;
-import org.spongepowered.api.item.Enchantment;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.common.text.SpongeTexts;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 
 /**
  * A standard utility class for interacting and manipulating {@link ItemStack}s

--- a/src/main/java/org/spongepowered/common/util/ColorUtil.java
+++ b/src/main/java/org/spongepowered/common/util/ColorUtil.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util;
+
+import java.awt.Color;
+import java.util.Map;
+
+import org.spongepowered.api.data.type.DyeColor;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import net.minecraft.item.EnumDyeColor;
+
+public final class ColorUtil {
+
+    /**
+     * Caching to prevent creating more Colors than needed.
+     */
+    private static final Map<EnumDyeColor, Color> ENUM_DYE_COLORS;
+    static {
+        ImmutableMap.Builder<EnumDyeColor, Color> b = ImmutableMap.builder();
+        for (EnumDyeColor color : EnumDyeColor.values()) {
+            b.put(color, ((DyeColor) (Object) color).getColor());
+        }
+        ENUM_DYE_COLORS = Maps.immutableEnumMap(b.build());
+    }
+
+    public static Color colorFromDyeColor(EnumDyeColor color) {
+        return ENUM_DYE_COLORS.get(color);
+    }
+
+    private ColorUtil() {}
+
+}

--- a/src/main/java/org/spongepowered/common/util/ColorUtil.java
+++ b/src/main/java/org/spongepowered/common/util/ColorUtil.java
@@ -32,6 +32,7 @@ import org.spongepowered.common.data.util.NbtDataUtil;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemArmor.ArmorMaterial;
 
 public final class ColorUtil {
 
@@ -46,16 +47,23 @@ public final class ColorUtil {
     }
 
     public static void setItemStackColor(ItemStack stack, Color value) {
-        NbtDataUtil.setColorToNBT(stack, value);
+        NbtDataUtil.setColorToNbt(stack, value);
     }
 
     /**
-     * N.B This differs from {@link #getItemStackColor(ItemStack)}.isPresent()
+     * N.B This differs from {@link #hasColor(ItemStack)}
      * because leather armor has a color even without a set color. This returns
      * {@code true} only if there is a color set on the display tag.
      */
-    public static boolean hasItemStackColor(ItemStack stack) {
+    public static boolean hasNbtColor(ItemStack stack) {
         return NbtDataUtil.hasColorFromNBT(stack);
+    }
+    
+    public static boolean hasColor(ItemStack stack) {
+        final Item item = stack.getItem();
+        return hasNbtColor(stack) ||
+                (item instanceof ItemArmor &&
+                        ((ItemArmor) item).getArmorMaterial() == ArmorMaterial.LEATHER);
     }
 
     private ColorUtil() {

--- a/src/main/java/org/spongepowered/common/util/ColorUtil.java
+++ b/src/main/java/org/spongepowered/common/util/ColorUtil.java
@@ -55,15 +55,14 @@ public final class ColorUtil {
      * because leather armor has a color even without a set color. This returns
      * {@code true} only if there is a color set on the display tag.
      */
-    public static boolean hasNbtColor(ItemStack stack) {
+    public static boolean hasColorInNbt(ItemStack stack) {
         return NbtDataUtil.hasColorFromNBT(stack);
     }
     
     public static boolean hasColor(ItemStack stack) {
         final Item item = stack.getItem();
-        return hasNbtColor(stack) ||
-                (item instanceof ItemArmor &&
-                        ((ItemArmor) item).getArmorMaterial() == ArmorMaterial.LEATHER);
+        return item instanceof ItemArmor &&
+                        ((ItemArmor) item).getArmorMaterial() == ArmorMaterial.LEATHER;
     }
 
     private ColorUtil() {


### PR DESCRIPTION
Implementation of `SpongeColoredData`.
- [x] Registration of field getters and setters
- [X] Accurately used the appropriate `AbstractData` implementation

Implementation of `ImmutableSpongeColoredData`
- [X] Accurately extended the appropriate `AbstractImmutableData` implementation
- [X] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters (probably? cache utils)

Implementation of the `ItemColorValueProcessor`(s):
- [X] Appropriately extended `AbstractSpongeValueProcessor`
- [X] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [X] Registered the `Key` correctly by `color` in the `KeyRegistry`
- [X] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `SpongeSerializationRegistry`
- [x] Registered the `ValueProcessor`s in the `SpongeSerializationRegistry`

Test Plugin code:
http://sh.kenzierocks.me/coloreddataplugin