### PR TITLE
Implementing FurnaceData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
@@ -83,10 +83,11 @@ import org.spongepowered.api.data.manipulator.immutable.item.ImmutableGoldenAppl
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutableLoreData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePagedData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePlaceableData;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableFurnaceData;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableSignData;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
-import org.spongepowered.api.data.manipulator.mutable.RepresentedPlayerData;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedItemData;
+import org.spongepowered.api.data.manipulator.mutable.RepresentedPlayerData;
 import org.spongepowered.api.data.manipulator.mutable.SkullData;
 import org.spongepowered.api.data.manipulator.mutable.WetData;
 import org.spongepowered.api.data.manipulator.mutable.entity.BreathingData;
@@ -121,6 +122,7 @@ import org.spongepowered.api.data.manipulator.mutable.item.GoldenAppleData;
 import org.spongepowered.api.data.manipulator.mutable.item.LoreData;
 import org.spongepowered.api.data.manipulator.mutable.item.PagedData;
 import org.spongepowered.api.data.manipulator.mutable.item.PlaceableData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.FurnaceData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.SignData;
 import org.spongepowered.api.data.meta.ItemEnchantment;
 import org.spongepowered.api.data.meta.PatternLayer;
@@ -191,6 +193,7 @@ import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeG
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeLoreData;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongePagedData;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongePlaceableData;
+import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeFurnaceData;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeSignData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeDisplayNameData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeRepresentedItemData;
@@ -229,6 +232,7 @@ import org.spongepowered.common.data.manipulator.mutable.item.SpongeGoldenAppleD
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeLoreData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongePagedData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongePlaceableData;
+import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeFurnaceData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeSignData;
 import org.spongepowered.common.data.processor.data.DisplayNameDataProcessor;
 import org.spongepowered.common.data.processor.data.RepresentedItemDataProcessor;
@@ -265,9 +269,10 @@ import org.spongepowered.common.data.processor.data.item.ItemAuthorDataProcessor
 import org.spongepowered.common.data.processor.data.item.ItemEnchantmentDataProcessor;
 import org.spongepowered.common.data.processor.data.item.ItemLoreDataProcessor;
 import org.spongepowered.common.data.processor.data.item.ItemPagedDataProcessor;
+import org.spongepowered.common.data.processor.data.item.ItemSkullRepresentedPlayerDataProcessor;
 import org.spongepowered.common.data.processor.data.item.ItemWetDataProcessor;
 import org.spongepowered.common.data.processor.data.item.PlaceableDataProcessor;
-import org.spongepowered.common.data.processor.data.item.ItemSkullRepresentedPlayerDataProcessor;
+import org.spongepowered.common.data.processor.data.tileentity.FurnaceDataProcessor;
 import org.spongepowered.common.data.processor.data.tileentity.SignDataProcessor;
 import org.spongepowered.common.data.processor.data.tileentity.SkullRepresentedPlayerDataProcessor;
 import org.spongepowered.common.data.processor.value.DisplayNameVisibleValueProcessor;
@@ -321,10 +326,15 @@ import org.spongepowered.common.data.processor.value.item.ItemSkullRepresentedPl
 import org.spongepowered.common.data.processor.value.item.ItemSkullValueProcessor;
 import org.spongepowered.common.data.processor.value.item.ItemWetValueProcessor;
 import org.spongepowered.common.data.processor.value.item.PlaceableValueProcessor;
-import org.spongepowered.common.data.processor.value.tileentity.SkullRepresentedPlayerProcessor;
+import org.spongepowered.common.data.processor.value.tileentity.MaxBurnTimeValueProcessor;
+import org.spongepowered.common.data.processor.value.tileentity.MaxCookTimeValueProcessor;
+import org.spongepowered.common.data.processor.value.tileentity.PassedBurnTimeValueProcessor;
+import org.spongepowered.common.data.processor.value.tileentity.PassedCookTimeValueProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.SignLinesValueProcessor;
+import org.spongepowered.common.data.processor.value.tileentity.SkullRepresentedPlayerProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.TileEntityDisplayNameValueProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.TileEntitySkullValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 import org.spongepowered.common.service.persistence.SpongeSerializationService;
 
