### PR TITLE
[WIP] Data API cleanup

### DIFF
--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -144,6 +144,9 @@ public class KeyRegistry {
         keyMap.put("spawner_minimum_delay", makeSingleKey(Short.class, MutableBoundedValue.class, of("SpawnerMinimumDelay")));
         keyMap.put("connected_directions", makeSetKey(Direction.class, of("ConnectedDirections")));
         keyMap.put("connected_north", makeSingleKey(Boolean.class, Value.class, of("ConnectedNorth")));
+        keyMap.put("connected_south", makeSingleKey(Boolean.class, Value.class, of("ConnectedSouth")));
+        keyMap.put("connected_east", makeSingleKey(Boolean.class, Value.class, of("ConnectedEast")));
+        keyMap.put("connected_west", makeSingleKey(Boolean.class, Value.class, of("ConnectedWest")));
         keyMap.put("direction", makeSingleKey(Direction.class, Value.class, of("Direction")));
         keyMap.put("dirt_type", makeSingleKey(DirtType.class, Value.class, of("DirtType")));
         keyMap.put("disguised_block_type", makeSingleKey(DisguisedBlockType.class, Value.class, of("DisguisedBlockType")));

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeColoredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeColoredData.java
@@ -36,6 +36,8 @@ import java.awt.Color;
 
 public class ImmutableSpongeColoredData extends AbstractImmutableSingleData<Color, ImmutableColoredData, ColoredData> implements ImmutableColoredData {
 
+    private final ImmutableValue<Color> immutableValue = new ImmutableSpongeValue<>(Keys.COLOR, Color.BLACK, this.value);
+    
     public ImmutableSpongeColoredData(Color value) {
         super(ImmutableColoredData.class, value, Keys.COLOR);
     }
@@ -52,7 +54,7 @@ public class ImmutableSpongeColoredData extends AbstractImmutableSingleData<Colo
 
     @Override
     public ImmutableValue<Color> color() {
-        return ImmutableSpongeValue.cachedOf(Keys.COLOR, Color.BLACK, this.value);
+        return immutableValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeCooldownData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeCooldownData.java
@@ -28,41 +28,27 @@ import com.google.common.collect.ComparisonChain;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableCooldownData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.CooldownData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeCooldownData;
+import org.spongepowered.common.data.util.ComparatorUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
-public class ImmutableSpongeCooldownData extends AbstractImmutableSingleData<Integer, ImmutableCooldownData, CooldownData>
+public class ImmutableSpongeCooldownData extends AbstractImmutableBoundedComparableData<Integer, ImmutableCooldownData, CooldownData>
         implements ImmutableCooldownData {
 
     public ImmutableSpongeCooldownData(int value) {
-        super(ImmutableCooldownData.class, value, Keys.COOLDOWN);
+        super(ImmutableCooldownData.class, value, Keys.COOLDOWN, ComparatorUtil.intComparator(), SpongeCooldownData.class, 0, Integer.MAX_VALUE, 0);
     }
 
     public ImmutableSpongeCooldownData() {
-        this(-1);
+        this(0);
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return cooldown();
-    }
-
-    @Override
-    public CooldownData asMutable() {
-        return new SpongeCooldownData(this.getValue());
-    }
-
-    @Override
-    public ImmutableValue<Integer> cooldown() {
-        return ImmutableSpongeValue.cachedOf(Keys.COOLDOWN, -1, this.getValue());
-    }
-
-    @Override
-    public int compareTo(ImmutableCooldownData o) {
-        return ComparisonChain.start()
-                .compare(this.getValue(), o.cooldown().get())
-                .result();
+    public ImmutableBoundedValue<Integer> cooldown() {
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeDisplayNameData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeDisplayNameData.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.data.manipulator.immutable;
 
+import com.google.common.collect.ComparisonChain;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
@@ -41,31 +42,41 @@ public class ImmutableSpongeDisplayNameData extends AbstractImmutableData<Immuta
     private final Text displayName;
     private final boolean displays;
 
+    private final ImmutableValue<Text> nameValue;
+    private final ImmutableValue<Boolean> displaysValue;
+
     public ImmutableSpongeDisplayNameData(Text displayName, boolean displays) {
         super(ImmutableDisplayNameData.class);
         this.displayName = displayName;
         this.displays = displays;
+
+        this.nameValue = new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, this.displayName);
+        this.displaysValue = ImmutableSpongeValue.cachedOf(Keys.SHOWS_DISPLAY_NAME, false, this.displays);
+
         registerGetters();
     }
 
     @Override
     public ImmutableValue<Text> displayName() {
-        return new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, this.displayName);
+        return nameValue;
     }
 
     @Override
     public ImmutableValue<Boolean> customNameVisible() {
-        return ImmutableSpongeValue.cachedOf(Keys.SHOWS_DISPLAY_NAME, false, this.displays);
+        return displaysValue;
     }
 
     @Override
     public DisplayNameData asMutable() {
-        return new SpongeDisplayNameData(this.displayName).setDisplays(this.displays);
+        return new SpongeDisplayNameData(this.displayName, this.displays);
     }
 
     @Override
     public int compareTo(ImmutableDisplayNameData o) {
-        return 0;
+        return ComparisonChain.start()
+                .compare(Texts.json().to(o.get(Keys.DISPLAY_NAME).get()), Texts.json().to(this.displayName))
+                .compare(o.get(Keys.SHOWS_DISPLAY_NAME).get(), this.displays)
+                .result();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeFireworkData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeFireworkData.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.immutable;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
-
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
@@ -37,7 +35,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeFireworkData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 
 import java.util.List;
@@ -47,21 +45,34 @@ public class ImmutableSpongeFireworkData extends AbstractImmutableData<Immutable
     private final ImmutableList<FireworkEffect> fireworkEffects;
     private final int modifier;
 
+    private final ImmutableListValue<FireworkEffect> effectsValue;
+    private final ImmutableBoundedValue<Integer> modifierValue;
+
     public ImmutableSpongeFireworkData(List<FireworkEffect> effects, int flightModifier) {
         super(ImmutableFireworkData.class);
         this.fireworkEffects = ImmutableList.copyOf(effects);
         this.modifier = flightModifier;
+
+        this.effectsValue = new ImmutableSpongeListValue<>(Keys.FIREWORK_EFFECTS, this.fireworkEffects);
+        this.modifierValue = SpongeValueBuilder.boundedBuilder(Keys.FIREWORK_FLIGHT_MODIFIER)
+                .actualValue(this.modifier)
+                .defaultValue(0)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
         registerGetters();
     }
 
     @Override
     public ImmutableListValue<FireworkEffect> effects() {
-        return new ImmutableSpongeListValue<>(Keys.FIREWORK_EFFECTS, this.fireworkEffects);
+        return effectsValue;
     }
 
     @Override
     public ImmutableBoundedValue<Integer> flightModifier() {
-        return new ImmutableSpongeBoundedValue<>(Keys.FIREWORK_FLIGHT_MODIFIER, 0, 0, intComparator(), Integer.MAX_VALUE, this.modifier);
+        return modifierValue;
     }
 
     @Override
@@ -81,8 +92,20 @@ public class ImmutableSpongeFireworkData extends AbstractImmutableData<Immutable
             .set(Keys.FIREWORK_FLIGHT_MODIFIER, this.modifier);
     }
 
+    public ImmutableList<FireworkEffect> getFireworkEffects() {
+        return fireworkEffects;
+    }
+
+    public int getModifier() {
+        return modifier;
+    }
+
     @Override
     protected void registerGetters() {
-        // TODO
+        registerFieldGetter(Keys.FIREWORK_EFFECTS, ImmutableSpongeFireworkData.this::getFireworkEffects);
+        registerFieldGetter(Keys.FIREWORK_FLIGHT_MODIFIER, ImmutableSpongeFireworkData.this::getModifier);
+
+        registerKeyValue(Keys.FIREWORK_EFFECTS, ImmutableSpongeFireworkData.this::effects);
+        registerKeyValue(Keys.FIREWORK_FLIGHT_MODIFIER, ImmutableSpongeFireworkData.this::flightModifier);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedItemData.java
@@ -36,13 +36,15 @@ import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeRepresentedItemData extends AbstractImmutableSingleData<ItemStackSnapshot, ImmutableRepresentedItemData, RepresentedItemData> implements ImmutableRepresentedItemData {
 
+    private final ImmutableValue<ItemStackSnapshot> immutableValue = new ImmutableSpongeValue<>(Keys.REPRESENTED_ITEM, this.value);
+
     public ImmutableSpongeRepresentedItemData(ItemStackSnapshot itemStack) {
         super(ImmutableRepresentedItemData.class, itemStack, Keys.REPRESENTED_ITEM);
     }
 
     @Override
     public ImmutableValue<ItemStackSnapshot> item() {
-        return new ImmutableSpongeValue<>(Keys.REPRESENTED_ITEM, this.value);
+        return immutableValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedPlayerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedPlayerData.java
@@ -40,6 +40,8 @@ public class ImmutableSpongeRepresentedPlayerData
         extends AbstractImmutableSingleData<GameProfile, ImmutableRepresentedPlayerData, RepresentedPlayerData>
         implements ImmutableRepresentedPlayerData {
 
+    private final ImmutableValue<GameProfile> immutableValue = new ImmutableSpongeValue<>(Keys.REPRESENTED_PLAYER, this.value);
+
     public ImmutableSpongeRepresentedPlayerData() {
         this(SpongeRepresentedPlayerData.NULL_PROFILE);
     }
@@ -50,7 +52,7 @@ public class ImmutableSpongeRepresentedPlayerData
 
     @Override
     public ImmutableValue<GameProfile> owner() {
-        return new ImmutableSpongeValue<GameProfile>(this.usedKey, this.value);
+        return immutableValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeTargetedLocationData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeTargetedLocationData.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.data.manipulator.immutable;
 
 import com.flowpowered.math.vector.Vector3d;
+import com.google.common.collect.ComparisonChain;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableTargetedLocationData;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
@@ -37,6 +38,8 @@ import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeTargetedLocationData extends AbstractImmutableSingleData<Location<World>, ImmutableTargetedLocationData, TargetedLocationData>
     implements ImmutableTargetedLocationData {
+
+    private final ImmutableValue<Location<World>> immutableValue = new ImmutableSpongeValue<>(Keys.TARGETED_LOCATION, this.value);
 
     public ImmutableSpongeTargetedLocationData(Location<World> value) {
         super(ImmutableTargetedLocationData.class, value, Keys.TARGETED_LOCATION);
@@ -54,11 +57,14 @@ public class ImmutableSpongeTargetedLocationData extends AbstractImmutableSingle
 
     @Override
     public ImmutableValue<Location<World>> target() {
-        return new ImmutableSpongeValue<>(Keys.TARGETED_LOCATION, this.value);
+        return immutableValue;
     }
 
     @Override
     public int compareTo(ImmutableTargetedLocationData o) {
-        return 0;
+        return ComparisonChain.start()
+                .compare(o.get(Keys.TARGETED_LOCATION).get().getPosition(), this.getValue().getPosition())
+                .compare(o.get(Keys.TARGETED_LOCATION).get().getExtent().getName(), this.getValue().getExtent().getName())
+                .result();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeConnectedDirectionData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeConnectedDirectionData.java
@@ -45,35 +45,48 @@ public class ImmutableSpongeConnectedDirectionData extends AbstractImmutableData
 
     private final ImmutableSet<Direction> directions;
 
+    private final ImmutableSetValue<Direction> directionsValue;
+    private final ImmutableValue<Boolean> northValue;
+    private final ImmutableValue<Boolean> southValue;
+    private final ImmutableValue<Boolean> eastValue;
+    private final ImmutableValue<Boolean> westValue;
+
     public ImmutableSpongeConnectedDirectionData(Set<Direction> directions) {
         super(ImmutableConnectedDirectionData.class);
         this.directions = Sets.immutableEnumSet(directions);
+
+        this.directionsValue = new ImmutableSpongeSetValue<>(Keys.CONNECTED_DIRECTIONS, this.directions);
+        this.northValue = ImmutableSpongeValue.cachedOf(Keys.CONNECTED_NORTH, false, this.directions.contains(Direction.NORTH));
+        this.southValue = ImmutableSpongeValue.cachedOf(Keys.CONNECTED_SOUTH, false, this.directions.contains(Direction.SOUTH));
+        this.eastValue = ImmutableSpongeValue.cachedOf(Keys.CONNECTED_EAST, false, this.directions.contains(Direction.EAST));
+        this.westValue = ImmutableSpongeValue.cachedOf(Keys.CONNECTED_WEST, false, this.directions.contains(Direction.WEST));
+
         registerGetters();
     }
 
     @Override
     public ImmutableSetValue<Direction> connectedDirections() {
-        return new ImmutableSpongeSetValue<>(Keys.CONNECTED_DIRECTIONS, this.directions);
+        return directionsValue;
     }
 
     @Override
     public ImmutableValue<Boolean> connectedNorth() {
-        return ImmutableSpongeValue.cachedOf(Keys.CONNECTED_NORTH, false, this.directions.contains(Direction.NORTH));
+        return northValue;
     }
 
     @Override
     public ImmutableValue<Boolean> connectedSouth() {
-        return ImmutableSpongeValue.cachedOf(Keys.CONNECTED_SOUTH, false, this.directions.contains(Direction.SOUTH));
+        return southValue;
     }
 
     @Override
     public ImmutableValue<Boolean> connectedEast() {
-        return ImmutableSpongeValue.cachedOf(Keys.CONNECTED_EAST, false, this.directions.contains(Direction.EAST));
+        return eastValue;
     }
 
     @Override
     public ImmutableValue<Boolean> connectedWest() {
-        return ImmutableSpongeValue.cachedOf(Keys.CONNECTED_WEST, false, this.directions.contains(Direction.WEST));
+        return westValue;
     }
 
     @Override
@@ -96,8 +109,38 @@ public class ImmutableSpongeConnectedDirectionData extends AbstractImmutableData
             .set(Keys.CONNECTED_WEST.getQuery(), this.directions.contains(Direction.WEST));
     }
 
+    private Set<Direction> getDirections() {
+        return directions;
+    }
+
+    private boolean isNorth() {
+        return this.directions.contains(Direction.NORTH);
+    }
+
+    private boolean isSouth() {
+        return this.directions.contains(Direction.SOUTH);
+    }
+
+    private boolean isEast() {
+        return this.directions.contains(Direction.EAST);
+    }
+
+    private boolean isWest() {
+        return this.directions.contains(Direction.WEST);
+    }
+
     @Override
     protected void registerGetters() {
-        // TODO
+        registerKeyValue(Keys.CONNECTED_DIRECTIONS, ImmutableSpongeConnectedDirectionData.this::connectedDirections);
+        registerKeyValue(Keys.CONNECTED_NORTH, ImmutableSpongeConnectedDirectionData.this::connectedNorth);
+        registerKeyValue(Keys.CONNECTED_SOUTH, ImmutableSpongeConnectedDirectionData.this::connectedSouth);
+        registerKeyValue(Keys.CONNECTED_EAST, ImmutableSpongeConnectedDirectionData.this::connectedEast);
+        registerKeyValue(Keys.CONNECTED_WEST, ImmutableSpongeConnectedDirectionData.this::connectedWest);
+
+        registerFieldGetter(Keys.CONNECTED_DIRECTIONS, ImmutableSpongeConnectedDirectionData.this::getDirections);
+        registerFieldGetter(Keys.CONNECTED_NORTH, ImmutableSpongeConnectedDirectionData.this::isNorth);
+        registerFieldGetter(Keys.CONNECTED_SOUTH, ImmutableSpongeConnectedDirectionData.this::isSouth);
+        registerFieldGetter(Keys.CONNECTED_EAST, ImmutableSpongeConnectedDirectionData.this::isEast);
+        registerFieldGetter(Keys.CONNECTED_WEST, ImmutableSpongeConnectedDirectionData.this::isWest);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeLayeredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeLayeredData.java
@@ -35,6 +35,10 @@ import org.spongepowered.common.data.manipulator.mutable.block.SpongeLayeredData
 
 public class ImmutableSpongeLayeredData extends AbstractImmutableBoundedComparableData<Integer, ImmutableLayeredData, LayeredData> implements ImmutableLayeredData {
 
+    public ImmutableSpongeLayeredData(int value) {
+        this(value, 0, Integer.MAX_VALUE);
+    }
+
     public ImmutableSpongeLayeredData(int value, int lowerBound, int upperBound) {
         super(ImmutableLayeredData.class, value, Keys.LAYER, intComparator(), SpongeLayeredData.class, lowerBound, upperBound, 0);
     }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeMoistureData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeMoistureData.java
@@ -35,6 +35,10 @@ import org.spongepowered.common.data.manipulator.mutable.block.SpongeMoistureDat
 
 public class ImmutableSpongeMoistureData extends AbstractImmutableBoundedComparableData<Integer, ImmutableMoistureData, MoistureData> implements ImmutableMoistureData {
 
+    public ImmutableSpongeMoistureData(int value) {
+        this(value, 0, Integer.MAX_VALUE);
+    }
+
     public ImmutableSpongeMoistureData(int value, int lowerBound, int upperBound) {
         super(ImmutableMoistureData.class, value, Keys.MOISTURE, intComparator(), SpongeMoistureData.class, lowerBound, upperBound, 0);
     }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeRedstonePoweredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeRedstonePoweredData.java
@@ -35,6 +35,10 @@ import org.spongepowered.common.data.manipulator.mutable.block.SpongeRedstonePow
 
 public class ImmutableSpongeRedstonePoweredData extends AbstractImmutableBoundedComparableData<Integer, ImmutableRedstonePoweredData, RedstonePoweredData> implements ImmutableRedstonePoweredData {
 
+    public ImmutableSpongeRedstonePoweredData(int value) {
+        this(value, 0, 15);
+    }
+
     public ImmutableSpongeRedstonePoweredData(int value, int lowerBound, int upperBound) {
         super(ImmutableRedstonePoweredData.class, value, Keys.POWER, intComparator(), SpongeRedstonePoweredData.class, lowerBound, upperBound, 0);
     }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeWireAttachmentData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeWireAttachmentData.java
@@ -47,34 +47,47 @@ public class ImmutableSpongeWireAttachmentData extends AbstractImmutableData<Imm
 
     private final ImmutableMap<Direction, WireAttachmentType> wireAttachmentMap;
 
+    private final ImmutableMapValue<Direction, WireAttachmentType> wireAttachmentsValue;
+    private final ImmutableValue<WireAttachmentType> northValue;
+    private final ImmutableValue<WireAttachmentType> southValue;
+    private final ImmutableValue<WireAttachmentType> eastValue;
+    private final ImmutableValue<WireAttachmentType> westValue;
+
     public ImmutableSpongeWireAttachmentData(Map<Direction, WireAttachmentType> wireAttachmentMap) {
         super(ImmutableWireAttachmentData.class);
         this.wireAttachmentMap = ImmutableMap.copyOf(wireAttachmentMap);
+
+        this.wireAttachmentsValue = new ImmutableSpongeMapValue<Direction, WireAttachmentType>(Keys.WIRE_ATTACHMENTS, wireAttachmentMap);
+        this.northValue = ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_NORTH, WireAttachmentTypes.NONE, wireAttachmentMap.get(Direction.NORTH));
+        this.southValue = ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_SOUTH, WireAttachmentTypes.NONE, wireAttachmentMap.get(Direction.SOUTH));
+        this.eastValue = ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_EAST, WireAttachmentTypes.NONE, wireAttachmentMap.get(Direction.EAST));
+        this.westValue = ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_WEST, WireAttachmentTypes.NONE, wireAttachmentMap.get(Direction.WEST));
+
     }
 
     @Override
     public ImmutableMapValue<Direction, WireAttachmentType> wireAttachments() {
-        return new ImmutableSpongeMapValue<>(Keys.WIRE_ATTACHMENTS, this.wireAttachmentMap);
+        return wireAttachmentsValue;
     }
 
     @Override
     public ImmutableValue<WireAttachmentType> wireAttachmentNorth() {
-        return ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_NORTH, WireAttachmentTypes.NONE, this.wireAttachmentMap.get(Direction.NORTH));
+        return northValue;
     }
 
     @Override
     public ImmutableValue<WireAttachmentType> wireAttachmentSouth() {
-        return ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_SOUTH, WireAttachmentTypes.NONE, this.wireAttachmentMap.get(Direction.SOUTH));
+        return southValue;
     }
 
     @Override
     public ImmutableValue<WireAttachmentType> wireAttachmentEast() {
-        return ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_EAST, WireAttachmentTypes.NONE, this.wireAttachmentMap.get(Direction.EAST));
+        return eastValue;
     }
 
     @Override
     public ImmutableValue<WireAttachmentType> wireAttachmentWest() {
-        return ImmutableSpongeValue.cachedOf(Keys.WIRE_ATTACHMENT_WEST, WireAttachmentTypes.NONE, this.wireAttachmentMap.get(Direction.WEST));
+        return westValue;
     }
 
     @Override
@@ -102,8 +115,38 @@ public class ImmutableSpongeWireAttachmentData extends AbstractImmutableData<Imm
             .set(Keys.WIRE_ATTACHMENT_WEST.getQuery(), this.wireAttachmentMap.get(Direction.WEST).getId());
     }
 
+    public ImmutableMap<Direction, WireAttachmentType> getWireAttachmentMap() {
+        return wireAttachmentMap;
+    }
+
+    private WireAttachmentType getNorth() {
+        return this.wireAttachmentMap.get(Direction.NORTH);
+    }
+
+    private WireAttachmentType getSouth() {
+        return this.wireAttachmentMap.get(Direction.SOUTH);
+    }
+
+    private WireAttachmentType getEast() {
+        return this.wireAttachmentMap.get(Direction.EAST);
+    }
+
+    private WireAttachmentType getWest() {
+        return this.wireAttachmentMap.get(Direction.WEST);
+    }
+
     @Override
     protected void registerGetters() {
-        // TODO
+        registerKeyValue(Keys.WIRE_ATTACHMENTS, ImmutableSpongeWireAttachmentData.this::wireAttachments);
+        registerKeyValue(Keys.WIRE_ATTACHMENT_NORTH, ImmutableSpongeWireAttachmentData.this::wireAttachmentNorth);
+        registerKeyValue(Keys.WIRE_ATTACHMENT_SOUTH, ImmutableSpongeWireAttachmentData.this::wireAttachmentSouth);
+        registerKeyValue(Keys.WIRE_ATTACHMENT_EAST, ImmutableSpongeWireAttachmentData.this::wireAttachmentEast);
+        registerKeyValue(Keys.WIRE_ATTACHMENT_WEST, ImmutableSpongeWireAttachmentData.this::wireAttachmentWest);
+
+        registerFieldGetter(Keys.WIRE_ATTACHMENTS, ImmutableSpongeWireAttachmentData.this::getWireAttachmentMap);
+        registerFieldGetter(Keys.WIRE_ATTACHMENT_NORTH, ImmutableSpongeWireAttachmentData.this::getNorth);
+        registerFieldGetter(Keys.WIRE_ATTACHMENT_SOUTH, ImmutableSpongeWireAttachmentData.this::getSouth);
+        registerFieldGetter(Keys.WIRE_ATTACHMENT_EAST, ImmutableSpongeWireAttachmentData.this::getEast);
+        registerFieldGetter(Keys.WIRE_ATTACHMENT_WEST, ImmutableSpongeWireAttachmentData.this::getWest);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleListData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleListData.java
@@ -40,14 +40,14 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 
 public abstract class AbstractImmutableSingleListData<E, I extends ImmutableDataManipulator<I, M>, M extends DataManipulator<M, I>>
-    extends AbstractImmutableSingleData<List<E>, I, M> {
+        extends AbstractImmutableSingleData<List<E>, I, M> {
 
     private final Class<? extends M> mutable;
     private final ImmutableListValue<E> listValue;
 
-    public AbstractImmutableSingleListData(Class<I> manipulatorClass, List<E> value,
-                                           Key<? extends BaseValue<List<E>>> usedKey,
-                                           Class<? extends M> mutableClass) {
+    protected AbstractImmutableSingleListData(Class<I> manipulatorClass, List<E> value,
+                                              Key<? extends BaseValue<List<E>>> usedKey,
+                                              Class<? extends M> mutableClass) {
         super(manipulatorClass, ImmutableList.copyOf(value), usedKey);
         checkArgument(!Modifier.isAbstract(mutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(mutableClass.getModifiers()), "The immutable class cannot be an interface!");

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeBreathingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeBreathingData.java
@@ -33,13 +33,13 @@ import org.spongepowered.api.data.manipulator.mutable.entity.BreathingData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeBreathingData;
-import org.spongepowered.common.data.util.ComparatorUtil;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class ImmutableSpongeBreathingData extends AbstractImmutableData<ImmutableBreathingData, BreathingData> implements ImmutableBreathingData {
 
     private final int maxAir;
     private final int remainingAir;
+
     private final ImmutableBoundedValue<Integer> remainingAirValue;
     private final ImmutableBoundedValue<Integer> maxAirValue;
 
@@ -47,18 +47,23 @@ public class ImmutableSpongeBreathingData extends AbstractImmutableData<Immutabl
         super(ImmutableBreathingData.class);
         this.maxAir = maxAir;
         this.remainingAir = remainingAir;
-        this.remainingAirValue = new ImmutableSpongeBoundedValue<>(Keys.REMAINING_AIR,
-                                                                   this.remainingAir,
-                                                                   this.maxAir,
-                                                                   ComparatorUtil.intComparator(),
-                                                                   -20,
-                                                                   this.maxAir);
-        this.maxAirValue = new ImmutableSpongeBoundedValue<>(Keys.MAX_AIR,
-                                                             this.maxAir,
-                                                             300,
-                                                             ComparatorUtil.intComparator(),
-                                                             0,
-                                                             Integer.MAX_VALUE);
+
+        remainingAirValue = SpongeValueBuilder.boundedBuilder(Keys.REMAINING_AIR)
+                .actualValue(remainingAir)
+                .defaultValue(this.maxAir)
+                .minimum(-20)
+                .maximum(this.maxAir)
+                .build()
+                .asImmutable();
+
+        maxAirValue = SpongeValueBuilder.boundedBuilder(Keys.MAX_AIR)
+                .actualValue(this.maxAir)
+                .defaultValue(300)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
         registerGetters();
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeExpOrbData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeExpOrbData.java
@@ -24,43 +24,27 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
-
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExpOrbData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpOrbData;
-import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeExpOrbData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
-public class ImmutableSpongeExpOrbData extends AbstractImmutableSingleData<Integer, ImmutableExpOrbData, ExpOrbData> implements ImmutableExpOrbData {
+import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
 
-    final ImmutableBoundedValue<Integer> cachedValue;
+public class ImmutableSpongeExpOrbData extends AbstractImmutableBoundedComparableData<Integer, ImmutableExpOrbData, ExpOrbData> implements ImmutableExpOrbData {
 
-    public ImmutableSpongeExpOrbData(Integer value) {
-        super(ImmutableExpOrbData.class, value, Keys.CONTAINED_EXPERIENCE);
-        this.cachedValue = new ImmutableSpongeBoundedValue<>(Keys.CONTAINED_EXPERIENCE, this.value, 0, intComparator(), 0, Integer.MAX_VALUE);
-    }
+	public ImmutableSpongeExpOrbData(int value) {
+		this(value, 0, Integer.MAX_VALUE);
+	}
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return experience();
-    }
+	public ImmutableSpongeExpOrbData(int value, int minimum, int maximum) {
+		super(ImmutableExpOrbData.class, value, Keys.CONTAINED_EXPERIENCE, intComparator(), SpongeExpOrbData.class, minimum, maximum, 0);
+	}
 
-    @Override
-    public ExpOrbData asMutable() {
-        return new SpongeExpOrbData(getValue());
-    }
-
-    @Override
-    public ImmutableValue<Integer> experience() {
-        return this.cachedValue;
-    }
-
-    @Override
-    public int compareTo(ImmutableExpOrbData o) {
-        return o.experience().get().compareTo(this.value);
-    }
+	@Override
+	public ImmutableValue<Integer> experience() {
+		return getValueGetter();
+	}
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeExperienceHolderData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeExperienceHolderData.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
+import static org.spongepowered.common.data.value.SpongeValueBuilder.boundedBuilder;
 
 import com.google.common.collect.ComparisonChain;
 import org.spongepowered.api.data.DataContainer;
@@ -36,7 +36,6 @@ import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeExperienceHolderData;
 import org.spongepowered.common.data.processor.common.ExperienceHolderUtils;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeExperienceHolderData extends AbstractImmutableData<ImmutableExperienceHolderData, ExperienceHolderData> implements
         ImmutableExperienceHolderData {
@@ -46,12 +45,50 @@ public class ImmutableSpongeExperienceHolderData extends AbstractImmutableData<I
     private final int expSinceLevel;
     private final int expBetweenLevels;
 
+    private final ImmutableBoundedValue<Integer> levelValue;
+    private final ImmutableBoundedValue<Integer> totalExpValue;
+    private final ImmutableBoundedValue<Integer> expSinceLevelValue;
+    private final ImmutableBoundedValue<Integer> expBetweenLevelsValue;
+
     public ImmutableSpongeExperienceHolderData(int level, int totalExp, int expSinceLevel) {
         super(ImmutableExperienceHolderData.class);
         this.level = level;
         this.expBetweenLevels = ExperienceHolderUtils.getExpBetweenLevels(level);
         this.totalExp = totalExp;
         this.expSinceLevel = expSinceLevel;
+
+        this.levelValue = boundedBuilder(Keys.EXPERIENCE_LEVEL)
+                .actualValue(this.level)
+                .defaultValue(0)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
+        this.totalExpValue = boundedBuilder(Keys.TOTAL_EXPERIENCE)
+                .actualValue(this.totalExp)
+                .defaultValue(0)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
+        this.expSinceLevelValue = boundedBuilder(Keys.EXPERIENCE_SINCE_LEVEL)
+                .actualValue(this.expSinceLevel)
+                .defaultValue(0)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
+        this.expBetweenLevelsValue = boundedBuilder(Keys.EXPERIENCE_FROM_START_OF_LEVEL)
+                .actualValue(this.expBetweenLevels)
+                .defaultValue(this.expBetweenLevels)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
         registerGetters();
     }
 
@@ -79,24 +116,22 @@ public class ImmutableSpongeExperienceHolderData extends AbstractImmutableData<I
 
     @Override
     public ImmutableBoundedValue<Integer> level() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.EXPERIENCE_LEVEL, 0, this.level, intComparator(), 0, Integer.MAX_VALUE);
+        return levelValue;
     }
 
     @Override
     public ImmutableBoundedValue<Integer> totalExperience() {
-        return new ImmutableSpongeBoundedValue<>(Keys.TOTAL_EXPERIENCE, this.totalExp, 0, intComparator(), 0, Integer.MAX_VALUE);
+        return totalExpValue;
     }
 
     @Override
     public ImmutableBoundedValue<Integer> experienceSinceLevel() {
-        return new ImmutableSpongeBoundedValue<>(Keys.EXPERIENCE_SINCE_LEVEL, this.expSinceLevel, 0, intComparator(), 0,
-                                                 Integer.MAX_VALUE);
+        return expSinceLevelValue;
     }
 
     @Override
     public ImmutableBoundedValue<Integer> experienceBetweenLevels() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.EXPERIENCE_FROM_START_OF_LEVEL, this.expBetweenLevels,
-                this.expBetweenLevels, intComparator(), 0, Integer.MAX_VALUE);
+        return expBetweenLevelsValue;
     }
 
     public int getLevel() {

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFoodData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFoodData.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.doubleComparator;
 import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
 
 import com.google.common.collect.ComparisonChain;
@@ -36,6 +35,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.FoodData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeFoodData;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeFoodData extends AbstractImmutableData<ImmutableFoodData, FoodData> implements ImmutableFoodData {
@@ -44,11 +44,35 @@ public class ImmutableSpongeFoodData extends AbstractImmutableData<ImmutableFood
     private final float foodSaturationLevel;
     private final float foodExhaustionLevel;
 
+    private final ImmutableBoundedValue<Integer> foodLevelValue;
+    private final ImmutableBoundedValue<Double> saturationValue;
+    private final ImmutableBoundedValue<Double> exhaustionValue;
+
+
     public ImmutableSpongeFoodData(int foodLevel, float foodSaturationLevel, float foodExhaustionLevel) {
         super(ImmutableFoodData.class);
         this.foodLevel = foodLevel;
         this.foodSaturationLevel = foodSaturationLevel;
         this.foodExhaustionLevel = foodExhaustionLevel;
+
+        foodLevelValue = ImmutableSpongeBoundedValue.cachedOf(Keys.FOOD_LEVEL, 20, this.foodLevel, intComparator(), 0, 20);
+
+        exhaustionValue = SpongeValueBuilder.boundedBuilder(Keys.EXHAUSTION)
+                .actualValue((double) this.foodExhaustionLevel)
+                .defaultValue(0D)
+                .minimum(0D)
+                .maximum(40D)
+                .build()
+                .asImmutable();
+
+        saturationValue = SpongeValueBuilder.boundedBuilder(Keys.SATURATION)
+                .actualValue((double) this.foodSaturationLevel)
+                .defaultValue(5D)
+                .minimum(0D)
+                .maximum((double) this.foodLevel)
+                .build()
+                .asImmutable();
+
         registerGetters();
     }
 
@@ -76,19 +100,17 @@ public class ImmutableSpongeFoodData extends AbstractImmutableData<ImmutableFood
 
     @Override
     public ImmutableBoundedValue<Integer> foodLevel() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.FOOD_LEVEL, 20, this.foodLevel, intComparator(), 0, 20);
+        return foodLevelValue;
     }
 
     @Override
     public ImmutableBoundedValue<Double> exhaustion() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.EXHAUSTION, (double) this.foodExhaustionLevel,
-                (double) this.foodExhaustionLevel, doubleComparator(), 0D, 20D);
+        return exhaustionValue;
     }
 
     @Override
     public ImmutableBoundedValue<Double> saturation() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.SATURATION, (double) this.foodSaturationLevel,
-                                                 (double) this.foodSaturationLevel, doubleComparator(), 0D, 20D);
+        return saturationValue;
     }
 
     public int getFood() {

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeHealthData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeHealthData.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.HealthData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHealthData;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeHealthData extends AbstractImmutableData<ImmutableHealthData, HealthData> implements ImmutableHealthData {
@@ -42,21 +43,41 @@ public class ImmutableSpongeHealthData extends AbstractImmutableData<ImmutableHe
     private final double health;
     private final double maxHealth;
 
+    private final ImmutableBoundedValue<Double> healthValue;
+    private final ImmutableBoundedValue<Double> maxHealthValue;
+
     public ImmutableSpongeHealthData(double health, double maxHealth) {
         super(ImmutableHealthData.class);
         this.health = health;
         this.maxHealth = maxHealth;
+
+        healthValue = SpongeValueBuilder.boundedBuilder(Keys.HEALTH)
+                .actualValue(this.health)
+                .defaultValue(this.maxHealth)
+                .minimum(0D)
+                .maximum(this.maxHealth)
+                .build()
+                .asImmutable();
+
+        maxHealthValue = SpongeValueBuilder.boundedBuilder(Keys.MAX_HEALTH)
+                .actualValue(this.maxHealth)
+                .defaultValue(20D)
+                .minimum(0D)
+                .maximum((double) Float.MAX_VALUE)
+                .build()
+                .asImmutable();
+
         registerGetters();
     }
 
     @Override
     public ImmutableBoundedValue<Double> health() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.HEALTH, this.health, this.maxHealth, doubleComparator(), 0D, this.maxHealth);
+        return healthValue;
     }
 
     @Override
     public ImmutableBoundedValue<Double> maxHealth() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.HEALTH, this.maxHealth, this.maxHealth, doubleComparator(), 0D, (double) Float.MAX_VALUE);
+        return maxHealthValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeHorseData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeHorseData.java
@@ -47,11 +47,20 @@ public class ImmutableSpongeHorseData extends AbstractImmutableData<ImmutableHor
     private final HorseStyle horseStyle;
     private final HorseVariant horseVariant;
 
+    private final ImmutableValue<HorseColor> colorValue;
+    private final ImmutableValue<HorseStyle> styleValue;
+    private final ImmutableValue<HorseVariant> variantValue;
+
     public ImmutableSpongeHorseData(HorseColor horseColor, HorseStyle horseStyle, HorseVariant horseVariant) {
         super(ImmutableHorseData.class);
         this.horseColor = horseColor;
         this.horseStyle = horseStyle;
         this.horseVariant = horseVariant;
+
+        colorValue = ImmutableSpongeValue.cachedOf(Keys.HORSE_COLOR, HorseColors.BLACK, this.horseColor);
+        styleValue = ImmutableSpongeValue.cachedOf(Keys.HORSE_STYLE, HorseStyles.NONE, this.horseStyle);
+        variantValue = ImmutableSpongeValue.cachedOf(Keys.HORSE_VARIANT, HorseVariants.HORSE, this.horseVariant);
+
         registerGetters();
     }
 
@@ -69,17 +78,17 @@ public class ImmutableSpongeHorseData extends AbstractImmutableData<ImmutableHor
 
     @Override
     public ImmutableValue<HorseColor> color() {
-        return ImmutableSpongeValue.cachedOf(Keys.HORSE_COLOR, HorseColors.BLACK, this.horseColor);
+        return colorValue;
     }
 
     @Override
     public ImmutableValue<HorseStyle> style() {
-        return ImmutableSpongeValue.cachedOf(Keys.HORSE_STYLE, HorseStyles.NONE, this.horseStyle);
+        return styleValue;
     }
 
     @Override
     public ImmutableValue<HorseVariant> variant() {
-        return ImmutableSpongeValue.cachedOf(Keys.HORSE_VARIANT, HorseVariants.HORSE, this.horseVariant);
+        return variantValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeIgniteableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeIgniteableData.java
@@ -36,29 +36,49 @@ import org.spongepowered.api.data.manipulator.mutable.entity.IgniteableData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeIgniteableData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class ImmutableSpongeIgniteableData extends AbstractImmutableData<ImmutableIgniteableData, IgniteableData> implements ImmutableIgniteableData {
 
     private final int fireTicks;
     private final int fireDelay;
 
+    private final ImmutableBoundedValue<Integer> fireTicksValue;
+    private final ImmutableBoundedValue<Integer> fireDelayValue;
+
     public ImmutableSpongeIgniteableData(int fireTicks, int fireDelay) {
         super(ImmutableIgniteableData.class);
         checkArgument(fireTicks > 0);
         this.fireTicks = fireTicks;
         this.fireDelay = fireDelay;
+
+        fireTicksValue = SpongeValueBuilder.boundedBuilder(Keys.FIRE_TICKS)
+                .actualValue(this.fireTicks)
+                .defaultValue(1)
+                .minimum(1)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
+        fireDelayValue = SpongeValueBuilder.boundedBuilder(Keys.FIRE_DAMAGE_DELAY)
+                .actualValue(this.fireDelay)
+                .defaultValue(20)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build()
+                .asImmutable();
+
         registerGetters();
     }
 
     @Override
     public ImmutableBoundedValue<Integer> fireTicks() {
-        return new ImmutableSpongeBoundedValue<>(Keys.FIRE_TICKS, this.fireTicks, 1, intComparator(), 1, Integer.MAX_VALUE);
+        return fireTicksValue;
     }
 
     @Override
     public ImmutableBoundedValue<Integer> fireDelay() {
-        return new ImmutableSpongeBoundedValue<>(Keys.FIRE_DAMAGE_DELAY, this.fireDelay, 20, intComparator(), 0, Integer.MAX_VALUE);
+        return fireDelayValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeMovementSpeedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeMovementSpeedData.java
@@ -24,34 +24,33 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.doubleComparator;
-
 import com.google.common.collect.ComparisonChain;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableMovementSpeedData;
 import org.spongepowered.api.data.manipulator.mutable.entity.MovementSpeedData;
-import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeMovementSpeedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeMovementSpeedData extends AbstractImmutableData<ImmutableMovementSpeedData, MovementSpeedData> implements ImmutableMovementSpeedData  {
 
     private final double walkSpeed;
     private final double flySpeed;
 
-    final ImmutableBoundedValue<Double> walkSpeedValue;
-    final ImmutableBoundedValue<Double> flyingSpeedValue;
+    private final ImmutableValue<Double> walkSpeedValue;
+    private final ImmutableValue<Double> flyingSpeedValue;
 
 
     public ImmutableSpongeMovementSpeedData(double walkSpeed, double flySpeed) {
         super(ImmutableMovementSpeedData.class);
         this.walkSpeed = walkSpeed;
         this.flySpeed = flySpeed;
-        this.walkSpeedValue = new ImmutableSpongeBoundedValue<>(Keys.WALKING_SPEED, 0.1d, doubleComparator(), Double.MIN_VALUE, Double.MAX_VALUE);
-        this.flyingSpeedValue = new ImmutableSpongeBoundedValue<>(Keys.FLYING_SPEED, 0.05d, doubleComparator(), Double.MIN_VALUE, Double.MAX_VALUE);
+        this.walkSpeedValue = new ImmutableSpongeValue<>(Keys.WALKING_SPEED, 0.7D, this.walkSpeed);
+        this.flyingSpeedValue = new ImmutableSpongeValue<>(Keys.FLYING_SPEED, 0.05D, this.flySpeed);
+
         registerGetters();
     }
 
@@ -73,12 +72,12 @@ public class ImmutableSpongeMovementSpeedData extends AbstractImmutableData<Immu
     }
 
     @Override
-    public ImmutableBoundedValue<Double> walkSpeed() {
+    public ImmutableValue<Double> walkSpeed() {
         return this.walkSpeedValue;
     }
 
     @Override
-    public ImmutableBoundedValue<Double> flySpeed() {
+    public ImmutableValue<Double> flySpeed() {
         return this.flyingSpeedValue;
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeTameableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeTameableData.java
@@ -43,6 +43,8 @@ import javax.annotation.Nullable;
 
 public class ImmutableSpongeTameableData extends AbstractImmutableData<ImmutableTameableData, TameableData> implements ImmutableTameableData {
 
+    //TODO: Wat
+
     //Lazily initialized, do not use directly, use create & createValue factory methods instead.
     @Nullable private static ImmutableSpongeTameableData empty = null;
     @Nullable private static ImmutableSpongeOptionalValue<UUID> emptyValue = null;

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeVelocityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeVelocityData.java
@@ -35,12 +35,14 @@ import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeVelocityData extends AbstractImmutableSingleData<Vector3d, ImmutableVelocityData, VelocityData> implements ImmutableVelocityData {
 
+    private final ImmutableSpongeValue<Vector3d> velocityValue = new ImmutableSpongeValue<>(Keys.VELOCITY, new Vector3d(), this.value);
+
     public ImmutableSpongeVelocityData(Vector3d value) {
         super(ImmutableVelocityData.class, value, Keys.VELOCITY);
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
+    protected ImmutableValue<Vector3d> getValueGetter() {
         return velocity();
     }
 
@@ -51,7 +53,7 @@ public class ImmutableSpongeVelocityData extends AbstractImmutableSingleData<Vec
 
     @Override
     public ImmutableValue<Vector3d> velocity() {
-        return new ImmutableSpongeValue<>(Keys.VELOCITY, new Vector3d(), this.value);
+        return this.velocityValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBreakableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBreakableData.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.data.manipulator.immutable.item;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.primitives.Booleans;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
@@ -47,12 +46,6 @@ public class ImmutableSpongeBreakableData extends AbstractImmutableSingleSetData
 
     public ImmutableSpongeBreakableData(Set<BlockType> breakable) {
         super(ImmutableBreakableData.class, breakable, Keys.BREAKABLE_BLOCK_TYPES, SpongeBreakableData.class);
-    }
-
-    @Override
-    public int compareTo(ImmutableBreakableData o) {
-        return Booleans.compare(o.breakable().containsAll(getValue()),
-                getValue().containsAll(o.breakable().get()));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeLoreData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeLoreData.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.data.manipulator.immutable.item;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Booleans;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
@@ -34,55 +33,29 @@ import org.spongepowered.api.data.manipulator.mutable.item.LoreData;
 import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
-import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
+import org.spongepowered.common.data.manipulator.immutable.common.collection.AbstractImmutableSingleListData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeLoreData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 import org.spongepowered.common.text.SpongeTexts;
 
 import java.util.List;
 
-public class ImmutableSpongeLoreData extends AbstractImmutableData<ImmutableLoreData, LoreData> implements ImmutableLoreData {
-
-    private final ImmutableList<Text> lore;
+public class ImmutableSpongeLoreData extends AbstractImmutableSingleListData<Text, ImmutableLoreData, LoreData> implements ImmutableLoreData {
 
     public ImmutableSpongeLoreData() {
         this(ImmutableList.of(Texts.of()));
     }
 
     public ImmutableSpongeLoreData(List<Text> lore) {
-        super(ImmutableLoreData.class);
-        this.lore = ImmutableList.copyOf(lore);
-        registerGetters();
+        super(ImmutableLoreData.class, lore, Keys.ITEM_LORE, SpongeLoreData.class);
     }
 
     @Override
     public ImmutableListValue<Text> lore() {
-        return new ImmutableSpongeListValue<>(Keys.ITEM_LORE, this.lore);
-    }
-
-    @Override
-    public LoreData asMutable() {
-        return new SpongeLoreData(this.lore);
-    }
-
-    @Override
-    public int compareTo(ImmutableLoreData o) {
-        return Booleans.compare(o.lore().containsAll(this.lore),
-                this.lore.containsAll(o.lore().get()));
+        return getValueGetter();
     }
 
     @Override
     public DataContainer toContainer() {
-        return new MemoryDataContainer().set(Keys.ITEM_LORE.getQuery(), SpongeTexts.asJson(this.lore));
-    }
-
-    public List<Text> getLore() {
-        return this.lore;
-    }
-
-    @Override
-    protected void registerGetters() {
-        registerFieldGetter(Keys.ITEM_LORE, ImmutableSpongeLoreData.this::getLore);
-        registerKeyValue(Keys.ITEM_LORE, ImmutableSpongeLoreData.this::lore);
+        return new MemoryDataContainer().set(Keys.ITEM_LORE.getQuery(), SpongeTexts.asJson(this.getValue()));
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePagedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePagedData.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.data.manipulator.immutable.item;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Booleans;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
@@ -34,56 +33,29 @@ import org.spongepowered.api.data.manipulator.mutable.item.PagedData;
 import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
-import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
+import org.spongepowered.common.data.manipulator.immutable.common.collection.AbstractImmutableSingleListData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongePagedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 import org.spongepowered.common.text.SpongeTexts;
 
 import java.util.List;
 
-public class ImmutableSpongePagedData extends AbstractImmutableData<ImmutablePagedData, PagedData> implements ImmutablePagedData {
-
-    private final ImmutableList<Text> pages;
+public class ImmutableSpongePagedData extends AbstractImmutableSingleListData<Text, ImmutablePagedData, PagedData> implements ImmutablePagedData {
 
     public ImmutableSpongePagedData() {
         this(ImmutableList.of(Texts.of()));
     }
 
     public ImmutableSpongePagedData(List<Text> pages) {
-        super(ImmutablePagedData.class);
-        this.pages = ImmutableList.copyOf(pages);
-        registerGetters();
+        super(ImmutablePagedData.class, pages, Keys.BOOK_PAGES, SpongePagedData.class);
     }
 
     @Override
     public ImmutableListValue<Text> pages() {
-        return new ImmutableSpongeListValue<>(Keys.BOOK_PAGES, this.pages);
-    }
-
-    @Override
-    public PagedData asMutable() {
-        return new SpongePagedData(this.pages);
-    }
-
-    @Override
-    public int compareTo(ImmutablePagedData o) {
-        return Booleans.compare(o.pages().containsAll(this.pages),
-                this.pages.containsAll(o.pages().get()));
+        return getValueGetter();
     }
 
     @Override
     public DataContainer toContainer() {
-        return new MemoryDataContainer().set(Keys.BOOK_PAGES.getQuery(), SpongeTexts.asJson(this.pages));
+        return new MemoryDataContainer().set(Keys.BOOK_PAGES.getQuery(), SpongeTexts.asJson(this.getValue()));
     }
-
-    public List<Text> getPages() {
-        return this.pages;
-    }
-
-    @Override
-    protected void registerGetters() {
-        registerFieldGetter(Keys.BOOK_PAGES, ImmutableSpongePagedData.this::getPages);
-        registerKeyValue(Keys.BOOK_PAGES, ImmutableSpongePagedData.this::pages);
-    }
-
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePlaceableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePlaceableData.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.data.manipulator.immutable.item;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.common.primitives.Booleans;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.data.DataContainer;

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeCommandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeCommandData.java
@@ -33,12 +33,14 @@ import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableCommandData;
 import org.spongepowered.api.data.manipulator.mutable.CommandData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.OptionalValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeCommandData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 import org.spongepowered.common.data.value.mutable.SpongeOptionalValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
@@ -64,8 +66,13 @@ public class SpongeCommandData extends AbstractData<CommandData, ImmutableComman
     }
 
     @Override
-    public Value<Integer> successCount() {
-        return new SpongeValue<>(Keys.SUCCESS_COUNT, getSuccessCount());
+    public MutableBoundedValue<Integer> successCount() {
+        return SpongeValueBuilder.boundedBuilder(Keys.SUCCESS_COUNT)
+                .actualValue(this.success)
+                .defaultValue(0)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .build();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeFireworkData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeFireworkData.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.data.manipulator.mutable;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 import org.spongepowered.api.data.DataContainer;
@@ -94,6 +95,23 @@ public class SpongeFireworkData extends AbstractData<FireworkData, ImmutableFire
                 .result();
     }
 
+    public List<FireworkEffect> getFireworkEffects() {
+        return fireworkEffects;
+    }
+
+    public void setFireworkEffects(List<FireworkEffect> effects) {
+        Preconditions.checkNotNull(effects).forEach(Preconditions::checkNotNull);
+        this.fireworkEffects = effects;
+    }
+
+    public int getFlightModifier() {
+        return flightModifier;
+    }
+
+    public void setFlightModifier(int flightModifier) {
+        this.flightModifier = flightModifier;
+    }
+
     @Override
     public DataContainer toContainer() {
         return new MemoryDataContainer()
@@ -103,6 +121,13 @@ public class SpongeFireworkData extends AbstractData<FireworkData, ImmutableFire
 
     @Override
     protected void registerGettersAndSetters() {
-        // TODO
+        registerFieldGetter(Keys.FIREWORK_EFFECTS, SpongeFireworkData.this::getFireworkEffects);
+        registerFieldGetter(Keys.FIREWORK_FLIGHT_MODIFIER, SpongeFireworkData.this::getFlightModifier);
+
+        registerFieldSetter(Keys.FIREWORK_EFFECTS, SpongeFireworkData.this::setFireworkEffects);
+        registerFieldSetter(Keys.FIREWORK_FLIGHT_MODIFIER, SpongeFireworkData.this::setFlightModifier);
+
+        registerKeyValue(Keys.FIREWORK_EFFECTS, SpongeFireworkData.this::effects);
+        registerKeyValue(Keys.FIREWORK_FLIGHT_MODIFIER, SpongeFireworkData.this::flightModifier);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeMobSpawnerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeMobSpawnerData.java
@@ -24,6 +24,9 @@
  */
 package org.spongepowered.common.data.manipulator.mutable;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
@@ -33,6 +36,7 @@ import org.spongepowered.api.data.manipulator.mutable.MobSpawnerData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.WeightedEntityCollectionValue;
 import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.entity.EntityTypes;
 import org.spongepowered.api.util.weighted.WeightedCollection;
 import org.spongepowered.api.util.weighted.WeightedSerializableObject;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeMobSpawnerData;
@@ -40,6 +44,7 @@ import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
 import org.spongepowered.common.data.value.SpongeValueBuilder;
 import org.spongepowered.common.data.value.mutable.SpongeNextEntityToSpawnValue;
 import org.spongepowered.common.data.value.mutable.SpongeWeightedEntityCollectionValue;
+import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 
 public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, ImmutableMobSpawnerData> implements MobSpawnerData {
 
@@ -65,13 +70,16 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
         this.maximumEntities = maximumEntities;
         this.playerRange = playerRange;
         this.spawnRange = spawnRange;
-        this.nextEntityToSpawn = nextEntityToSpawn;
+        this.nextEntityToSpawn = checkNotNull(nextEntityToSpawn);
+        checkNotNull(entities).forEach(Preconditions::checkNotNull);
         this.entities = entities;
         registerGettersAndSetters();
     }
 
     public SpongeMobSpawnerData() {
-        super(MobSpawnerData.class);
+        this((short) 20, (short) 200, (short) 800, (short) 4, (short) 6, (short) 16, (short) 4,
+                new WeightedSerializableObject<>(new SpongeEntitySnapshotBuilder().type(EntityTypes.PIG).build(), 1),
+                new WeightedCollection<>());
     }
 
 
@@ -80,7 +88,7 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
         return SpongeValueBuilder.boundedBuilder(Keys.SPAWNER_REMAINING_DELAY)
             .minimum((short) 0)
             .maximum(this.maximumDelay)
-            .defaultValue((short) 0)
+            .defaultValue((short) 20)
             .actualValue(this.remainingDelay)
             .build();
     }
@@ -90,7 +98,7 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
         return SpongeValueBuilder.boundedBuilder(Keys.SPAWNER_MINIMUM_DELAY)
             .minimum((short) 0)
             .maximum(Short.MAX_VALUE)
-            .defaultValue((short) 0)
+            .defaultValue((short) 200)
             .actualValue(this.minimumDelay)
             .build();
     }
@@ -98,9 +106,9 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
     @Override
     public MutableBoundedValue<Short> maximumSpawnDelay() {
         return SpongeValueBuilder.boundedBuilder(Keys.SPAWNER_MAXIMUM_DELAY)
-            .minimum((short) 0)
+            .minimum((short) 1)
             .maximum(Short.MAX_VALUE)
-            .defaultValue((short) 0)
+            .defaultValue((short) 800)
             .actualValue(this.maximumDelay)
             .build();
     }
@@ -110,7 +118,7 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
         return SpongeValueBuilder.boundedBuilder(Keys.SPAWNER_SPAWN_COUNT)
             .minimum((short) 0)
             .maximum(Short.MAX_VALUE)
-            .defaultValue((short) 0)
+            .defaultValue((short) 4)
             .actualValue(this.count)
             .build();
     }
@@ -120,7 +128,7 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
         return SpongeValueBuilder.boundedBuilder(Keys.SPAWNER_MAXIMUM_NEARBY_ENTITIES)
             .minimum((short) 0)
             .maximum(Short.MAX_VALUE)
-            .defaultValue((short) 0)
+            .defaultValue((short) 6)
             .actualValue(this.maximumEntities)
             .build();
     }
@@ -130,7 +138,7 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
         return SpongeValueBuilder.boundedBuilder(Keys.SPAWNER_REQURED_PLAYER_RANGE)
             .minimum((short) 0)
             .maximum(Short.MAX_VALUE)
-            .defaultValue((short) 0)
+            .defaultValue((short) 16)
             .actualValue(this.playerRange)
             .build();
     }
@@ -140,7 +148,7 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
         return SpongeValueBuilder.boundedBuilder(Keys.SPAWNER_SPAWN_RANGE)
             .minimum((short) 0)
             .maximum(Short.MAX_VALUE)
-            .defaultValue((short) 0)
+            .defaultValue((short) 4)
             .actualValue(this.spawnRange)
             .build();
     }
@@ -195,8 +203,109 @@ public class SpongeMobSpawnerData extends AbstractData<MobSpawnerData, Immutable
 
     }
 
+    public short getRemainingDelay() {
+        return remainingDelay;
+    }
+
+    public void setRemainingDelay(short remainingDelay) {
+        this.remainingDelay = remainingDelay;
+    }
+
+    public short getMinimumDelay() {
+        return minimumDelay;
+    }
+
+    public void setMinimumDelay(short minimumDelay) {
+        this.minimumDelay = minimumDelay;
+    }
+
+    public short getMaximumDelay() {
+        return maximumDelay;
+    }
+
+    public void setMaximumDelay(short maximumDelay) {
+        this.maximumDelay = maximumDelay;
+    }
+
+    public short getCount() {
+        return count;
+    }
+
+    public void setCount(short count) {
+        this.count = count;
+    }
+
+    public short getMaximumEntities() {
+        return maximumEntities;
+    }
+
+    public void setMaximumEntities(short maximumEntities) {
+        this.maximumEntities = maximumEntities;
+    }
+
+    public short getPlayerRange() {
+        return playerRange;
+    }
+
+    public void setPlayerRange(short playerRange) {
+        this.playerRange = playerRange;
+    }
+
+    public short getSpawnRange() {
+        return spawnRange;
+    }
+
+    public void setSpawnRange(short spawnRange) {
+        this.spawnRange = spawnRange;
+    }
+
+    public WeightedSerializableObject<EntitySnapshot> getNextEntityToSpawn() {
+        return nextEntityToSpawn;
+    }
+
+    public void setNextEntityToSpawn(WeightedSerializableObject<EntitySnapshot> nextEntityToSpawn) {
+        this.nextEntityToSpawn = checkNotNull(nextEntityToSpawn);
+    }
+
+    public WeightedCollection<WeightedSerializableObject<EntitySnapshot>> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(WeightedCollection<WeightedSerializableObject<EntitySnapshot>> entities) {
+        checkNotNull(entities).forEach(Preconditions::checkNotNull);
+        this.entities = entities;
+    }
+
     @Override
     protected void registerGettersAndSetters() {
-        // TODO
+        registerKeyValue(Keys.SPAWNER_REMAINING_DELAY, SpongeMobSpawnerData.this::remainingDelay);
+        registerKeyValue(Keys.SPAWNER_MINIMUM_DELAY, SpongeMobSpawnerData.this::minimumSpawnDelay);
+        registerKeyValue(Keys.SPAWNER_MAXIMUM_DELAY, SpongeMobSpawnerData.this::maximumSpawnDelay);
+        registerKeyValue(Keys.SPAWNER_SPAWN_COUNT, SpongeMobSpawnerData.this::spawnCount);
+        registerKeyValue(Keys.SPAWNER_MAXIMUM_NEARBY_ENTITIES, SpongeMobSpawnerData.this::maximumNearbyEntities);
+        registerKeyValue(Keys.SPAWNER_REQURED_PLAYER_RANGE, SpongeMobSpawnerData.this::requiredPlayerRange);
+        registerKeyValue(Keys.SPAWNER_SPAWN_RANGE, SpongeMobSpawnerData.this::spawnRange);
+        registerKeyValue(Keys.SPAWNER_NEXT_ENTITY_TO_SPAWN, SpongeMobSpawnerData.this::nextEntityToSpawn);
+        registerKeyValue(Keys.SPAWNER_ENTITIES, SpongeMobSpawnerData.this::possibleEntitiesToSpawn);
+
+        registerFieldGetter(Keys.SPAWNER_REMAINING_DELAY, SpongeMobSpawnerData.this::getRemainingDelay);
+        registerFieldGetter(Keys.SPAWNER_MINIMUM_DELAY, SpongeMobSpawnerData.this::getMinimumDelay);
+        registerFieldGetter(Keys.SPAWNER_MAXIMUM_DELAY, SpongeMobSpawnerData.this::getMaximumDelay);
+        registerFieldGetter(Keys.SPAWNER_SPAWN_COUNT, SpongeMobSpawnerData.this::getCount);
+        registerFieldGetter(Keys.SPAWNER_MAXIMUM_NEARBY_ENTITIES, SpongeMobSpawnerData.this::getMaximumEntities);
+        registerFieldGetter(Keys.SPAWNER_REQURED_PLAYER_RANGE, SpongeMobSpawnerData.this::getPlayerRange);
+        registerFieldGetter(Keys.SPAWNER_SPAWN_RANGE, SpongeMobSpawnerData.this::getSpawnRange);
+        registerFieldGetter(Keys.SPAWNER_NEXT_ENTITY_TO_SPAWN, SpongeMobSpawnerData.this::getNextEntityToSpawn);
+        registerFieldGetter(Keys.SPAWNER_ENTITIES, SpongeMobSpawnerData.this::getEntities);
+
+        registerFieldSetter(Keys.SPAWNER_REMAINING_DELAY, SpongeMobSpawnerData.this::setRemainingDelay);
+        registerFieldSetter(Keys.SPAWNER_MINIMUM_DELAY, SpongeMobSpawnerData.this::setMinimumDelay);
+        registerFieldSetter(Keys.SPAWNER_MAXIMUM_DELAY, SpongeMobSpawnerData.this::setMaximumDelay);
+        registerFieldSetter(Keys.SPAWNER_SPAWN_COUNT, SpongeMobSpawnerData.this::setCount);
+        registerFieldSetter(Keys.SPAWNER_MAXIMUM_NEARBY_ENTITIES, SpongeMobSpawnerData.this::setMaximumEntities);
+        registerFieldSetter(Keys.SPAWNER_REQURED_PLAYER_RANGE, SpongeMobSpawnerData.this::setPlayerRange);
+        registerFieldSetter(Keys.SPAWNER_SPAWN_RANGE, SpongeMobSpawnerData.this::setSpawnRange);
+        registerFieldSetter(Keys.SPAWNER_NEXT_ENTITY_TO_SPAWN, SpongeMobSpawnerData.this::setNextEntityToSpawn);
+        registerFieldSetter(Keys.SPAWNER_ENTITIES, SpongeMobSpawnerData.this::setEntities);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongePotionEffectData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongePotionEffectData.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.mutable;
 
-import com.google.common.collect.Lists;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
@@ -33,49 +32,29 @@ import org.spongepowered.api.data.manipulator.mutable.PotionEffectData;
 import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.potion.PotionEffect;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongePotionEffectData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
-import org.spongepowered.common.data.value.mutable.SpongeListValue;
+import org.spongepowered.common.data.manipulator.mutable.common.collection.AbstractSingleListData;
 
 import java.util.List;
 
-public class SpongePotionEffectData extends AbstractData<PotionEffectData, ImmutablePotionEffectData> implements PotionEffectData {
-
-    private List<PotionEffect> effects;
+public class SpongePotionEffectData extends AbstractSingleListData<PotionEffect, PotionEffectData, ImmutablePotionEffectData> implements PotionEffectData {
 
     public SpongePotionEffectData(List<PotionEffect> effects) {
-        super(PotionEffectData.class);
-        this.effects = Lists.newArrayList(effects);
-        registerGettersAndSetters();
+        super(PotionEffectData.class, effects, Keys.POTION_EFFECTS, ImmutableSpongePotionEffectData.class);
     }
 
     @Override
     public ListValue<PotionEffect> effects() {
-        return new SpongeListValue<>(Keys.POTION_EFFECTS, this.effects);
-    }
-
-    @Override
-    public PotionEffectData copy() {
-        return new SpongePotionEffectData(this.effects);
-    }
-
-    @Override
-    public ImmutablePotionEffectData asImmutable() {
-        return new ImmutableSpongePotionEffectData(this.effects);
+        return getValueGetter();
     }
 
     @Override
     public int compareTo(PotionEffectData o) {
-        return 0;
+        return 0; //TODO
     }
 
     @Override
     public DataContainer toContainer() {
         return new MemoryDataContainer()
-            .set(Keys.POTION_EFFECTS.getQuery(), this.effects);
-    }
-
-    @Override
-    protected void registerGettersAndSetters() {
-        // TODO
+            .set(Keys.POTION_EFFECTS.getQuery(), this.getValue());
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeTradeOfferData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeTradeOfferData.java
@@ -24,12 +24,8 @@
  */
 package org.spongepowered.common.data.manipulator.mutable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spongepowered.api.data.DataQuery.of;
-
 import com.google.common.collect.Lists;
 import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableTradeOfferData;
@@ -37,52 +33,20 @@ import org.spongepowered.api.data.manipulator.mutable.entity.TradeOfferData;
 import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.item.merchant.TradeOffer;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeTradeOfferData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
-import org.spongepowered.common.data.value.mutable.SpongeListValue;
+import org.spongepowered.common.data.manipulator.mutable.common.collection.AbstractSingleListData;
 
 import java.util.List;
 
-public class SpongeTradeOfferData extends AbstractData<TradeOfferData, ImmutableTradeOfferData> implements TradeOfferData {
-
-    public static final DataQuery OFFERS = of("Offers");
+public class SpongeTradeOfferData extends AbstractSingleListData<TradeOffer, TradeOfferData, ImmutableTradeOfferData> implements TradeOfferData {
 
     private List<TradeOffer> offers = Lists.newArrayList();
 
     public SpongeTradeOfferData() {
-        super(TradeOfferData.class);
+        this(Lists.newArrayList());
     }
 
     public SpongeTradeOfferData(List<TradeOffer> tradeOffers) {
-        super(TradeOfferData.class);
-        this.offers.addAll(tradeOffers);
-        registerGettersAndSetters();
-    }
-
-    public List<TradeOffer> getOffers() {
-        return this.offers;
-    }
-
-    public TradeOfferData setOffers(List<TradeOffer> offers) {
-        this.offers.clear();
-        for (TradeOffer offer : offers) {
-            this.offers.add(checkNotNull(offer));
-        }
-        return this;
-    }
-
-    public TradeOfferData addOffer(TradeOffer offer) {
-        this.offers.add(checkNotNull(offer));
-        return this;
-    }
-
-    @Override
-    public TradeOfferData copy() {
-        return new SpongeTradeOfferData(this.offers);
-    }
-
-    @Override
-    public ImmutableTradeOfferData asImmutable() {
-        return new ImmutableSpongeTradeOfferData(this.offers);
+        super(TradeOfferData.class, tradeOffers, Keys.TRADE_OFFERS, ImmutableSpongeTradeOfferData.class);
     }
 
     @Override
@@ -92,16 +56,11 @@ public class SpongeTradeOfferData extends AbstractData<TradeOfferData, Immutable
 
     @Override
     public DataContainer toContainer() {
-        return new MemoryDataContainer().set(OFFERS, this.offers);
+        return new MemoryDataContainer().set(Keys.TRADE_OFFERS.getQuery(), this.offers);
     }
 
     @Override
     public ListValue<TradeOffer> tradeOffers() {
-        return new SpongeListValue<>(Keys.TRADE_OFFERS, this.offers);
-    }
-
-    @Override
-    protected void registerGettersAndSetters() {
-        // TODO
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeWetData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeWetData.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.data.manipulator.mutable.WetData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeWetData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeWetData extends AbstractBooleanData<WetData, ImmutableWetData> implements WetData {
 
@@ -39,16 +38,11 @@ public class SpongeWetData extends AbstractBooleanData<WetData, ImmutableWetData
     }
 
     public SpongeWetData(boolean value) {
-        super(WetData.class, value, Keys.IS_WET, ImmutableSpongeWetData.class);
+        super(WetData.class, value, Keys.IS_WET, ImmutableSpongeWetData.class, false);
     }
 
     @Override
     public Value<Boolean> wet() {
-        return new SpongeValue<>(Keys.IS_WET, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return wet();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeAttachedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeAttachedData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.block.AttachedData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeAttachedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeAttachedData extends AbstractBooleanData<AttachedData, ImmutableAttachedData> implements AttachedData {
 
     public SpongeAttachedData(boolean attached) {
-        super(AttachedData.class, attached, Keys.ATTACHED, ImmutableSpongeAttachedData.class);
+        super(AttachedData.class, attached, Keys.ATTACHED, ImmutableSpongeAttachedData.class, false);
     }
 
     public SpongeAttachedData() {
@@ -44,11 +43,6 @@ public class SpongeAttachedData extends AbstractBooleanData<AttachedData, Immuta
 
     @Override
     public Value<Boolean> attached() {
-        return new SpongeValue<>(Keys.ATTACHED, false, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return attached();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeAxisData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeAxisData.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.block;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableAxisData;
 import org.spongepowered.api.data.manipulator.mutable.block.AxisData;
@@ -33,12 +31,11 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.util.Axis;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeAxisData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleEnumData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeAxisData extends AbstractSingleEnumData<Axis, AxisData, ImmutableAxisData> implements AxisData {
 
     public SpongeAxisData(Axis axis) {
-        super(AxisData.class, checkNotNull(axis), Keys.AXIS, ImmutableSpongeAxisData.class);
+        super(AxisData.class, axis, Keys.AXIS, ImmutableSpongeAxisData.class, Axis.X);
     }
 
     public SpongeAxisData() {
@@ -46,12 +43,7 @@ public class SpongeAxisData extends AbstractSingleEnumData<Axis, AxisData, Immut
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return type();
-    }
-
-    @Override
     public Value<Axis> type() {
-        return new SpongeValue<>(Keys.AXIS, getValue());
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeConnectedDirectionData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeConnectedDirectionData.java
@@ -24,6 +24,9 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.block;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Preconditions;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
@@ -92,11 +95,88 @@ public class SpongeConnectedDirectionData extends AbstractData<ConnectedDirectio
 
     @Override
     public DataContainer toContainer() {
-        return new MemoryDataContainer(); // todo
+        return new MemoryDataContainer()
+                .set(Keys.CONNECTED_DIRECTIONS.getQuery(), this.connectedDirections)
+                .set(Keys.CONNECTED_NORTH.getQuery(), this.connectedDirections.contains(Direction.NORTH))
+                .set(Keys.CONNECTED_SOUTH.getQuery(), this.connectedDirections.contains(Direction.SOUTH))
+                .set(Keys.CONNECTED_EAST.getQuery(), this.connectedDirections.contains(Direction.EAST))
+                .set(Keys.CONNECTED_WEST.getQuery(), this.connectedDirections.contains(Direction.WEST));
+    }
+
+    private Set<Direction> getDirections() {
+        return connectedDirections;
+    }
+
+    private boolean isNorth() {
+        return connectedDirections.contains(Direction.NORTH);
+    }
+
+    private boolean isSouth() {
+        return connectedDirections.contains(Direction.SOUTH);
+    }
+
+    private boolean isEast() {
+        return connectedDirections.contains(Direction.EAST);
+    }
+
+    private boolean isWest() {
+        return connectedDirections.contains(Direction.WEST);
+    }
+
+    private void setDirections(Set<Direction> directions) {
+        this.connectedDirections = EnumSet.copyOf(checkNotNull(directions));
+    }
+
+    private void setNorth(Boolean north) {
+        if(checkNotNull(north)) {
+            this.connectedDirections.add(Direction.NORTH);
+        } else {
+            this.connectedDirections.remove(Direction.NORTH);
+        }
+    }
+
+    private void setSouth(Boolean south) {
+        if(checkNotNull(south)) {
+            this.connectedDirections.add(Direction.SOUTH);
+        } else {
+            this.connectedDirections.remove(Direction.SOUTH);
+        }
+    }
+
+    private void setEast(Boolean east) {
+        if(checkNotNull(east)) {
+            this.connectedDirections.add(Direction.EAST);
+        } else {
+            this.connectedDirections.remove(Direction.EAST);
+        }
+    }
+
+    private void setWest(Boolean west) {
+        if(checkNotNull(west)) {
+            this.connectedDirections.add(Direction.WEST);
+        } else {
+            this.connectedDirections.remove(Direction.WEST);
+        }
     }
 
     @Override
     protected void registerGettersAndSetters() {
-        // TODO
+        registerKeyValue(Keys.CONNECTED_DIRECTIONS, SpongeConnectedDirectionData.this::connectedDirections);
+        registerKeyValue(Keys.CONNECTED_NORTH, SpongeConnectedDirectionData.this::connectedNorth);
+        registerKeyValue(Keys.CONNECTED_SOUTH, SpongeConnectedDirectionData.this::connectedSouth);
+        registerKeyValue(Keys.CONNECTED_EAST, SpongeConnectedDirectionData.this::connectedEast);
+        registerKeyValue(Keys.CONNECTED_WEST, SpongeConnectedDirectionData.this::connectedWest);
+
+        registerFieldGetter(Keys.CONNECTED_DIRECTIONS, SpongeConnectedDirectionData.this::getDirections);
+        registerFieldGetter(Keys.CONNECTED_NORTH, SpongeConnectedDirectionData.this::isNorth);
+        registerFieldGetter(Keys.CONNECTED_SOUTH, SpongeConnectedDirectionData.this::isSouth);
+        registerFieldGetter(Keys.CONNECTED_EAST, SpongeConnectedDirectionData.this::isEast);
+        registerFieldGetter(Keys.CONNECTED_WEST, SpongeConnectedDirectionData.this::isWest);
+
+        registerFieldSetter(Keys.CONNECTED_DIRECTIONS, SpongeConnectedDirectionData.this::setDirections);
+        registerFieldSetter(Keys.CONNECTED_NORTH, SpongeConnectedDirectionData.this::setNorth);
+        registerFieldSetter(Keys.CONNECTED_SOUTH, SpongeConnectedDirectionData.this::setSouth);
+        registerFieldSetter(Keys.CONNECTED_EAST, SpongeConnectedDirectionData.this::setEast);
+        registerFieldSetter(Keys.CONNECTED_WEST, SpongeConnectedDirectionData.this::setWest);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDecayableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDecayableData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.block.DecayableData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeDecayableData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeDecayableData extends AbstractBooleanData<DecayableData, ImmutableDecayableData> implements DecayableData {
 
     public SpongeDecayableData(boolean decayable) {
-        super(DecayableData.class, decayable, Keys.DECAYABLE, ImmutableSpongeDecayableData.class);
+        super(DecayableData.class, decayable, Keys.DECAYABLE, ImmutableSpongeDecayableData.class, false);
     }
 
     public SpongeDecayableData() {
@@ -44,11 +43,6 @@ public class SpongeDecayableData extends AbstractBooleanData<DecayableData, Immu
 
     @Override
     public Value<Boolean> decayable() {
-        return new SpongeValue<>(Keys.DECAYABLE, true, getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return decayable();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDirectionalData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDirectionalData.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.block;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableDirectionalData;
 import org.spongepowered.api.data.manipulator.mutable.block.DirectionalData;
@@ -33,12 +31,11 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeDirectionalData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleEnumData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeDirectionalData extends AbstractSingleEnumData<Direction, DirectionalData, ImmutableDirectionalData> implements DirectionalData {
 
     public SpongeDirectionalData(Direction direction) {
-        super(DirectionalData.class, checkNotNull(direction), Keys.DIRECTION, ImmutableSpongeDirectionalData.class);
+        super(DirectionalData.class, direction, Keys.DIRECTION, ImmutableSpongeDirectionalData.class, Direction.NORTH);
     }
 
     public SpongeDirectionalData() {
@@ -47,11 +44,6 @@ public class SpongeDirectionalData extends AbstractSingleEnumData<Direction, Dir
 
     @Override
     public Value<Direction> direction() {
-        return new SpongeValue<>(Keys.DIRECTION, Direction.NONE, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return direction();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDisarmedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDisarmedData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.DisarmedData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeDisarmedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeDisarmedData extends AbstractBooleanData<DisarmedData, ImmutableDisarmedData> implements DisarmedData {
 
     public SpongeDisarmedData(boolean value) {
-        super(DisarmedData.class, value, Keys.DISARMED, ImmutableSpongeDisarmedData.class);
+        super(DisarmedData.class, value, Keys.DISARMED, ImmutableSpongeDisarmedData.class, false);
     }
 
     @Override
     public Value<Boolean> disarmed() {
-        return new SpongeValue<>(Keys.DISARMED, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return disarmed();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDropData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeDropData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.DropData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeDropData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeDropData extends AbstractBooleanData<DropData, ImmutableDropData> implements DropData {
 
     public SpongeDropData(boolean value) {
-        super(DropData.class, value, Keys.SHOULD_DROP, ImmutableSpongeDropData.class);
+        super(DropData.class, value, Keys.SHOULD_DROP, ImmutableSpongeDropData.class, false);
     }
 
     @Override
     public Value<Boolean> willDrop() {
-        return new SpongeValue<>(Keys.SHOULD_DROP, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return willDrop();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeExtendedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeExtendedData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.ExtendedData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeExtendedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeExtendedData extends AbstractBooleanData<ExtendedData, ImmutableExtendedData> implements ExtendedData {
 
     public SpongeExtendedData(boolean value) {
-        super(ExtendedData.class, value, Keys.EXTENDED, ImmutableSpongeExtendedData.class);
+        super(ExtendedData.class, value, Keys.EXTENDED, ImmutableSpongeExtendedData.class, false);
     }
 
     @Override
     public Value<Boolean> extended() {
-        return new SpongeValue<>(Keys.EXTENDED, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return extended();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeFilledData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeFilledData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.block.FilledData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeFilledData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeFilledData extends AbstractBooleanData<FilledData, ImmutableFilledData> implements FilledData {
 
     public SpongeFilledData(boolean value) {
-        super(FilledData.class, value, Keys.FILLED, ImmutableSpongeFilledData.class);
+        super(FilledData.class, value, Keys.FILLED, ImmutableSpongeFilledData.class, false);
     }
 
     @Override
     public Value<Boolean> filled() {
-        return new SpongeValue<>(Keys.FILLED, this.getValue());
+        return getValueGetter();
     }
 
-    @Override
-    protected Value<?> getValueGetter() {
-        return filled();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeFluidLevelData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeFluidLevelData.java
@@ -30,29 +30,25 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableFluidLevelData;
 import org.spongepowered.api.data.manipulator.mutable.block.FluidLevelData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeFluidLevelData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class SpongeFluidLevelData extends AbstractBoundedComparableData<Integer, FluidLevelData, ImmutableFluidLevelData> implements FluidLevelData {
 
-    public SpongeFluidLevelData(Integer value, Integer lowerBound, Integer upperBound) {
-        super(FluidLevelData.class, value, Keys.FLUID_LEVEL, intComparator(), ImmutableSpongeFluidLevelData.class, lowerBound, upperBound);
+    public SpongeFluidLevelData() {
+        this(0);
+    }
+
+    public SpongeFluidLevelData(int value) {
+        this(value, 0, Integer.MAX_VALUE);
+    }
+
+    public SpongeFluidLevelData(int value, int lowerBound, int upperBound) {
+        super(FluidLevelData.class, value, Keys.FLUID_LEVEL, intComparator(), ImmutableSpongeFluidLevelData.class, lowerBound, upperBound, 0);
     }
 
     @Override
     public MutableBoundedValue<Integer> level() {
-        return SpongeValueBuilder.boundedBuilder(Keys.FLUID_LEVEL)
-            .defaultValue(0)
-            .minimum(this.lowerBound)
-            .maximum(this.upperBound)
-            .actualValue(this.getValue())
-            .build();
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return level();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeGrowthData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeGrowthData.java
@@ -30,33 +30,25 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableGrowthData;
 import org.spongepowered.api.data.manipulator.mutable.block.GrowthData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeGrowthData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class SpongeGrowthData extends AbstractBoundedComparableData<Integer, GrowthData, ImmutableGrowthData> implements GrowthData {
 
     public SpongeGrowthData() {
-        this(0, 0, 1);
+        this(0);
+    }
+
+    public SpongeGrowthData(int value) {
+        this(value, 0, 1);
     }
 
     public SpongeGrowthData(int value, int lowerBound, int upperBound) {
-        super(GrowthData.class, value, Keys.GROWTH_STAGE, intComparator(), ImmutableSpongeGrowthData.class, lowerBound, upperBound);
+        super(GrowthData.class, value, Keys.GROWTH_STAGE, intComparator(), ImmutableSpongeGrowthData.class, lowerBound, upperBound, 0);
     }
 
     @Override
     public MutableBoundedValue<Integer> growthStage() {
-        return SpongeValueBuilder.boundedBuilder(Keys.FLUID_LEVEL)
-            .defaultValue(0)
-            .minimum(this.lowerBound)
-            .maximum(this.upperBound)
-            .actualValue(this.getValue())
-            .build();
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return growthStage();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeInWallData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeInWallData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.InWallData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeInWallData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeInWallData extends AbstractBooleanData<InWallData, ImmutableInWallData> implements InWallData {
 
     public SpongeInWallData(boolean value) {
-        super(InWallData.class, value, Keys.IN_WALL, ImmutableSpongeInWallData.class);
+        super(InWallData.class, value, Keys.IN_WALL, ImmutableSpongeInWallData.class, false);
     }
 
     @Override
     public Value<Boolean> inWall() {
-        return new SpongeValue<>(Keys.IN_WALL, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return inWall();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeLayeredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeLayeredData.java
@@ -30,29 +30,25 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableLayeredData;
 import org.spongepowered.api.data.manipulator.mutable.block.LayeredData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeLayeredData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class SpongeLayeredData extends AbstractBoundedComparableData<Integer, LayeredData, ImmutableLayeredData> implements LayeredData {
 
+    public SpongeLayeredData() {
+        this(0);
+    }
+
+    public SpongeLayeredData(int value) {
+        this(value, 0, Integer.MAX_VALUE);
+    }
+
     public SpongeLayeredData(int value, int lowerBound, int upperBound) {
-        super(LayeredData.class, value, Keys.LAYER, intComparator(), ImmutableSpongeLayeredData.class, lowerBound, upperBound);
+        super(LayeredData.class, value, Keys.LAYER, intComparator(), ImmutableSpongeLayeredData.class, lowerBound, upperBound, 0);
     }
 
     @Override
     public MutableBoundedValue<Integer> layer() {
-        return SpongeValueBuilder.boundedBuilder(Keys.LAYER)
-            .defaultValue(0)
-            .minimum(this.lowerBound)
-            .maximum(this.upperBound)
-            .actualValue(this.getValue())
-            .build();
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return layer();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeMoistureData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeMoistureData.java
@@ -30,29 +30,25 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableMoistureData;
 import org.spongepowered.api.data.manipulator.mutable.block.MoistureData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeMoistureData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class SpongeMoistureData extends AbstractBoundedComparableData<Integer, MoistureData, ImmutableMoistureData> implements MoistureData {
 
+    public SpongeMoistureData() {
+        this(0);
+    }
+
+    public SpongeMoistureData(int value) {
+        this(value, 0, Integer.MAX_VALUE);
+    }
+
     public SpongeMoistureData(int value, int lowerBound, int upperBound) {
-        super(MoistureData.class, value, Keys.MOISTURE, intComparator(), ImmutableSpongeMoistureData.class, lowerBound, upperBound);
+        super(MoistureData.class, value, Keys.MOISTURE, intComparator(), ImmutableSpongeMoistureData.class, lowerBound, upperBound, 0);
     }
 
     @Override
     public MutableBoundedValue<Integer> moisture() {
-        return SpongeValueBuilder.boundedBuilder(Keys.MOISTURE)
-            .defaultValue(0)
-            .minimum(this.lowerBound)
-            .maximum(this.upperBound)
-            .actualValue(this.getValue())
-            .build();
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return moisture();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeOccupiedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeOccupiedData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.OccupiedData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeOccupiedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeOccupiedData extends AbstractBooleanData<OccupiedData, ImmutableOccupiedData> implements OccupiedData {
 
     public SpongeOccupiedData(boolean value) {
-        super(OccupiedData.class, value, Keys.OCCUPIED, ImmutableSpongeOccupiedData.class);
+        super(OccupiedData.class, value, Keys.OCCUPIED, ImmutableSpongeOccupiedData.class, false);
     }
 
     @Override
     public Value<Boolean> occupied() {
-        return new SpongeValue<>(Keys.OCCUPIED, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return occupied();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeOpenData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeOpenData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.OpenData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeOpenData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeOpenData extends AbstractBooleanData<OpenData, ImmutableOpenData> implements OpenData {
 
     public SpongeOpenData(boolean value) {
-        super(OpenData.class, value, Keys.OPEN, ImmutableSpongeOpenData.class);
+        super(OpenData.class, value, Keys.OPEN, ImmutableSpongeOpenData.class, false);
     }
 
     @Override
     public Value<Boolean> open() {
-        return new SpongeValue<>(Keys.OPEN, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return open();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongePoweredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongePoweredData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.PoweredData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongePoweredData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongePoweredData extends AbstractBooleanData<PoweredData, ImmutablePoweredData> implements PoweredData {
 
     public SpongePoweredData(boolean value) {
-        super(PoweredData.class, value, Keys.POWERED, ImmutableSpongePoweredData.class);
+        super(PoweredData.class, value, Keys.POWERED, ImmutableSpongePoweredData.class, false);
     }
 
     @Override
     public Value<Boolean> powered() {
-        return new SpongeValue<>(Keys.POWERED, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return powered();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeRedstonePoweredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeRedstonePoweredData.java
@@ -30,10 +30,8 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableRedstonePoweredData;
 import org.spongepowered.api.data.manipulator.mutable.block.RedstonePoweredData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeRedstonePoweredData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class SpongeRedstonePoweredData extends AbstractBoundedComparableData<Integer, RedstonePoweredData, ImmutableRedstonePoweredData>
     implements RedstonePoweredData {
@@ -43,21 +41,15 @@ public class SpongeRedstonePoweredData extends AbstractBoundedComparableData<Int
     }
 
     public SpongeRedstonePoweredData(int value) {
-        super(RedstonePoweredData.class, value, Keys.MOISTURE, intComparator(), ImmutableSpongeRedstonePoweredData.class, 0, 15);
+        this(value, 0, 15);
+    }
+
+    public SpongeRedstonePoweredData(int value, int minimum, int maximum) {
+        super(RedstonePoweredData.class, value, Keys.MOISTURE, intComparator(), ImmutableSpongeRedstonePoweredData.class, minimum, maximum, 0);
     }
 
     @Override
     public MutableBoundedValue<Integer> power() {
-        return SpongeValueBuilder.boundedBuilder(Keys.POWER)
-            .defaultValue(0)
-            .minimum(0)
-            .maximum(15)
-            .actualValue(this.getValue())
-            .build();
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return power();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeSeamlessData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeSeamlessData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.SeamlessData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeSeamlessData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeSeamlessData extends AbstractBooleanData<SeamlessData, ImmutableSeamlessData> implements SeamlessData {
 
     public SpongeSeamlessData(boolean value) {
-        super(SeamlessData.class, value, Keys.SEAMLESS, ImmutableSpongeSeamlessData.class);
+        super(SeamlessData.class, value, Keys.SEAMLESS, ImmutableSpongeSeamlessData.class, false);
     }
 
     @Override
     public Value<Boolean> seamless() {
-        return new SpongeValue<>(Keys.SEAMLESS, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return seamless();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeSnowedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeSnowedData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.SnowedData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeSnowedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeSnowedData extends AbstractBooleanData<SnowedData, ImmutableSnowedData> implements SnowedData {
 
     public SpongeSnowedData(boolean value) {
-        super(SnowedData.class, value, Keys.SNOWED, ImmutableSpongeSnowedData.class);
+        super(SnowedData.class, value, Keys.SNOWED, ImmutableSpongeSnowedData.class, false);
     }
 
     @Override
     public Value<Boolean> hasSnow() {
-        return new SpongeValue<>(Keys.SNOWED, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return hasSnow();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeSuspendedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/block/SpongeSuspendedData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.SuspendedData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.block.ImmutableSpongeSuspendedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeSuspendedData extends AbstractBooleanData<SuspendedData, ImmutableSuspendedData> implements SuspendedData {
 
     public SpongeSuspendedData(boolean value) {
-        super(SuspendedData.class, value, Keys.SUSPENDED, ImmutableSpongeSuspendedData.class);
+        super(SuspendedData.class, value, Keys.SUSPENDED, ImmutableSpongeSuspendedData.class, false);
     }
 
     @Override
     public Value<Boolean> suspended() {
-        return new SpongeValue<>(Keys.SUSPENDED, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return suspended();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractBooleanData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractBooleanData.java
@@ -34,7 +34,9 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.util.ReflectionUtil;
 
 import java.lang.reflect.Modifier;
@@ -43,12 +45,19 @@ public abstract class AbstractBooleanData<M extends DataManipulator<M, I>, I ext
         AbstractSingleData<Boolean, M, I> {
 
     private final Class<? extends I> immutableClass;
+    private final Boolean defaultValue;
 
-    protected AbstractBooleanData(Class<M> manipulatorClass, Boolean value, Key<? extends BaseValue<Boolean>> usedKey, Class<? extends I> immutableClass) {
+    protected AbstractBooleanData(Class<M> manipulatorClass, Boolean value, Key<? extends BaseValue<Boolean>> usedKey, Class<? extends I> immutableClass, Boolean defaultValue) {
         super(manipulatorClass, value, usedKey);
         checkArgument(!Modifier.isAbstract(immutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(immutableClass.getModifiers()), "The immutable class cannot be an interface!");
         this.immutableClass = checkNotNull(immutableClass);
+        this.defaultValue = checkNotNull(defaultValue);
+    }
+
+    @Override
+    protected Value<Boolean> getValueGetter() {
+        return new SpongeValue<>(this.usedKey, this.defaultValue, this.getValue());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractBoundedComparableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractBoundedComparableData.java
@@ -33,7 +33,9 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
+import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 import org.spongepowered.common.util.ReflectionUtil;
 
 import java.lang.reflect.Modifier;
@@ -46,9 +48,10 @@ public abstract class AbstractBoundedComparableData<T extends Comparable<T>, M e
     protected final Comparator<T> comparator;
     protected final T lowerBound;
     protected final T upperBound;
+    protected final T defaultValue;
 
     protected AbstractBoundedComparableData(Class<M> manipulatorClass, T value, Key<? extends BaseValue<T>> usedKey, Comparator<T> comparator,
-                                         Class<? extends I> immutableClass, T lowerBound, T upperBound) {
+                                         Class<? extends I> immutableClass, T lowerBound, T upperBound, T defaultValue) {
         super(manipulatorClass, value, usedKey);
         this.comparator = checkNotNull(comparator);
         checkArgument(!Modifier.isAbstract(immutableClass.getModifiers()), "The immutable class cannot be abstract!");
@@ -56,12 +59,18 @@ public abstract class AbstractBoundedComparableData<T extends Comparable<T>, M e
         this.immutableClass = checkNotNull(immutableClass);
         this.lowerBound = checkNotNull(lowerBound);
         this.upperBound = checkNotNull(upperBound);
+        this.defaultValue = checkNotNull(defaultValue);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public M copy() {
         return (M) ReflectionUtil.createInstance(this.getClass(), this.getValue(), this.lowerBound, this.upperBound);
+    }
+
+    @Override
+    protected MutableBoundedValue<T> getValueGetter() {
+        return new SpongeBoundedValue<>(this.usedKey, this.defaultValue, this.comparator, this.lowerBound, this.upperBound, this.getValue());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractSingleEnumData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/AbstractSingleEnumData.java
@@ -33,7 +33,9 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.ImmutableDataCachingUtil;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.util.ReflectionUtil;
 
 import java.lang.reflect.Modifier;
@@ -50,12 +52,14 @@ public abstract class AbstractSingleEnumData<E extends Enum<E>, M extends DataMa
         extends AbstractSingleData<E, M, I> {
 
     private final Class<? extends I> immutableClass;
+    private final E defaultValue;
 
-    protected AbstractSingleEnumData(Class<M> manipulatorClass, E value, Key<? extends BaseValue<E>> usedKey, Class<? extends I> immutableClass) {
+    protected AbstractSingleEnumData(Class<M> manipulatorClass, E value, Key<? extends BaseValue<E>> usedKey, Class<? extends I> immutableClass, E defaultValue) {
         super(manipulatorClass, value, usedKey);
         checkArgument(!Modifier.isAbstract(immutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(immutableClass.getModifiers()), "The immutable class cannot be an interface!");
         this.immutableClass = checkNotNull(immutableClass);
+        this.defaultValue = checkNotNull(defaultValue);
     }
 
     @Override
@@ -79,4 +83,8 @@ public abstract class AbstractSingleEnumData<E extends Enum<E>, M extends DataMa
         return ImmutableDataCachingUtil.getManipulator(this.immutableClass, getValue());
     }
 
+    @Override
+    protected Value<E> getValueGetter() {
+        return new SpongeValue<E>(this.usedKey, this.defaultValue, this.getValue());
+    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/collection/AbstractSingleListData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/collection/AbstractSingleListData.java
@@ -25,13 +25,15 @@
 package org.spongepowered.common.data.manipulator.mutable.common.collection;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
-import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
 import org.spongepowered.common.data.value.mutable.SpongeListValue;
 import org.spongepowered.common.util.ReflectionUtil;
@@ -60,11 +62,12 @@ public abstract class AbstractSingleListData<E, M extends DataManipulator<M, I>,
 
     @Override
     public M setValue(List<E> value) {
+        checkNotNull(value).forEach(Preconditions::checkNotNull);
         return super.setValue(Lists.newArrayList(value));
     }
 
     @Override
-    protected Value<?> getValueGetter() {
+    protected ListValue<E> getValueGetter() {
         return new SpongeListValue<>(this.usedKey, getValue());
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeAgentData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeAgentData.java
@@ -35,7 +35,7 @@ import org.spongepowered.common.data.value.mutable.SpongeValue;
 public class SpongeAgentData extends AbstractBooleanData<AgentData, ImmutableAgentData> implements AgentData {
 
     public SpongeAgentData(Boolean value) {
-        super(AgentData.class, value, Keys.AI_ENABLED, ImmutableSpongeAgentData.class);
+        super(AgentData.class, value, Keys.AI_ENABLED, ImmutableSpongeAgentData.class, true);
     }
 
     public SpongeAgentData() {
@@ -43,12 +43,7 @@ public class SpongeAgentData extends AbstractBooleanData<AgentData, ImmutableAge
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return aiEnabled();
-    }
-
-    @Override
     public Value<Boolean> aiEnabled() {
-        return new SpongeValue<>(Keys.AI_ENABLED, true, getValue());
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeChargedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeChargedData.java
@@ -35,7 +35,7 @@ import org.spongepowered.common.data.value.mutable.SpongeValue;
 public class SpongeChargedData extends AbstractBooleanData<ChargedData, ImmutableChargedData> implements ChargedData {
 
     public SpongeChargedData(Boolean value) {
-        super(ChargedData.class, value, Keys.CREEPER_CHARGED, ImmutableSpongeChargedData.class);
+        super(ChargedData.class, value, Keys.CREEPER_CHARGED, ImmutableSpongeChargedData.class, false);
     }
 
     public SpongeChargedData() {
@@ -43,13 +43,8 @@ public class SpongeChargedData extends AbstractBooleanData<ChargedData, Immutabl
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return charged();
-    }
-
-    @Override
     public Value<Boolean> charged() {
-        return new SpongeValue<>(Keys.CREEPER_CHARGED, false, this.getValue());
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeElderData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeElderData.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.data.manipulator.mutable.entity.ElderData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeElderData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeElderData extends AbstractBooleanData<ElderData, ImmutableElderData> implements ElderData {
 
@@ -39,16 +38,11 @@ public class SpongeElderData extends AbstractBooleanData<ElderData, ImmutableEld
     }
 
     public SpongeElderData(boolean value) {
-        super(ElderData.class, value, Keys.ELDER_GUARDIAN, ImmutableSpongeElderData.class);
+        super(ElderData.class, value, Keys.ELDER_GUARDIAN, ImmutableSpongeElderData.class, false);
     }
 
     @Override
     public Value<Boolean> elder() {
-        return new SpongeValue<>(Keys.ELDER_GUARDIAN, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return elder();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeExpOrbData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeExpOrbData.java
@@ -24,56 +24,32 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.entity;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
-
-import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableExpOrbData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpOrbData;
-import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeExpOrbData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
-import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
 
-public class SpongeExpOrbData extends AbstractSingleData<Integer, ExpOrbData, ImmutableExpOrbData> implements ExpOrbData {
+import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
 
-    public SpongeExpOrbData(Integer value) {
-        super(ExpOrbData.class, value, Keys.CONTAINED_EXPERIENCE);
+public class SpongeExpOrbData extends AbstractBoundedComparableData<Integer, ExpOrbData, ImmutableExpOrbData> implements ExpOrbData {
+
+	public SpongeExpOrbData() {
+		this(0);
+	}
+
+	public SpongeExpOrbData(int value) {
+		this(value, 0, Integer.MAX_VALUE);
+	}
+
+    // For reflection
+	public SpongeExpOrbData(int value, int minimum, int maximum) {
+        super(ExpOrbData.class, value, Keys.CONTAINED_EXPERIENCE, intComparator(), ImmutableSpongeExpOrbData.class, minimum, maximum, 0);
     }
 
-    public SpongeExpOrbData() {
-        this(0);
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return experience();
-    }
-
-    @Override
-    public ExpOrbData copy() {
-        return new SpongeExpOrbData(this.getValue());
-    }
-
-    @Override
-    public ImmutableExpOrbData asImmutable() {
-        return new ImmutableSpongeExpOrbData(this.getValue());
-    }
-
-    @Override
-    public int compareTo(ExpOrbData o) {
-        return o.experience().get().compareTo(this.getValue());
-    }
-
-    @Override
-    public Value<Integer> experience() {
-        return new SpongeBoundedValue<>(Keys.CONTAINED_EXPERIENCE, 0, intComparator(), 0, Integer.MAX_VALUE, this.getValue());
-    }
-
-    @Override
-    public DataContainer toContainer() {
-        return new MemoryDataContainer().set(Keys.CONTAINED_EXPERIENCE, this.getValue());
-    }
-
+	@Override
+	public MutableBoundedValue<Integer> experience() {
+		return getValueGetter();
+	}
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFallDistanceData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFallDistanceData.java
@@ -41,21 +41,11 @@ public class SpongeFallDistanceData extends AbstractBoundedComparableData<Float,
     }
 
     public SpongeFallDistanceData(float fallDistance) {
-        super(FallDistanceData.class, fallDistance, Keys.FALL_DISTANCE, ComparatorUtil.floatComparator(), ImmutableSpongeFallDistanceData.class, 0F, Float.MAX_VALUE);
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return this.fallDistance();
+        super(FallDistanceData.class, fallDistance, Keys.FALL_DISTANCE, ComparatorUtil.floatComparator(), ImmutableSpongeFallDistanceData.class, 0F, Float.MAX_VALUE, 0F);
     }
 
     @Override
     public MutableBoundedValue<Float> fallDistance() {
-        return SpongeValueBuilder.boundedBuilder(Keys.FALL_DISTANCE)
-                .actualValue(this.getValue())
-                .defaultValue(0F)
-                .minimum(0F)
-                .maximum(Float.MAX_VALUE)
-                .build();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFlyingAbilityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFlyingAbilityData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.entity.FlyingAbilityData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeFlyingAbilityData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeFlyingAbilityData extends AbstractBooleanData<FlyingAbilityData, ImmutableFlyingAbilityData> implements FlyingAbilityData {
 
     public SpongeFlyingAbilityData(boolean value) {
-        super(FlyingAbilityData.class, value, Keys.CAN_FLY, ImmutableSpongeFlyingAbilityData.class);
+        super(FlyingAbilityData.class, value, Keys.CAN_FLY, ImmutableSpongeFlyingAbilityData.class, false);
     }
 
     public SpongeFlyingAbilityData() {
@@ -43,13 +42,8 @@ public class SpongeFlyingAbilityData extends AbstractBooleanData<FlyingAbilityDa
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return canFly();
-    }
-
-    @Override
     public Value<Boolean> canFly() {
-        return new SpongeValue<>(Keys.CAN_FLY, false, this.getValue());
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFlyingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeFlyingData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.entity.FlyingData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeFlyingData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeFlyingData extends AbstractBooleanData<FlyingData, ImmutableFlyingData> implements FlyingData {
 
     public SpongeFlyingData(boolean value) {
-        super(FlyingData.class, value, Keys.IS_FLYING, ImmutableSpongeFlyingData.class);
+        super(FlyingData.class, value, Keys.IS_FLYING, ImmutableSpongeFlyingData.class, false);
     }
 
     public SpongeFlyingData() {
@@ -44,13 +43,7 @@ public class SpongeFlyingData extends AbstractBooleanData<FlyingData, ImmutableF
 
     @Override
     public Value<Boolean> flying() {
-        return new SpongeValue<>(Keys.IS_FLYING, false, this.getValue());
+        return getValueGetter();
     }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return flying();
-    }
-
 }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeHealthData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeHealthData.java
@@ -67,7 +67,7 @@ public class SpongeHealthData extends AbstractData<HealthData, ImmutableHealthDa
     @Override
     public MutableBoundedValue<Double> maxHealth() {
         return SpongeValueBuilder.boundedBuilder(Keys.MAX_HEALTH)
-            .defaultValue(this.maxHealth)
+            .defaultValue(20D)
             .minimum(0D)
             .maximum((double) Float.MAX_VALUE)
             .actualValue(this.maxHealth)

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeMovementSpeedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeMovementSpeedData.java
@@ -30,10 +30,10 @@ import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableMovementSpeedData;
 import org.spongepowered.api.data.manipulator.mutable.entity.MovementSpeedData;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeMovementSpeedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeMovementSpeedData extends AbstractData<MovementSpeedData, ImmutableMovementSpeedData> implements MovementSpeedData {
 
@@ -48,7 +48,7 @@ public class SpongeMovementSpeedData extends AbstractData<MovementSpeedData, Imm
     }
 
     public SpongeMovementSpeedData() {
-        this(0.1d, 0.05d);
+        this(0.7D, 0.05D);
     }
 
     public double getWalkSpeed() {
@@ -82,23 +82,13 @@ public class SpongeMovementSpeedData extends AbstractData<MovementSpeedData, Imm
     }
 
     @Override
-    public MutableBoundedValue<Double> walkSpeed() {
-        return SpongeValueBuilder.boundedBuilder(Keys.WALKING_SPEED)
-            .defaultValue(0.1D)
-            .minimum(Double.MIN_VALUE)
-            .maximum(Double.MAX_VALUE)
-            .actualValue(this.walkSpeed)
-            .build();
+    public Value<Double> walkSpeed() {
+        return new SpongeValue<>(Keys.WALKING_SPEED, 0.7D, this.walkSpeed);
     }
 
     @Override
-    public MutableBoundedValue<Double> flySpeed() {
-        return SpongeValueBuilder.boundedBuilder(Keys.FLYING_SPEED)
-            .defaultValue(0.05D)
-            .minimum(Double.MIN_VALUE)
-            .maximum(Double.MAX_VALUE)
-            .actualValue(this.flySpeed)
-            .build();
+    public Value<Double> flySpeed() {
+        return new SpongeValue<>(Keys.FLYING_SPEED, 0.05D, this.flySpeed);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePigSaddleData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePigSaddleData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.entity.PigSaddleData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongePigSaddleData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongePigSaddleData extends AbstractBooleanData<PigSaddleData, ImmutablePigSaddleData> implements PigSaddleData  {
 
     public SpongePigSaddleData(boolean value) {
-        super(PigSaddleData.class, value, Keys.PIG_SADDLE, ImmutableSpongePigSaddleData.class);
+        super(PigSaddleData.class, value, Keys.PIG_SADDLE, ImmutableSpongePigSaddleData.class, false);
     }
 
     public SpongePigSaddleData() {
@@ -43,12 +42,7 @@ public class SpongePigSaddleData extends AbstractBooleanData<PigSaddleData, Immu
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return saddle();
-    }
-
-    @Override
     public Value<Boolean> saddle() {
-        return new SpongeValue<>(Keys.PIG_SADDLE, false, this.getValue());
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePlayingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongePlayingData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.entity.PlayingData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongePlayingData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongePlayingData extends AbstractBooleanData<PlayingData, ImmutablePlayingData> implements PlayingData {
 
     public SpongePlayingData(boolean value) {
-        super(PlayingData.class, value, Keys.IS_PLAYING, ImmutableSpongePlayingData.class);
+        super(PlayingData.class, value, Keys.IS_PLAYING, ImmutableSpongePlayingData.class, false);
     }
 
     public SpongePlayingData() {
@@ -43,13 +42,8 @@ public class SpongePlayingData extends AbstractBooleanData<PlayingData, Immutabl
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return playing();
-    }
-
-    @Override
     public Value<Boolean> playing() {
-        return new SpongeValue<>(Keys.IS_PLAYING, false, this.getValue());
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeScreamingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeScreamingData.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.data.manipulator.mutable.entity.ScreamingData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeScreamingData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeScreamingData extends AbstractBooleanData<ScreamingData, ImmutableScreamingData> implements ScreamingData {
 
@@ -39,16 +38,11 @@ public class SpongeScreamingData extends AbstractBooleanData<ScreamingData, Immu
     }
 
     public SpongeScreamingData(boolean value) {
-        super(ScreamingData.class, value, Keys.IS_SCREAMING, ImmutableSpongeScreamingData.class);
+        super(ScreamingData.class, value, Keys.IS_SCREAMING, ImmutableSpongeScreamingData.class, false);
     }
 
     @Override
     public Value<Boolean> screaming() {
-        return new SpongeValue<>(Keys.IS_SCREAMING, this.getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return screaming();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeShearedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeShearedData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.entity.ShearedData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeShearedData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeShearedData extends AbstractBooleanData<ShearedData, ImmutableShearedData> implements ShearedData {
 
     public SpongeShearedData(boolean value) {
-        super(ShearedData.class, value, Keys.IS_SHEARED, ImmutableSpongeShearedData.class);
+        super(ShearedData.class, value, Keys.IS_SHEARED, ImmutableSpongeShearedData.class, false);
     }
 
     public SpongeShearedData() {
@@ -43,12 +42,7 @@ public class SpongeShearedData extends AbstractBooleanData<ShearedData, Immutabl
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return sheared();
-    }
-
-    @Override
     public Value<Boolean> sheared() {
-        return new SpongeValue<>(Keys.IS_SHEARED, false, this.getValue());
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSittingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSittingData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.entity.SittingData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSittingData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeSittingData extends AbstractBooleanData<SittingData, ImmutableSittingData> implements SittingData {
 
     public SpongeSittingData(boolean value) {
-        super(SittingData.class, value, Keys.IS_SITTING, ImmutableSpongeSittingData.class);
+        super(SittingData.class, value, Keys.IS_SITTING, ImmutableSpongeSittingData.class, false);
     }
 
     public SpongeSittingData() {
@@ -43,13 +42,8 @@ public class SpongeSittingData extends AbstractBooleanData<SittingData, Immutabl
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return sitting();
-    }
-
-    @Override
     public Value<Boolean> sitting() {
-        return new SpongeValue<>(Keys.IS_SITTING, false, this.getValue());
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSlimeData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSlimeData.java
@@ -30,33 +30,25 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSlimeData;
 import org.spongepowered.api.data.manipulator.mutable.entity.SlimeData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSlimeData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 public class SpongeSlimeData extends AbstractBoundedComparableData<Integer, SlimeData, ImmutableSlimeData> implements SlimeData {
-
-    public SpongeSlimeData(int value) {
-        super(SlimeData.class, value, Keys.SLIME_SIZE, intComparator(), ImmutableSpongeSlimeData.class, 0, Integer.MAX_VALUE);
-    }
 
     public SpongeSlimeData() {
         this(0);
     }
 
-    @Override
-    public MutableBoundedValue<Integer> size() {
-        return SpongeValueBuilder.boundedBuilder(Keys.SLIME_SIZE)
-            .defaultValue(0)
-            .minimum(0)
-            .maximum(Integer.MAX_VALUE)
-            .actualValue(this.getValue())
-            .build();
+    public SpongeSlimeData(int value) {
+        this(value, 0, Integer.MAX_VALUE);
+    }
+
+    public SpongeSlimeData(int value, int minimum, int maximum) {
+        super(SlimeData.class, value, Keys.SLIME_SIZE, intComparator(), ImmutableSpongeSlimeData.class, minimum, maximum, 0);
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return this.size();
+    public MutableBoundedValue<Integer> size() {
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSneakingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSneakingData.java
@@ -30,7 +30,6 @@ import org.spongepowered.api.data.manipulator.mutable.entity.SneakingData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSneakingData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeSneakingData extends AbstractBooleanData<SneakingData, ImmutableSneakingData> implements SneakingData {
 
@@ -39,16 +38,11 @@ public class SpongeSneakingData extends AbstractBooleanData<SneakingData, Immuta
     }
 
     public SpongeSneakingData(boolean sneaking) {
-        super(SneakingData.class, sneaking, Keys.IS_SNEAKING, ImmutableSpongeSneakingData.class);
+        super(SneakingData.class, sneaking, Keys.IS_SNEAKING, ImmutableSpongeSneakingData.class, false);
     }
 
     @Override
     public Value<Boolean> sneaking() {
-        return new SpongeValue<>(Keys.IS_SNEAKING, false, getValue());
-    }
-
-    @Override
-    protected Value<?> getValueGetter() {
-        return sneaking();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeVillagerZombieData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeVillagerZombieData.java
@@ -30,12 +30,11 @@ import org.spongepowered.api.data.manipulator.mutable.entity.VillagerZombieData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeVillagerZombieData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeVillagerZombieData extends AbstractBooleanData<VillagerZombieData, ImmutableVillagerZombieData> implements VillagerZombieData {
 
     public SpongeVillagerZombieData(boolean value) {
-        super(VillagerZombieData.class, value, Keys.IS_VILLAGER_ZOMBIE, ImmutableSpongeVillagerZombieData.class);
+        super(VillagerZombieData.class, value, Keys.IS_VILLAGER_ZOMBIE, ImmutableSpongeVillagerZombieData.class, false);
     }
 
     public SpongeVillagerZombieData() {
@@ -43,12 +42,7 @@ public class SpongeVillagerZombieData extends AbstractBooleanData<VillagerZombie
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return this.villagerZombie();
-    }
-
-    @Override
     public Value<Boolean> villagerZombie() {
-        return new SpongeValue<Boolean>(Keys.IS_VILLAGER_ZOMBIE, false, this.getValue());
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeBrewingStandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeBrewingStandData.java
@@ -24,64 +24,31 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.tileentity;
 
-import com.google.common.collect.ComparisonChain;
-import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableBrewingStandData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.BrewingStandData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeBrewingStandData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
+import org.spongepowered.common.data.util.ComparatorUtil;
 
-public class SpongeBrewingStandData extends AbstractSingleData<Integer, BrewingStandData, ImmutableBrewingStandData> implements BrewingStandData {
-
-    public SpongeBrewingStandData(Integer value) {
-        super(BrewingStandData.class, value, Keys.REMAINING_BREW_TIME);
-    }
+public class SpongeBrewingStandData extends AbstractBoundedComparableData<Integer, BrewingStandData, ImmutableBrewingStandData> implements BrewingStandData {
 
     public SpongeBrewingStandData() {
-        this(0);
+        this(400);
     }
 
-    @Override
-    protected Value<?> getValueGetter() {
-        return this.remainingBrewTime();
+    public SpongeBrewingStandData(int value) {
+        this(value, 0, Integer.MAX_VALUE);
     }
 
-    @Override
-    public BrewingStandData copy() {
-        return new SpongeBrewingStandData(this.getValue());
-    }
-
-    @Override
-    public ImmutableBrewingStandData asImmutable() {
-        return new ImmutableSpongeBrewingStandData(this.getValue());
-    }
-
-    @Override
-    public int compareTo(BrewingStandData o) {
-        return ComparisonChain
-                .start()
-                .compare(o.remainingBrewTime().get(), this.getValue())
-                .result();
+    // For reflection
+    public SpongeBrewingStandData(int value, int minimum, int maximum) {
+        super(BrewingStandData.class, value, Keys.REMAINING_BREW_TIME, ComparatorUtil.intComparator(), ImmutableSpongeBrewingStandData.class, minimum, maximum, 400);
     }
 
     @Override
     public MutableBoundedValue<Integer> remainingBrewTime() {
-        return SpongeValueBuilder.boundedBuilder(Keys.REMAINING_BREW_TIME)
-                .minimum(0)
-                .maximum(Integer.MAX_VALUE)
-                .defaultValue(400)
-                .actualValue(this.getValue())
-                .build();
-    }
-
-    @Override
-    public DataContainer toContainer() {
-        return new MemoryDataContainer()
-                .set(Keys.REMAINING_BREW_TIME, this.getValue());
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeCooldownData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeCooldownData.java
@@ -24,57 +24,26 @@
  */
 package org.spongepowered.common.data.manipulator.mutable.tileentity;
 
-import com.google.common.collect.ComparisonChain;
-import org.spongepowered.api.data.DataContainer;
-import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableCooldownData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.CooldownData;
-import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeCooldownData;
-import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
-import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractBoundedComparableData;
+import org.spongepowered.common.data.util.ComparatorUtil;
 
-public class SpongeCooldownData extends AbstractSingleData<Integer, CooldownData, ImmutableCooldownData> implements CooldownData {
+public class SpongeCooldownData extends AbstractBoundedComparableData<Integer, CooldownData, ImmutableCooldownData> implements CooldownData {
 
     public SpongeCooldownData(int value) {
-        super(CooldownData.class, value, Keys.COOLDOWN);
+        super(CooldownData.class, value, Keys.COOLDOWN, ComparatorUtil.intComparator(), ImmutableSpongeCooldownData.class, 0, Integer.MAX_VALUE, 0);
     }
 
     public SpongeCooldownData() {
-        this(-1);
+        this(0);
     }
 
     @Override
-    protected Value<?> getValueGetter() {
-        return cooldown();
-    }
-
-    @Override
-    public CooldownData copy() {
-        return new SpongeCooldownData(this.getValue());
-    }
-
-    @Override
-    public ImmutableCooldownData asImmutable() {
-        return new ImmutableSpongeCooldownData(this.getValue());
-    }
-
-    @Override
-    public int compareTo(CooldownData o) {
-        return ComparisonChain.start()
-                .compare(this.getValue(), o.cooldown().get())
-                .result();
-    }
-
-    @Override
-    public Value<Integer> cooldown() {
-        return new SpongeValue<Integer>(Keys.COOLDOWN, -1, this.getValue());
-    }
-
-    @Override
-    public DataContainer toContainer() {
-        return new MemoryDataContainer()
-                .set(Keys.COOLDOWN, this.getValue());
+    public MutableBoundedValue<Integer> cooldown() {
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/tileentity/CooldownDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/tileentity/CooldownDataProcessor.java
@@ -31,16 +31,19 @@ import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableCooldownData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.CooldownData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeCooldownData;
 import org.spongepowered.common.data.processor.common.AbstractTileEntitySingleDataProcessor;
+import org.spongepowered.common.data.value.SpongeValueBuilder;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 import java.util.Optional;
 
 public class CooldownDataProcessor
-        extends AbstractTileEntitySingleDataProcessor<TileEntityHopper, Integer, Value<Integer>, CooldownData, ImmutableCooldownData> {
+        extends AbstractTileEntitySingleDataProcessor<TileEntityHopper, Integer, MutableBoundedValue<Integer>, CooldownData, ImmutableCooldownData> {
 
     public CooldownDataProcessor() {
         super(TileEntityHopper.class, Keys.COOLDOWN);
@@ -58,8 +61,14 @@ public class CooldownDataProcessor
     }
 
     @Override
-    public ImmutableValue<Integer> constructImmutableValue(Integer value) {
-        return ImmutableSpongeValue.cachedOf(Keys.COOLDOWN, -1, value);
+    public ImmutableBoundedValue<Integer> constructImmutableValue(Integer value) {
+        return SpongeValueBuilder.boundedBuilder(Keys.COOLDOWN)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(0)
+                .actualValue(value)
+                .build()
+                .asImmutable();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FlyingSpeedValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FlyingSpeedValueProcessor.java
@@ -30,26 +30,21 @@ import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 import java.util.Optional;
 
-public class FlyingSpeedValueProcessor extends AbstractSpongeValueProcessor<EntityPlayer, Double, MutableBoundedValue<Double>> {
+public class FlyingSpeedValueProcessor extends AbstractSpongeValueProcessor<EntityPlayer, Double, Value<Double>> {
 
     public FlyingSpeedValueProcessor() {
         super(EntityPlayer.class, Keys.FLYING_SPEED);
     }
 
     @Override
-    protected MutableBoundedValue<Double> constructValue(Double defaultValue) {
-        return SpongeValueBuilder.boundedBuilder(Keys.FLYING_SPEED)
-            .defaultValue(0.05d)
-            .minimum(Double.MIN_VALUE)
-            .maximum(Double.MAX_VALUE)
-            .actualValue(defaultValue)
-            .build();
+    protected Value<Double> constructValue(Double value) {
+        return new SpongeValue<>(Keys.FLYING_SPEED, 0.05D, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/WalkingSpeedValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/WalkingSpeedValueProcessor.java
@@ -29,31 +29,26 @@ import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.ValueContainer;
-import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
-import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
-import org.spongepowered.common.data.value.SpongeValueBuilder;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 import java.util.Optional;
 
-public class WalkingSpeedValueProcessor extends AbstractSpongeValueProcessor<EntityPlayer, Double, MutableBoundedValue<Double>> {
+public class WalkingSpeedValueProcessor extends AbstractSpongeValueProcessor<EntityPlayer, Double, Value<Double>> {
 
     public WalkingSpeedValueProcessor() {
         super(EntityPlayer.class, Keys.WALKING_SPEED);
     }
 
     @Override
-    protected MutableBoundedValue<Double> constructValue(Double defaultValue) {
-        return SpongeValueBuilder.boundedBuilder(Keys.WALKING_SPEED)
-            .defaultValue(0.1D)
-            .minimum(Double.MIN_VALUE)
-            .maximum(Double.MAX_VALUE)
-            .actualValue(defaultValue)
-            .build();
+    protected Value<Double> constructValue(Double defaultValue) {
+        return new SpongeValue<>(Keys.WALKING_SPEED, 0.7D);
     }
 
     @Override
-    protected ImmutableBoundedValue<Double> constructImmutableValue(Double value) {
+    protected ImmutableValue<Double> constructImmutableValue(Double value) {
         return constructValue(value).asImmutable();
     }
 

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/CooldownValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/CooldownValueProcessor.java
@@ -30,21 +30,27 @@ import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 import java.util.Optional;
 
-public class CooldownValueProcessor extends AbstractSpongeValueProcessor<TileEntityHopper, Integer, Value<Integer>> {
+public class CooldownValueProcessor extends AbstractSpongeValueProcessor<TileEntityHopper, Integer, MutableBoundedValue<Integer>> {
 
     public CooldownValueProcessor() {
         super(TileEntityHopper.class, Keys.COOLDOWN);
     }
 
     @Override
-    public Value<Integer> constructValue(Integer defaultValue) {
-        return new SpongeValueBuilder().createValue(Keys.COOLDOWN, defaultValue, -1);
+    public MutableBoundedValue<Integer> constructValue(Integer value) {
+        return SpongeValueBuilder.boundedBuilder(Keys.COOLDOWN)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(0)
+                .actualValue(value)
+                .build();
     }
 
     @Override


### PR DESCRIPTION
API side: SpongePowered/SpongeAPI#893

This cleans up some data implementations, especially where the requirements for data has been changed recently.

- Final/Private values
  * `ImmutableBreathingData`
  * `ImmutableFoodData`
  * `ImmutableMovementSpeedData`
- Fixing `Value`s being created with uninitialized value
  * `ImmutableBreathingData`
- Move `Value`s to instance fields
  * `ImmutableExperienceHolderData`
  * `ImmutableFlyingData`
  * `ImmutableFoodData`
  * `ImmutableHorseData`
  * `ImmutableIgnitableData` 
  * `ImmutableConnectedDirectionData`
  * `ImmutableWireAttachmentData`
  * `ImmutableVelocityData`
  * `ImmutableColorData`
  * `ImmutableCommandData`
  * `ImmutableDisplayNameData`
  * `ImmutableFireworkData`
  * `ImmutableMobSpawnerData`
  * `ImmutableRepresentedItemData`
  * `ImmutableRepresentedPlayerData`
  * `ImmutableTargetedLocationData`
- Caching usage
  * `ImmutableFoodData`
- Fixing of defaults and bounds
  * `ImmutableMovementSpeedData`/`MovementSpeedData`
  * `ImmutableHealthData`/`HealthData`
- Use appropriate abstract data
  * `ImmutableLoreData`
  * `ImmutablePagedData`
  * `ImmutableSignData`
  * `ImmutableExpOrbData`/`ExpOrbData`
  * `ImmutableBrewingStandData`/`BrewingStandData`
- Implement data getter/setter registration
  * `TradeOfferData`
  * `ConnectedDirectionData`
  * `ImmutableCommandData`
  * `ImmutableFireworkData`
  * `ImmutableMobSpawnerData`
- Refactor values into the Abstract class
  * `AbstractBooleanData` and its implementations
  * `AbstractSingleEnumData` and its implementations
  * `AbstractBoundedComparableValue` and its implementations