@@ -394,7 +404,7 @@ public class SpongeSerializationRegistry {
         final FlyingDataProcessor flyingDataProcessor = new FlyingDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(FlyingData.class, SpongeFlyingData.class, ImmutableFlyingData.class,
                 ImmutableSpongeFlyingData.class, flyingDataProcessor);
-				
+
         final FlyingAbilityDataProcessor flyingAbilityDataProcessor = new FlyingAbilityDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(FlyingAbilityData.class, SpongeFlyingAbilityData.class, ImmutableFlyingAbilityData.class,
                 ImmutableSpongeFlyingAbilityData.class, flyingAbilityDataProcessor);
@@ -509,15 +519,15 @@ public class SpongeSerializationRegistry {
 
         final CoalDataProcessor coalDataProcessor = new CoalDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(CoalData.class, SpongeCoalData.class, ImmutableCoalData.class,
-                                                  ImmutableSpongeCoalData.class, coalDataProcessor);
+                ImmutableSpongeCoalData.class, coalDataProcessor);
 
         final CookedFishDataProcessor cookedFishDataProcessor = new CookedFishDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(CookedFishData.class, SpongeCookedFishData.class, ImmutableCookedFishData.class,
-                                                  ImmutableSpongeCookedFishData.class, cookedFishDataProcessor);
+                ImmutableSpongeCookedFishData.class, cookedFishDataProcessor);
 
         final FishDataProcessor fishDataProcessor = new FishDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(FishData.class, SpongeFishData.class, ImmutableFishData.class,
-                                                  ImmutableSpongeFishData.class, fishDataProcessor);
+                ImmutableSpongeFishData.class, fishDataProcessor);
 
         dataRegistry.registerDataProcessorAndImpl(RepresentedPlayerData.class, SpongeRepresentedPlayerData.class,
                 ImmutableRepresentedPlayerData.class, ImmutableSpongeRepresentedPlayerData.class,
@@ -525,6 +535,10 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerDataProcessorAndImpl(RepresentedPlayerData.class, SpongeRepresentedPlayerData.class,
                 ImmutableRepresentedPlayerData.class, ImmutableSpongeRepresentedPlayerData.class,
                 new ItemSkullRepresentedPlayerDataProcessor());
+
+        final FurnaceDataProcessor furnaceDataProcessor = new FurnaceDataProcessor();
+        dataRegistry.registerDataProcessorAndImpl(FurnaceData.class, SpongeFurnaceData.class,
+                ImmutableFurnaceData.class, ImmutableSpongeFurnaceData.class, furnaceDataProcessor);
 
         // Values
         dataRegistry.registerValueProcessor(Keys.HEALTH, new HealthValueProcessor());
@@ -582,6 +596,10 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerValueProcessor(Keys.FISH_TYPE, new FishValueProcessor());
         dataRegistry.registerValueProcessor(Keys.REPRESENTED_PLAYER, new SkullRepresentedPlayerProcessor());
         dataRegistry.registerValueProcessor(Keys.REPRESENTED_PLAYER, new ItemSkullRepresentedPlayerValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.PASSED_BURN_TIME, new PassedBurnTimeValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.MAX_BURN_TIME, new MaxBurnTimeValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.PASSED_COOK_TIME, new PassedCookTimeValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.MAX_COOK_TIME, new MaxCookTimeValueProcessor());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/builder/block/tileentity/SpongeFurnaceBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/builder/block/tileentity/SpongeFurnaceBuilder.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.data.builder.block.tileentity;
 
 import net.minecraft.tileentity.TileEntityFurnace;
+
 import org.spongepowered.api.Game;
 import org.spongepowered.api.block.tileentity.carrier.Furnace;
 import org.spongepowered.api.data.DataQuery;
@@ -42,24 +43,37 @@ public class SpongeFurnaceBuilder extends SpongeLockableBuilder<Furnace> {
     @Override
     @SuppressWarnings("unchecked")
     public Optional<Furnace> build(DataView container) throws InvalidDataException {
-        Optional<Furnace> furnaceOptional = super.build(container);
+        final Optional<Furnace> furnaceOptional = super.build(container);
+
         if (!furnaceOptional.isPresent()) {
-            throw new InvalidDataException("The container had insufficient data to create a Banner tile entity!");
+            throw new InvalidDataException("The container had insufficient data to create a Furnace tile entity!");
         }
-        Furnace furnace = furnaceOptional.get();
-        if (container.contains(new DataQuery("CustomName"))) {
-            ((TileEntityFurnace) furnace).setCustomInventoryName(container.getString(new DataQuery("CustomName")).get());
+
+        final Furnace furnace = furnaceOptional.get();
+        final TileEntityFurnace tileEntityFurnace = (TileEntityFurnace) furnace;
+        final DataQuery burnTime = new DataQuery("BurnTime");
+        final DataQuery burnTimeTotal = new DataQuery("BurnTimeTotal");
+        final DataQuery cookTime = new DataQuery("CookTime");
+        final DataQuery cookTimeTotal = new DataQuery("CookTimeTotal");
+        final DataQuery customName = new DataQuery("CustomName");
+
+        if (container.contains(customName)) {
+            tileEntityFurnace.setCustomInventoryName(container.getString(customName).get());
         }
-        if (!container.contains(new DataQuery("BurnTime"))
-                || !container.contains(new DataQuery("CookTime"))
-                || !container.contains(new DataQuery("CookTimeTotal"))) {
-            throw new InvalidDataException("The provided container does not contain the data to make a Hopper!");
+
+        if (!container.contains(burnTime)
+                || !container.contains(burnTimeTotal)
+                || !container.contains(cookTime)
+                || !container.contains(cookTimeTotal)) {
+            throw new InvalidDataException("The provided container does not contain the data to make a Furnace!");
         }
-        // TODO Write FurnaceData
-//        furnace.setRemainingBurnTime(container.getInt(new DataQuery("BurnTime")).get());
-//        furnace.setRemainingCookTime(container.getInt(new DataQuery("CookTime")).get());
-        ((TileEntityFurnace) furnace).setField(3, container.getInt(new DataQuery("CookTimeTotal")).get());
-        ((TileEntityFurnace) furnace).validate();
+
+        tileEntityFurnace.setField(0, container.getInt(burnTime).get());
+        tileEntityFurnace.setField(1, container.getInt(burnTimeTotal).get());
+        tileEntityFurnace.setField(2, container.getInt(cookTime).get());
+        tileEntityFurnace.setField(3, container.getInt(cookTimeTotal).get());
+        tileEntityFurnace.markDirty();
+
         return Optional.of(furnace);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -24,13 +24,9 @@
  */
 package org.spongepowered.common.data.key;
 
-import static org.spongepowered.api.data.DataQuery.of;
-import static org.spongepowered.api.data.key.KeyFactory.makeListKey;
-import static org.spongepowered.api.data.key.KeyFactory.makeSetKey;
-import static org.spongepowered.api.data.key.KeyFactory.makeSingleKey;
+import com.google.common.collect.MapMaker;
 
 import com.flowpowered.math.vector.Vector3d;
-import com.google.common.collect.MapMaker;
 
 import org.spongepowered.api.GameProfile;
 import org.spongepowered.api.block.BlockType;
@@ -68,9 +64,14 @@ import org.spongepowered.api.util.Axis;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.common.registry.RegistryHelper;
 
-import java.awt.Color;
+import java.awt.*;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.spongepowered.api.data.DataQuery.of;
+import static org.spongepowered.api.data.key.KeyFactory.makeListKey;
+import static org.spongepowered.api.data.key.KeyFactory.makeSetKey;
+import static org.spongepowered.api.data.key.KeyFactory.makeSingleKey;
 
 @SuppressWarnings({"unchecked"})
 public class KeyRegistry {
@@ -162,12 +163,14 @@ public class KeyRegistry {
         keyMap.put("cooked_fish", makeSingleKey(CookedFish.class, Value.class, of("CookedFishType")));
         keyMap.put("fish_type", makeSingleKey(Fish.class, Value.class, of("RawFishType")));
         keyMap.put("represented_player", makeSingleKey(GameProfile.class, Value.class, of("RepresentedPlayer")));
-
+        keyMap.put("passed_burn_time", makeSingleKey(Integer.class, MutableBoundedValue.class, of("PassedBurnTime")));
+        keyMap.put("max_burn_time", makeSingleKey(Integer.class, MutableBoundedValue.class, of("MaxBurnTime")));
+        keyMap.put("passed_cook_time", makeSingleKey(Integer.class, MutableBoundedValue.class, of("PassedCookTime")));
+        keyMap.put("max_cook_time", makeSingleKey(Integer.class, MutableBoundedValue.class, of("MaxCookTime")));
     }
 
     private static Map<String, Key<?>> getKeyMap() {
         generateKeyMap();
         return keyMap;
     }
-
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/tileentity/ImmutableSpongeFurnaceData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/tileentity/ImmutableSpongeFurnaceData.java
@@ -1,0 +1,153 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.tileentity;
+
+import com.google.common.collect.ComparisonChain;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableFurnaceData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.FurnaceData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
+import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeFurnaceData;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
+
+public class ImmutableSpongeFurnaceData extends AbstractImmutableData<ImmutableFurnaceData, FurnaceData> implements ImmutableFurnaceData {
+
+    private final int passedBurnTime; //time (int) the fuel item already burned
+    private final int maxBurnTime; //time (int) the fuel can burn until its depleted
+    private final int passedCookTime; //time (int) the item already cooked
+    private final int maxCookTime; //time (int) the item have to cook
+
+    private final ImmutableBoundedValue<Integer> passedBurnTimeValue; // -> see passedBurnTime
+    private final ImmutableBoundedValue<Integer> maxBurnTimeValue; // -> see maxBurnTime
+    private final ImmutableBoundedValue<Integer> passedCookTimeValue; // -> see passedCookTime
+    private final ImmutableBoundedValue<Integer> maxCookTimeValue; // -> see maxCookTime
+
+    public ImmutableSpongeFurnaceData(int passedBurnTime, int maxBurnTime, int passedCookTime, int maxCookTime) {
+        super(ImmutableFurnaceData.class);
+
+        this.passedBurnTime = passedBurnTime;
+        this.maxBurnTime = maxBurnTime;
+        this.passedCookTime = passedCookTime;
+        this.maxCookTime = maxCookTime;
+
+        this.passedBurnTimeValue = SpongeValueBuilder.boundedBuilder(Keys.PASSED_BURN_TIME)
+                .minimum(0).maximum(this.maxBurnTime).defaultValue(0)
+                .actualValue(this.passedBurnTime).build().asImmutable();
+
+        this.maxBurnTimeValue = SpongeValueBuilder.boundedBuilder(Keys.MAX_BURN_TIME)
+                .minimum(0).maximum(Integer.MAX_VALUE).defaultValue(1600)
+                .actualValue(this.maxBurnTime).build().asImmutable();
+
+        this.passedCookTimeValue = SpongeValueBuilder.boundedBuilder(Keys.PASSED_COOK_TIME)
+                .minimum(0).maximum(this.maxCookTime).defaultValue(0)
+                .actualValue(this.passedCookTime).build().asImmutable();
+
+        this.maxCookTimeValue = SpongeValueBuilder.boundedBuilder(Keys.MAX_COOK_TIME)
+                .minimum(0).maximum(Integer.MAX_VALUE).defaultValue(200)
+                .actualValue(this.maxCookTime).build().asImmutable();
+
+        this.registerGetters();
+    }
+
+    @Override
+    protected void registerGetters() {
+        registerFieldGetter(Keys.PASSED_BURN_TIME, ImmutableSpongeFurnaceData.this::getPassedBurnTime);
+        registerKeyValue(Keys.PASSED_BURN_TIME, ImmutableSpongeFurnaceData.this::passedBurnTime);
+
+        registerFieldGetter(Keys.MAX_BURN_TIME, ImmutableSpongeFurnaceData.this::getMaxBurnTime);
+        registerKeyValue(Keys.MAX_BURN_TIME, ImmutableSpongeFurnaceData.this::maxBurnTime);
+
+        registerFieldGetter(Keys.PASSED_COOK_TIME, ImmutableSpongeFurnaceData.this::getPassedCookTime);
+        registerKeyValue(Keys.PASSED_COOK_TIME, ImmutableSpongeFurnaceData.this::passedCookTime);
+
+        registerFieldGetter(Keys.MAX_COOK_TIME, ImmutableSpongeFurnaceData.this::getMaxCookTime);
+        registerKeyValue(Keys.MAX_COOK_TIME, ImmutableSpongeFurnaceData.this::maxCookTime);
+    }
+
+    @Override
+    public ImmutableBoundedValue<Integer> passedBurnTime() {
+        return this.passedBurnTimeValue;
+    }
+
+    public int getPassedBurnTime() {
+        return this.passedBurnTime;
+    }
+
+    @Override
+    public ImmutableBoundedValue<Integer> maxBurnTime() {
+        return this.maxBurnTimeValue;
+    }
+
+    public int getMaxBurnTime() {
+        return this.maxBurnTime;
+    }
+
+    @Override
+    public ImmutableBoundedValue<Integer> passedCookTime() {
+        return this.passedCookTimeValue;
+    }
+
+    public int getPassedCookTime() {
+        return this.passedCookTime;
+    }
+
+    @Override
+    public ImmutableBoundedValue<Integer> maxCookTime() {
+        return this.maxCookTimeValue;
+    }
+
+    public int getMaxCookTime() {
+        return this.maxCookTime;
+    }
+
+    @Override
+    public FurnaceData asMutable() {
+        return new SpongeFurnaceData(this.passedBurnTime, this.maxBurnTime, this.passedCookTime, this.maxCookTime);
+    }
+
+    @Override
+    public int compareTo(ImmutableFurnaceData o) {
+        return ComparisonChain
+                .start()
+                .compare(o.passedBurnTime().get().intValue(), this.passedBurnTime)
+                .compare(o.maxBurnTime().get().intValue(), this.maxBurnTime)
+                .compare(o.passedCookTime().get().intValue(), this.passedCookTime)
+                .compare(o.maxCookTime().get().intValue(), this.maxCookTime)
+                .result();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer()
+                .set(Keys.PASSED_BURN_TIME, this.passedBurnTime)
+                .set(Keys.MAX_BURN_TIME, this.maxBurnTime)
+                .set(Keys.PASSED_COOK_TIME, this.passedCookTime)
+                .set(Keys.MAX_COOK_TIME, this.maxCookTime);
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeFurnaceData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeFurnaceData.java
@@ -1,0 +1,182 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.tileentity;
+
+import com.google.common.collect.ComparisonChain;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableFurnaceData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.FurnaceData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeFurnaceData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
+
+public class SpongeFurnaceData extends AbstractData<FurnaceData, ImmutableFurnaceData> implements FurnaceData {
+
+    private int passedBurnTime; //time (int) the fuel item already burned
+    private int maxBurnTime; //time (int) the fuel can burn until its depleted
+    private int passedCookTime; //time (int) the item already cooked
+    private int maxCookTime; //time (int) the item have to cook
+
+    public SpongeFurnaceData() {
+        this(0, 0, 0, 0);
+    }
+
+    public SpongeFurnaceData(int passedBurnTime, int maxBurnTime, int passedCookTime, int maxCookTime) {
+
+        super(FurnaceData.class);
+
+        this.passedBurnTime = passedBurnTime;
+        this.maxBurnTime = maxBurnTime;
+        this.passedCookTime = passedCookTime;
+        this.maxCookTime = maxCookTime;
+
+        this.registerGettersAndSetters();
+    }
+
+    @Override
+    protected void registerGettersAndSetters() {
+        registerFieldGetter(Keys.PASSED_BURN_TIME, SpongeFurnaceData.this::getPassedBurnTime);
+        registerFieldSetter(Keys.PASSED_BURN_TIME, SpongeFurnaceData.this::setPassedBurnTime);
+        registerKeyValue(Keys.PASSED_BURN_TIME, SpongeFurnaceData.this::passedBurnTime);
+
+        registerFieldGetter(Keys.MAX_BURN_TIME, SpongeFurnaceData.this::getMaxBurnTime);
+        registerFieldSetter(Keys.MAX_BURN_TIME, SpongeFurnaceData.this::setMaxBurnTime);
+        registerKeyValue(Keys.MAX_BURN_TIME, SpongeFurnaceData.this::maxBurnTime);
+
+        registerFieldGetter(Keys.PASSED_COOK_TIME, SpongeFurnaceData.this::getPassedCookTime);
+        registerFieldSetter(Keys.PASSED_COOK_TIME, SpongeFurnaceData.this::setPassedCookTime);
+        registerKeyValue(Keys.PASSED_COOK_TIME, SpongeFurnaceData.this::passedCookTime);
+
+        registerFieldGetter(Keys.MAX_COOK_TIME, SpongeFurnaceData.this::getMaxCookTime);
+        registerFieldSetter(Keys.MAX_COOK_TIME, SpongeFurnaceData.this::setMaxCookTime);
+        registerKeyValue(Keys.MAX_COOK_TIME, SpongeFurnaceData.this::maxCookTime);
+    }
+
+    @Override
+    public MutableBoundedValue<Integer> passedBurnTime() {
+        return SpongeValueBuilder.boundedBuilder(Keys.PASSED_BURN_TIME)
+                .minimum(0)
+                .maximum(this.maxBurnTime)
+                .defaultValue(0)
+                .actualValue(this.passedBurnTime)
+                .build();
+    }
+
+    public int getPassedBurnTime() {
+        return this.passedBurnTime;
+    }
+
+    public void setPassedBurnTime(int passedBurnTime) {
+        this.passedBurnTime = passedBurnTime;
+    }
+
+    @Override
+    public MutableBoundedValue<Integer> maxBurnTime() {
+        return SpongeValueBuilder.boundedBuilder(Keys.MAX_BURN_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(1600)
+                .actualValue(this.maxBurnTime)
+                .build();
+    }
+
+    public int getMaxBurnTime() {
+        return this.maxBurnTime;
+    }
+
+    public void setMaxBurnTime(int maxBurnTime) {
+        this.maxBurnTime = maxBurnTime;
+    }
+
+    @Override
+    public MutableBoundedValue<Integer> passedCookTime() {
+        return SpongeValueBuilder.boundedBuilder(Keys.PASSED_COOK_TIME)
+                .minimum(0)
+                .maximum(this.maxCookTime)
+                .defaultValue(0)
+                .actualValue(this.passedCookTime)
+                .build();
+    }
+
+    public int getPassedCookTime() {
+        return this.passedCookTime;
+    }
+
+    public void setPassedCookTime(int passedCookTime) {
+        this.passedCookTime = passedCookTime;
+    }
+
+    @Override
+    public MutableBoundedValue<Integer> maxCookTime() {
+        return SpongeValueBuilder.boundedBuilder(Keys.MAX_COOK_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(200)
+                .actualValue(this.maxCookTime)
+                .build();
+    }
+
+    public int getMaxCookTime() {
+        return this.maxCookTime;
+    }
+
+    public void setMaxCookTime(int maxCookTime) {
+        this.maxCookTime = maxCookTime;
+    }
+
+    @Override
+    public FurnaceData copy() {
+        return new SpongeFurnaceData(this.passedBurnTime, this.maxBurnTime, this.passedCookTime, this.maxCookTime);
+    }
+
+    @Override
+    public ImmutableFurnaceData asImmutable() {
+        return new ImmutableSpongeFurnaceData(this.passedBurnTime, this.maxBurnTime, this.passedCookTime, this.maxCookTime);
+    }
+
+    @Override
+    public int compareTo(FurnaceData o) {
+        return ComparisonChain
+                .start()
+                .compare(o.passedBurnTime().get().intValue(), this.passedBurnTime)
+                .compare(o.maxBurnTime().get().intValue(), this.maxBurnTime)
+                .compare(o.passedCookTime().get().intValue(), this.passedCookTime)
+                .compare(o.maxCookTime().get().intValue(), this.maxCookTime)
+                .result();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer()
+                .set(Keys.PASSED_BURN_TIME, this.passedBurnTime)
+                .set(Keys.MAX_BURN_TIME, this.maxBurnTime)
+                .set(Keys.PASSED_COOK_TIME, this.passedCookTime)
+                .set(Keys.MAX_COOK_TIME, this.maxCookTime);
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/tileentity/FurnaceDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/tileentity/FurnaceDataProcessor.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.tileentity;
+
+import com.google.common.collect.Maps;
+
+import net.minecraft.tileentity.TileEntityFurnace;
+
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableFurnaceData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.FurnaceData;
+import org.spongepowered.api.world.World;
+import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeFurnaceData;
+import org.spongepowered.common.data.processor.common.AbstractTileEntityDataProcessor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FurnaceDataProcessor extends AbstractTileEntityDataProcessor<TileEntityFurnace, FurnaceData, ImmutableFurnaceData> {
+
+    public FurnaceDataProcessor() {
+        super(TileEntityFurnace.class);
+    }
+
+    @Override
+    protected boolean doesDataExist(TileEntityFurnace tileEntity) {
+        return true; //if it's an TileEntityFurnace it always has the data
+    }
+
+    @Override
+    protected boolean set(TileEntityFurnace tileEntity, Map<Key<?>, Object> keyValues) {
+        // getField() / setField()
+        //
+        // 0 : furnaceBurnTime -> NOT equal to passedBurnTime --> the remaining burn time
+        // 1 : currentItemBurnTime -> equal to maxBurnTime
+        // 2 : cookTime -> equal to passedCookTime
+        // 3 : totalCookTime -> equal to maxCookTime
+
+        final int passedBurnTime = (Integer) keyValues.get(Keys.PASSED_BURN_TIME); //time (int) the fuel item already burned
+        final int maxBurnTime = (Integer) keyValues.get(Keys.MAX_BURN_TIME); //time (int) the fuel can burn until its depleted
+        final int passedCookTime = (Integer) keyValues.get(Keys.PASSED_COOK_TIME); //time (int) the item already cooked
+        final int maxCookTime = (Integer) keyValues.get(Keys.MAX_COOK_TIME); //time (int) the item have to cook
+
+        if (passedBurnTime > maxBurnTime || passedCookTime > maxCookTime) {
+            return false;
+        }
+
+        final boolean needsUpdate = !tileEntity.isBurning() && maxBurnTime > 0 || tileEntity.isBurning() && maxBurnTime == 0;
+
+        if (needsUpdate) {
+            final World world = (World) tileEntity.getWorld();
+            world.setBlockType(tileEntity.getPos().getX(), tileEntity.getPos().getY(),
+                    tileEntity.getPos().getZ(), maxBurnTime > 0 ? BlockTypes.LIT_FURNACE : BlockTypes.FURNACE);
+            tileEntity = (TileEntityFurnace) tileEntity.getWorld().getTileEntity(tileEntity.getPos());
+        }
+
+        tileEntity.setField(0, maxBurnTime - passedBurnTime);
+        tileEntity.setField(1, maxBurnTime);
+        tileEntity.setField(2, passedCookTime);
+        tileEntity.setField(3, maxCookTime);
+
+        return true;
+    }
+
+    @Override
+    protected Map<Key<?>, ?> getValues(TileEntityFurnace tileEntity) {
+        HashMap<Key<?>, Integer> values = Maps.newHashMapWithExpectedSize(3);
+
+        final int passedBurnTime = tileEntity.getField(1) - tileEntity.getField(0);
+        final int maxBurnTime = tileEntity.getField(1);
+        final int passedCookTime = tileEntity.getField(2);
+        final int maxCookTime = tileEntity.getField(3);
+
+        values.put(Keys.PASSED_BURN_TIME, passedBurnTime);
+        values.put(Keys.MAX_BURN_TIME, maxBurnTime);
+        values.put(Keys.PASSED_COOK_TIME, passedCookTime);
+        values.put(Keys.MAX_COOK_TIME, maxCookTime);
+
+        return values;
+    }
+
+    @Override
+    protected FurnaceData createManipulator() {
+        return new SpongeFurnaceData();
+    }
+
+    @Override
+    public Optional<FurnaceData> fill(DataContainer container, FurnaceData furnaceData) {
+        if (!container.contains(Keys.PASSED_BURN_TIME.getQuery()) ||
+                !container.contains(Keys.MAX_BURN_TIME.getQuery()) ||
+                !container.contains(Keys.PASSED_COOK_TIME.getQuery()) ||
+                !container.contains(Keys.MAX_COOK_TIME.getQuery())) {
+            return Optional.empty();
+        }
+
+        final int passedBurnTime = container.getInt(Keys.PASSED_BURN_TIME.getQuery()).get();
+        final int maxBurnTime = container.getInt(Keys.MAX_BURN_TIME.getQuery()).get();
+        final int passedCookTime = container.getInt(Keys.PASSED_COOK_TIME.getQuery()).get();
+        final int maxCookTime = container.getInt(Keys.MAX_COOK_TIME.getQuery()).get();
+
+        furnaceData.set(Keys.PASSED_BURN_TIME, passedBurnTime);
+        furnaceData.set(Keys.MAX_BURN_TIME, maxBurnTime);
+        furnaceData.set(Keys.PASSED_COOK_TIME, passedCookTime);
+        furnaceData.set(Keys.MAX_COOK_TIME, maxCookTime);
+
+        return Optional.of(furnaceData);
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionBuilder.failNoData(); //cannot be removed
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/MaxBurnTimeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/MaxBurnTimeValueProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.tileentity;
+
+import net.minecraft.tileentity.TileEntityFurnace;
+
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.world.World;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
+
+import java.util.Optional;
+
+public class MaxBurnTimeValueProcessor extends AbstractSpongeValueProcessor<TileEntityFurnace, Integer, MutableBoundedValue<Integer>> {
+
+    public MaxBurnTimeValueProcessor() {
+        super(TileEntityFurnace.class, Keys.MAX_BURN_TIME);
+    }
+
+    @Override
+    protected MutableBoundedValue<Integer> constructValue(Integer defaultValue) {
+        return SpongeValueBuilder.boundedBuilder(Keys.MAX_BURN_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(defaultValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(TileEntityFurnace container, Integer value) {
+        if (!container.isBurning() && value > 0 || container.isBurning() && value == 0) {
+            final World world = (World) container.getWorld();
+            world.setBlockType(container.getPos().getX(), container.getPos().getY(),
+                    container.getPos().getZ(), value > 0 ? BlockTypes.LIT_FURNACE : BlockTypes.FURNACE);
+            container = (TileEntityFurnace) container.getWorld().getTileEntity(container.getPos());
+        }
+        container.setField(1, value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Integer> getVal(TileEntityFurnace container) {
+        return Optional.of(container.getField(1));
+    }
+
+    @Override
+    protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
+        return SpongeValueBuilder.boundedBuilder(Keys.MAX_BURN_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(1000)
+                .actualValue(value)
+                .build()
+                .asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData(); //cannot be removed
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/MaxCookTimeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/MaxCookTimeValueProcessor.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.tileentity;
+
+import net.minecraft.tileentity.TileEntityFurnace;
+
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
+
+import java.util.Optional;
+
+public class MaxCookTimeValueProcessor extends AbstractSpongeValueProcessor<TileEntityFurnace, Integer, MutableBoundedValue<Integer>> {
+
+    public MaxCookTimeValueProcessor() {
+        super(TileEntityFurnace.class, Keys.MAX_COOK_TIME);
+    }
+
+    @Override
+    protected MutableBoundedValue<Integer> constructValue(Integer defaultValue) {
+        return SpongeValueBuilder.boundedBuilder(Keys.MAX_COOK_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(defaultValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(TileEntityFurnace container, Integer value) {
+        if(container.getStackInSlot(0) == null) return false; //Item cannot be null, the time depends on it
+
+        container.setField(3, value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Integer> getVal(TileEntityFurnace container) {
+        return Optional.of(container.getStackInSlot(0) != null ? container.getField(3) : 0); //Item cannot be null, the time depends on it
+    }
+
+    @Override
+    protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
+        return SpongeValueBuilder.boundedBuilder(Keys.MAX_COOK_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(200)
+                .actualValue(value)
+                .build()
+                .asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData(); //cannot be removed
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/PassedBurnTimeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/PassedBurnTimeValueProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.tileentity;
+
+import net.minecraft.tileentity.TileEntityFurnace;
+
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
+
+import java.util.Optional;
+
+public class PassedBurnTimeValueProcessor extends AbstractSpongeValueProcessor<TileEntityFurnace, Integer, MutableBoundedValue<Integer>> {
+
+    public PassedBurnTimeValueProcessor() {
+        super(TileEntityFurnace.class, Keys.PASSED_BURN_TIME);
+    }
+
+    @Override
+    protected MutableBoundedValue<Integer> constructValue(Integer defaultValue) {
+        return SpongeValueBuilder.boundedBuilder(Keys.PASSED_BURN_TIME)
+                .minimum(0)
+                .maximum(1600)
+                .defaultValue(defaultValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(TileEntityFurnace container, Integer value) {
+        if(value > container.getField(1)){ //value cannot be higher than the maximum
+            return false;
+        }
+        container.setField(0, container.getField(1) - value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Integer> getVal(TileEntityFurnace container) {
+        return Optional.of(container.isBurning() ? container.getField(1) - container.getField(0) : 0); //When the furnace is not burning, the value is 0
+    }
+
+    @Override
+    protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
+        return SpongeValueBuilder.boundedBuilder(Keys.PASSED_BURN_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return null; //cannot be removed
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/PassedCookTimeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/PassedCookTimeValueProcessor.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.tileentity;
+
+import net.minecraft.tileentity.TileEntityFurnace;
+
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
+
+import java.util.Optional;
+
+public class PassedCookTimeValueProcessor extends AbstractSpongeValueProcessor<TileEntityFurnace, Integer, MutableBoundedValue<Integer>> {
+
+    public PassedCookTimeValueProcessor() {
+        super(TileEntityFurnace.class, Keys.PASSED_COOK_TIME);
+    }
+
+    @Override
+    protected MutableBoundedValue<Integer> constructValue(Integer defaultValue) {
+        return SpongeValueBuilder.boundedBuilder(Keys.PASSED_COOK_TIME)
+                .minimum(0)
+                .maximum(200) //TODO
+                .defaultValue(defaultValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(TileEntityFurnace container, Integer value) {
+        if(container.getStackInSlot(0) == null || value > container.getField(3)){ //The passedCookTime of nothing cannot be set | Cannot be higher than the maximum
+            return false;
+        }
+
+        container.setField(2, value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Integer> getVal(TileEntityFurnace container) {
+        return Optional.of(container.getStackInSlot(0) != null ? container.getField(2) : 0); //The passedCookTime of nothing cannot be set
+    }
+
+    @Override
+    protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
+        return SpongeValueBuilder.boundedBuilder(Keys.PASSED_COOK_TIME)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(200)
+                .actualValue(value)
+                .build()
+                .asImmutable();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData(); //cannot be removed
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntityFurnace.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntityFurnace.java
@@ -43,6 +43,7 @@ public abstract class MixinTileEntityFurnace extends MixinTileEntityLockable imp
     public DataContainer toContainer() {
         DataContainer container = super.toContainer();
         container.set(of("BurnTime"), this.getField(0));
+        container.set(of("BurnTimeTotal"), this.getField(1));
         container.set(of("CookTime"), this.getField(3) - this.getField(2));
         container.set(of("CookTimeTotal"), this.getField(3));
         if (this.furnaceCustomName != null) {


### PR DESCRIPTION
# The FurnaceData gets a full upgrade

## Why?
- The last code was very unstructured, for the same results many different ways was used.
- The values was picked very unthinkingly

## But why it would be better than the last version?
#### - Now it has an architecture:
all values correspond to the underlaying values:

Underlaying Value | Value for Implementation
------------ | -------------
furnaceBurnTime | passedBurnTime (Thats not the same but it is calculated out of it)
currentItemBurnTime | maxBurnTime
cookTime | passedCookTime
totalCookTime | maxCookTime
#### - Now im checking the structure and the efficiency before any commit

## Status
#### Implementation of `SpongeFurnaceData`.
- [x] Registration of field getters and setters
- [x] Accurately used the appropriate `AbstractData` implementation

#### Implementation of `ImmutableSpongeFurnaceData`
- [x] Accurately extended the appropriate `AbstractImmutableData` implementation
- [x] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [x] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

#### Implementation of the `PassedBurnTimeValueProcessor`:
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

#### Implementation of the `MaxBurnTimeValueProcessor`:
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary)

#### Implementation of the `PassedCookTimeValueProcessor`:
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary)

#### Implementation of the `MaxCookTimeValueProcessor`:
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary)

#### Registration:
- [x] Registered the `Key` correctly by `FIELD_NAME` in the `KeyRegistry`
- [x] Registered the `DataProcessor`s` in `SpongeSerializationRegistry`
- [x] Registered the `ValueProcessor`s in the `SpongeSerializationRegistry`

## Test Plugin

https://gist.github.com/Feeliiix/0d9e456ae455ffc60e29