### PR TITLE
Extract various constants into a static DataConstants

### DIFF
--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeColorData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeColorData.java
@@ -36,13 +36,15 @@ import java.awt.Color;
 
 public class ImmutableSpongeColorData extends AbstractImmutableSingleData<Color, ImmutableColoredData, ColoredData> implements ImmutableColoredData {
 
+    private final ImmutableValue<Color> immutableValue = new ImmutableSpongeValue<>(Keys.COLOR, Color.BLACK, this.value);
+
     public ImmutableSpongeColorData(Color value) {
         super(ImmutableColoredData.class, value, Keys.COLOR);
     }
 
     @Override
     protected ImmutableValue<?> getValueGetter() {
-        return color();
+        return this.immutableValue;
     }
 
     @Override
@@ -52,7 +54,7 @@ public class ImmutableSpongeColorData extends AbstractImmutableSingleData<Color,
 
     @Override
     public ImmutableValue<Color> color() {
-        return ImmutableSpongeValue.cachedOf(Keys.COLOR, Color.BLACK, this.value);
+        return this.immutableValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeCommandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeCommandData.java
@@ -32,9 +32,9 @@ import org.spongepowered.api.data.manipulator.mutable.CommandData;
 import org.spongepowered.api.data.value.immutable.ImmutableOptionalValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeCommandData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeOptionalValue;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
@@ -82,7 +82,7 @@ public class ImmutableSpongeCommandData extends AbstractImmutableData<ImmutableC
                 .setSuccessCount(this.success)
                 .setStoredCommand(this.storedCommand)
                 .shouldTrackOutput(this.tracks)
-                .setLastOutput(this.lastOutput == null ? Texts.of() : this.lastOutput);
+                .setLastOutput(this.lastOutput == null ? DataConstants.EMPTY_TEXT : this.lastOutput);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongePotionEffectData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongePotionEffectData.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.immutable;
 
-import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.ImmutablePotionEffectData;
 import org.spongepowered.api.data.manipulator.mutable.PotionEffectData;
@@ -32,7 +31,6 @@ import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.potion.PotionEffect;
 import org.spongepowered.common.data.manipulator.immutable.common.collection.AbstractImmutableSingleListData;
 import org.spongepowered.common.data.manipulator.mutable.SpongePotionEffectData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 
 import java.util.List;
 
@@ -45,7 +43,7 @@ public class ImmutableSpongePotionEffectData extends AbstractImmutableSingleList
 
     @Override
     public ImmutableListValue<PotionEffect> effects() {
-        return new ImmutableSpongeListValue<>(Keys.POTION_EFFECTS, ImmutableList.copyOf(this.value));
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedItemData.java
@@ -42,7 +42,7 @@ public class ImmutableSpongeRepresentedItemData extends AbstractImmutableSingleD
 
     @Override
     public ImmutableValue<ItemStackSnapshot> item() {
-        return new ImmutableSpongeValue<>(Keys.REPRESENTED_ITEM, this.value);
+        return new ImmutableSpongeValue<>(Keys.REPRESENTED_ITEM, ItemStackSnapshot.NONE, this.value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedPlayerData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeRepresentedPlayerData.java
@@ -40,6 +40,8 @@ public class ImmutableSpongeRepresentedPlayerData
         extends AbstractImmutableSingleData<GameProfile, ImmutableRepresentedPlayerData, RepresentedPlayerData>
         implements ImmutableRepresentedPlayerData {
 
+    private final ImmutableValue<GameProfile> immutableValue = new ImmutableSpongeValue<>(this.usedKey, SpongeRepresentedPlayerData.NULL_PROFILE, this.value);
+
     public ImmutableSpongeRepresentedPlayerData() {
         this(SpongeRepresentedPlayerData.NULL_PROFILE);
     }
@@ -50,7 +52,7 @@ public class ImmutableSpongeRepresentedPlayerData
 
     @Override
     public ImmutableValue<GameProfile> owner() {
-        return new ImmutableSpongeValue<GameProfile>(this.usedKey, this.value);
+        return this.immutableValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeTargetedLocationData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeTargetedLocationData.java
@@ -43,7 +43,7 @@ public class ImmutableSpongeTargetedLocationData extends AbstractImmutableSingle
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
+    protected ImmutableValue<Location<World>> getValueGetter() {
         return new ImmutableSpongeValue<>(Keys.TARGETED_LOCATION, new Location<>(this.value.getExtent(), Vector3d.ZERO), this.value);
     }
 
@@ -54,7 +54,7 @@ public class ImmutableSpongeTargetedLocationData extends AbstractImmutableSingle
 
     @Override
     public ImmutableValue<Location<World>> target() {
-        return new ImmutableSpongeValue<>(Keys.TARGETED_LOCATION, this.value);
+        return getValueGetter();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeWetData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/ImmutableSpongeWetData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.WetData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeWetData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeWetData extends AbstractImmutableBooleanData<ImmutableWetData, WetData> implements ImmutableWetData {
 
     public ImmutableSpongeWetData(boolean value) {
-        super(ImmutableWetData.class, value, Keys.IS_WET, SpongeWetData.class);
+        super(ImmutableWetData.class, value, Keys.IS_WET, SpongeWetData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> wet() {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_WET, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return wet();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeAttachedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeAttachedData.java
@@ -30,23 +30,17 @@ import org.spongepowered.api.data.manipulator.mutable.block.AttachedData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeAttachedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeAttachedData extends AbstractImmutableBooleanData<ImmutableAttachedData, AttachedData> implements ImmutableAttachedData {
 
-    private final ImmutableValue<Boolean> attachedValue = ImmutableSpongeValue.cachedOf(Keys.ATTACHED, false, this.getValue());
-
     public ImmutableSpongeAttachedData(boolean attached) {
-        super(ImmutableAttachedData.class, attached, Keys.ATTACHED, SpongeAttachedData.class);
+        super(ImmutableAttachedData.class, attached, Keys.ATTACHED, SpongeAttachedData.class, DataConstants.DEFAULT_ATTACHED);
     }
 
     @Override
     public ImmutableValue<Boolean> attached() {
-        return this.attachedValue;
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return attached();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeAxisData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeAxisData.java
@@ -33,11 +33,12 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.util.Axis;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleEnumData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeAxisData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeAxisData extends AbstractImmutableSingleEnumData<Axis, ImmutableAxisData, AxisData> implements ImmutableAxisData {
 
     public ImmutableSpongeAxisData(Axis value) {
-        super(ImmutableAxisData.class, checkNotNull(value), Axis.X, Keys.AXIS, SpongeAxisData.class);
+        super(ImmutableAxisData.class, checkNotNull(value), DataConstants.DEFAULT_AXIS, Keys.AXIS, SpongeAxisData.class);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeBigMushroomData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeBigMushroomData.java
@@ -28,15 +28,15 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableBigMushroomData;
 import org.spongepowered.api.data.manipulator.mutable.block.BigMushroomData;
 import org.spongepowered.api.data.type.BigMushroomType;
-import org.spongepowered.api.data.type.BigMushroomTypes;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleCatalogData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeBigMushroomData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeBigMushroomData extends AbstractImmutableSingleCatalogData<BigMushroomType, ImmutableBigMushroomData, BigMushroomData>
         implements ImmutableBigMushroomData {
 
     public ImmutableSpongeBigMushroomData(BigMushroomType value) {
-        super(ImmutableBigMushroomData.class, value, BigMushroomTypes.ALL_OUTSIDE, Keys.BIG_MUSHROOM_TYPE, SpongeBigMushroomData.class);
+        super(ImmutableBigMushroomData.class, value, DataConstants.DEFAULT_BIG_MUSHROOM_TYPE, Keys.BIG_MUSHROOM_TYPE, SpongeBigMushroomData.class);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeBrickData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeBrickData.java
@@ -28,15 +28,15 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableBrickData;
 import org.spongepowered.api.data.manipulator.mutable.block.BrickData;
 import org.spongepowered.api.data.type.BrickType;
-import org.spongepowered.api.data.type.BrickTypes;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleCatalogData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeBrickData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeBrickData extends AbstractImmutableSingleCatalogData<BrickType, ImmutableBrickData, BrickData>
         implements ImmutableBrickData {
 
     public ImmutableSpongeBrickData(BrickType value) {
-        super(ImmutableBrickData.class, value, BrickTypes.DEFAULT, Keys.BRICK_TYPE, SpongeBrickData.class);
+        super(ImmutableBrickData.class, value, DataConstants.DEFAULT_BRICK_TYPE, Keys.BRICK_TYPE, SpongeBrickData.class);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeComparatorData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeComparatorData.java
@@ -28,15 +28,15 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableComparatorData;
 import org.spongepowered.api.data.manipulator.mutable.block.ComparatorData;
 import org.spongepowered.api.data.type.ComparatorType;
-import org.spongepowered.api.data.type.ComparatorTypes;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleCatalogData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeComparatorData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeComparatorData extends AbstractImmutableSingleCatalogData<ComparatorType, ImmutableComparatorData, ComparatorData>
         implements ImmutableComparatorData {
 
     public ImmutableSpongeComparatorData(ComparatorType value) {
-        super(ImmutableComparatorData.class, value, ComparatorTypes.COMPARE, Keys.COMPARATOR_TYPE, SpongeComparatorData.class);
+        super(ImmutableComparatorData.class, value, DataConstants.DEFAULT_COMPARATOR_TYPE, Keys.COMPARATOR_TYPE, SpongeComparatorData.class);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDecayableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDecayableData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.block.DecayableData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeDecayableData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeDecayableData extends AbstractImmutableBooleanData<ImmutableDecayableData, DecayableData> implements ImmutableDecayableData {
 
     public ImmutableSpongeDecayableData(boolean value) {
-        super(ImmutableDecayableData.class, value, Keys.DECAYABLE, SpongeDecayableData.class);
+        super(ImmutableDecayableData.class, value, Keys.DECAYABLE, SpongeDecayableData.class, DataConstants.DEFAULT_DECAYABLE_VALUE);
     }
 
     @Override
     public ImmutableValue<Boolean> decayable() {
-        return ImmutableSpongeValue.cachedOf(Keys.DECAYABLE, false, this.value);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return decayable();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDirectionalData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDirectionalData.java
@@ -31,12 +31,13 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleEnumData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeDirectionalData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeDirectionalData extends AbstractImmutableSingleEnumData<Direction, ImmutableDirectionalData, DirectionalData> implements
         ImmutableDirectionalData {
 
     public ImmutableSpongeDirectionalData(Direction direction) {
-        super(ImmutableDirectionalData.class, direction, Direction.NONE, Keys.DIRECTION, SpongeDirectionalData.class);
+        super(ImmutableDirectionalData.class, direction, DataConstants.DEFAULT_DIRECTION, Keys.DIRECTION, SpongeDirectionalData.class);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDirtData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDirtData.java
@@ -28,14 +28,14 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableDirtData;
 import org.spongepowered.api.data.manipulator.mutable.block.DirtData;
 import org.spongepowered.api.data.type.DirtType;
-import org.spongepowered.api.data.type.DirtTypes;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleCatalogData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeDirtData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeDirtData extends AbstractImmutableSingleCatalogData<DirtType, ImmutableDirtData, DirtData> implements ImmutableDirtData {
 
     public ImmutableSpongeDirtData(DirtType value) {
-        super(ImmutableDirtData.class, value, DirtTypes.DIRT, Keys.DIRT_TYPE, SpongeDirtData.class);
+        super(ImmutableDirtData.class, value, DataConstants.DEFAULT_DIRT_TYPE, Keys.DIRT_TYPE, SpongeDirtData.class);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDisarmedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDisarmedData.java
@@ -30,21 +30,17 @@ import org.spongepowered.api.data.manipulator.mutable.block.DisarmedData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeDisarmedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeDisarmedData extends AbstractImmutableBooleanData<ImmutableDisarmedData, DisarmedData> implements ImmutableDisarmedData {
 
     public ImmutableSpongeDisarmedData(boolean value) {
-        super(ImmutableDisarmedData.class, value, Keys.DISARMED, SpongeDisarmedData.class);
+        super(ImmutableDisarmedData.class, value, Keys.DISARMED, SpongeDisarmedData.class, DataConstants.DEFAULT_DISARMED);
     }
 
     @Override
     public ImmutableValue<Boolean> disarmed() {
-        return ImmutableSpongeValue.cachedOf(Keys.DISARMED, true, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return disarmed();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDisguisedBlockData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDisguisedBlockData.java
@@ -28,14 +28,14 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableDisguisedBlockData;
 import org.spongepowered.api.data.manipulator.mutable.block.DisguisedBlockData;
 import org.spongepowered.api.data.type.DisguisedBlockType;
-import org.spongepowered.api.data.type.DisguisedBlockTypes;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleCatalogData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeDisguisedBlockData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeDisguisedBlockData extends AbstractImmutableSingleCatalogData<DisguisedBlockType, ImmutableDisguisedBlockData,
         DisguisedBlockData> implements ImmutableDisguisedBlockData {
 
     public ImmutableSpongeDisguisedBlockData(DisguisedBlockType value) {
-        super(ImmutableDisguisedBlockData.class, value, DisguisedBlockTypes.STONE, Keys.DISGUISED_BLOCK_TYPE, SpongeDisguisedBlockData.class);
+        super(ImmutableDisguisedBlockData.class, value, DataConstants.DEFAULT_DISGUISED_BLOCK, Keys.DISGUISED_BLOCK_TYPE, SpongeDisguisedBlockData.class);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDoublePlantData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDoublePlantData.java
@@ -28,14 +28,14 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.block.ImmutableDoublePlantData;
 import org.spongepowered.api.data.manipulator.mutable.block.DoublePlantData;
 import org.spongepowered.api.data.type.DoublePlantType;
-import org.spongepowered.api.data.type.DoublePlantTypes;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleCatalogData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeDoublePlantData;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeDoublePlantData extends AbstractImmutableSingleCatalogData<DoublePlantType, ImmutableDoublePlantData,
     DoublePlantData> implements ImmutableDoublePlantData {
 
     public ImmutableSpongeDoublePlantData(DoublePlantType value) {
-        super(ImmutableDoublePlantData.class, value, DoublePlantTypes.GRASS, Keys.DOUBLE_PLANT_TYPE, SpongeDoublePlantData.class);
+        super(ImmutableDoublePlantData.class, value, DataConstants.DEFAULT_DOUBLE_PLANT, Keys.DOUBLE_PLANT_TYPE, SpongeDoublePlantData.class);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDropData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeDropData.java
@@ -30,21 +30,17 @@ import org.spongepowered.api.data.manipulator.mutable.block.DropData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeDropData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeDropData extends AbstractImmutableBooleanData<ImmutableDropData, DropData> implements ImmutableDropData {
 
     public ImmutableSpongeDropData(boolean value) {
-        super(ImmutableDropData.class, value, Keys.SHOULD_DROP, SpongeDropData.class);
+        super(ImmutableDropData.class, value, Keys.SHOULD_DROP, SpongeDropData.class, DataConstants.DEFAULT_SHOULD_DROP);
     }
 
     @Override
     public ImmutableValue<Boolean> willDrop() {
-        return ImmutableSpongeValue.cachedOf(Keys.SHOULD_DROP, true, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return willDrop();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeExtendedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeExtendedData.java
@@ -30,21 +30,17 @@ import org.spongepowered.api.data.manipulator.mutable.block.ExtendedData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeExtendedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.util.DataConstants;
 
 public class ImmutableSpongeExtendedData extends AbstractImmutableBooleanData<ImmutableExtendedData, ExtendedData> implements ImmutableExtendedData {
 
     public ImmutableSpongeExtendedData(boolean value) {
-        super(ImmutableExtendedData.class, value, Keys.EXTENDED, SpongeExtendedData.class);
+        super(ImmutableExtendedData.class, value, Keys.EXTENDED, SpongeExtendedData.class, DataConstants.DEFAULT_PISTON_EXTENDED);
     }
 
     @Override
     public ImmutableValue<Boolean> extended() {
-        return ImmutableSpongeValue.cachedOf(Keys.EXTENDED, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return extended();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeFilledData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeFilledData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.block.FilledData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeFilledData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeFilledData extends AbstractImmutableBooleanData<ImmutableFilledData, FilledData> implements ImmutableFilledData {
 
     public ImmutableSpongeFilledData(boolean value) {
-        super(ImmutableFilledData.class, value, Keys.FILLED, SpongeFilledData.class);
+        super(ImmutableFilledData.class, value, Keys.FILLED, SpongeFilledData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> filled() {
-        return ImmutableSpongeValue.cachedOf(Keys.FILLED, true, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return filled();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeFluidLevelData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeFluidLevelData.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.block;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
 
 import org.spongepowered.api.data.key.Keys;
@@ -33,21 +32,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.FluidLevelData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeFluidLevelData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeFluidLevelData extends AbstractImmutableBoundedComparableData<Integer, ImmutableFluidLevelData, FluidLevelData> implements ImmutableFluidLevelData {
 
-    private final int defaultValue;
-
     public ImmutableSpongeFluidLevelData(int value, int lowerBound, int upperBound, int defaultValue) {
-        super(ImmutableFluidLevelData.class, value, Keys.FLUID_LEVEL, intComparator(), SpongeFluidLevelData.class, lowerBound, upperBound);
-        checkArgument(defaultValue >= lowerBound && defaultValue <= upperBound);
-        this.defaultValue = defaultValue;
+        super(ImmutableFluidLevelData.class, value, Keys.FLUID_LEVEL, intComparator(), SpongeFluidLevelData.class, lowerBound, upperBound, defaultValue);
     }
 
     @Override
     public ImmutableBoundedValue<Integer> level() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.FLUID_LEVEL, this.defaultValue, this.value, this.comparator,
-                                                 this.lowerBound, this.upperBound);
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeGrowthData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeGrowthData.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.block;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
 
 import org.spongepowered.api.data.key.Keys;
@@ -33,25 +32,19 @@ import org.spongepowered.api.data.manipulator.mutable.block.GrowthData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeGrowthData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeGrowthData extends AbstractImmutableBoundedComparableData<Integer, ImmutableGrowthData, GrowthData> implements ImmutableGrowthData {
-
-    private final int defaultValue;
 
     public ImmutableSpongeGrowthData(int value, int lowerBound, int upperBound) {
         this(value, lowerBound, upperBound, 0);
     }
 
     public ImmutableSpongeGrowthData(int value, int lowerBound, int upperBound, int defaultValue) {
-        super(ImmutableGrowthData.class, value, Keys.GROWTH_STAGE, intComparator(), SpongeGrowthData.class, lowerBound, upperBound);
-        checkArgument(defaultValue >= lowerBound && defaultValue <= upperBound);
-        this.defaultValue = defaultValue;
+        super(ImmutableGrowthData.class, value, Keys.GROWTH_STAGE, intComparator(), SpongeGrowthData.class, lowerBound, upperBound, defaultValue);
     }
 
     @Override
     public ImmutableBoundedValue<Integer> growthStage() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.GROWTH_STAGE, this.defaultValue, this.value,
-                                                 this.comparator, this.lowerBound, this.upperBound);
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeInWallData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeInWallData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.block.InWallData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeInWallData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeInWallData extends AbstractImmutableBooleanData<ImmutableInWallData, InWallData> implements ImmutableInWallData {
 
     public ImmutableSpongeInWallData(boolean value) {
-        super(ImmutableInWallData.class, value, Keys.IN_WALL, SpongeInWallData.class);
+        super(ImmutableInWallData.class, value, Keys.IN_WALL, SpongeInWallData.class, true);
     }
 
     @Override
     public ImmutableValue<Boolean> inWall() {
-        return ImmutableSpongeValue.cachedOf(Keys.IN_WALL, true, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return inWall();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeLayeredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeLayeredData.java
@@ -32,16 +32,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.LayeredData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeLayeredData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeLayeredData extends AbstractImmutableBoundedComparableData<Integer, ImmutableLayeredData, LayeredData> implements ImmutableLayeredData {
 
     public ImmutableSpongeLayeredData(int value, int lowerBound, int upperBound) {
-        super(ImmutableLayeredData.class, value, Keys.LAYER, intComparator(), SpongeLayeredData.class, lowerBound, upperBound);
+        super(ImmutableLayeredData.class, value, Keys.LAYER, intComparator(), SpongeLayeredData.class, lowerBound, upperBound, 0);
     }
 
     @Override
     public ImmutableBoundedValue<Integer> layer() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.LAYER, 0, this.value, this.comparator, this.lowerBound, this.upperBound);
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeMoistureData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeMoistureData.java
@@ -32,16 +32,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.MoistureData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeMoistureData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeMoistureData extends AbstractImmutableBoundedComparableData<Integer, ImmutableMoistureData, MoistureData> implements ImmutableMoistureData {
 
     public ImmutableSpongeMoistureData(int value, int lowerBound, int upperBound) {
-        super(ImmutableMoistureData.class, value, Keys.MOISTURE, intComparator(), SpongeMoistureData.class, lowerBound, upperBound);
+        super(ImmutableMoistureData.class, value, Keys.MOISTURE, intComparator(), SpongeMoistureData.class, lowerBound, upperBound, 0);
     }
 
     @Override
     public ImmutableBoundedValue<Integer> moisture() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.MOISTURE, this.value, 0, this.comparator, this.lowerBound, this.upperBound);
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeOccupiedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeOccupiedData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.block.OccupiedData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeOccupiedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeOccupiedData extends AbstractImmutableBooleanData<ImmutableOccupiedData, OccupiedData> implements ImmutableOccupiedData {
 
     public ImmutableSpongeOccupiedData(boolean value) {
-        super(ImmutableOccupiedData.class, value, Keys.OCCUPIED, SpongeOccupiedData.class);
+        super(ImmutableOccupiedData.class, value, Keys.OCCUPIED, SpongeOccupiedData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> occupied() {
-        return ImmutableSpongeValue.cachedOf(Keys.OCCUPIED, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return occupied();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeOpenData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeOpenData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.OpenData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeOpenData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeOpenData extends AbstractImmutableBooleanData<ImmutableOpenData, OpenData> implements ImmutableOpenData {
 
     public ImmutableSpongeOpenData(boolean value) {
-        super(ImmutableOpenData.class, value, Keys.OPEN, SpongeOpenData.class);
+        super(ImmutableOpenData.class, value, Keys.OPEN, SpongeOpenData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> open() {
-        return ImmutableSpongeValue.cachedOf(Keys.OPEN, false, this.value);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return open();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongePoweredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongePoweredData.java
@@ -30,21 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.block.PoweredData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongePoweredData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongePoweredData extends AbstractImmutableBooleanData<ImmutablePoweredData, PoweredData> implements ImmutablePoweredData {
 
     public ImmutableSpongePoweredData(boolean value) {
-        super(ImmutablePoweredData.class, value, Keys.POWERED, SpongePoweredData.class);
+        super(ImmutablePoweredData.class, value, Keys.POWERED, SpongePoweredData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> powered() {
-        return ImmutableSpongeValue.cachedOf(Keys.POWERED, false, this.value);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return powered();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeRedstonePoweredData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeRedstonePoweredData.java
@@ -32,16 +32,19 @@ import org.spongepowered.api.data.manipulator.mutable.block.RedstonePoweredData;
 import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeRedstonePoweredData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
 
 public class ImmutableSpongeRedstonePoweredData extends AbstractImmutableBoundedComparableData<Integer, ImmutableRedstonePoweredData, RedstonePoweredData> implements ImmutableRedstonePoweredData {
 
+    public ImmutableSpongeRedstonePoweredData(int value) {
+        this(value, 0, 15);
+    }
+
     public ImmutableSpongeRedstonePoweredData(int value, int lowerBound, int upperBound) {
-        super(ImmutableRedstonePoweredData.class, value, Keys.POWER, intComparator(), SpongeRedstonePoweredData.class, lowerBound, upperBound);
+        super(ImmutableRedstonePoweredData.class, value, Keys.POWER, intComparator(), SpongeRedstonePoweredData.class, lowerBound, upperBound, 0);
     }
 
     @Override
     public ImmutableBoundedValue<Integer> power() {
-        return ImmutableSpongeBoundedValue.cachedOf(Keys.POWER, 0, this.value, this.comparator, 0, 15);
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeSeamlessData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeSeamlessData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.block.SeamlessData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeSeamlessData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeSeamlessData extends AbstractImmutableBooleanData<ImmutableSeamlessData, SeamlessData> implements ImmutableSeamlessData {
 
     public ImmutableSpongeSeamlessData(boolean value) {
-        super(ImmutableSeamlessData.class, value, Keys.SEAMLESS, SpongeSeamlessData.class);
+        super(ImmutableSeamlessData.class, value, Keys.SEAMLESS, SpongeSeamlessData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> seamless() {
-        return ImmutableSpongeValue.cachedOf(Keys.SEAMLESS, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return seamless();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeSnowedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeSnowedData.java
@@ -30,22 +30,17 @@ import org.spongepowered.api.data.manipulator.mutable.block.SnowedData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeSnowedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeSnowedData extends AbstractImmutableBooleanData<ImmutableSnowedData, SnowedData>
     implements ImmutableSnowedData {
 
     public ImmutableSpongeSnowedData(boolean value) {
-        super(ImmutableSnowedData.class, value, Keys.SNOWED, SpongeSnowedData.class);
+        super(ImmutableSnowedData.class, value, Keys.SNOWED, SpongeSnowedData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> hasSnow() {
-        return ImmutableSpongeValue.cachedOf(Keys.SNOWED, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return hasSnow();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeSuspendedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/block/ImmutableSpongeSuspendedData.java
@@ -30,22 +30,17 @@ import org.spongepowered.api.data.manipulator.mutable.block.SuspendedData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.block.SpongeSuspendedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeSuspendedData extends AbstractImmutableBooleanData<ImmutableSuspendedData, SuspendedData>
     implements ImmutableSuspendedData {
 
     public ImmutableSpongeSuspendedData(boolean value) {
-        super(ImmutableSuspendedData.class, value, Keys.SUSPENDED, SpongeSuspendedData.class);
+        super(ImmutableSuspendedData.class, value, Keys.SUSPENDED, SpongeSuspendedData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> suspended() {
-        return ImmutableSpongeValue.cachedOf(Keys.SUSPENDED, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return suspended();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableBooleanData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableBooleanData.java
@@ -32,6 +32,8 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.util.ReflectionUtil;
 
 import java.lang.reflect.Modifier;
@@ -40,13 +42,22 @@ public abstract class AbstractImmutableBooleanData<I extends ImmutableDataManipu
         AbstractImmutableSingleData<Boolean, I, M> {
 
     private final Class<? extends M> mutableClass;
+    protected final boolean defaultValue;
+    protected final ImmutableValue<Boolean> immutableValue;
 
-    public AbstractImmutableBooleanData(Class<I> immutableClass, Boolean value, Key<? extends BaseValue<Boolean>> usedKey,
-                                        Class<? extends M> mutableClass) {
+    protected AbstractImmutableBooleanData(Class<I> immutableClass, boolean value, Key<? extends BaseValue<Boolean>> usedKey,
+                                        Class<? extends M> mutableClass, boolean defaultValue) {
         super(immutableClass, value, usedKey);
         checkArgument(!Modifier.isAbstract(mutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(mutableClass.getModifiers()), "The immutable class cannot be an interface!");
         this.mutableClass = checkNotNull(mutableClass);
+        this.defaultValue = defaultValue;
+        this.immutableValue = ImmutableSpongeValue.cachedOf(usedKey, defaultValue, value);
+    }
+
+    @Override
+    protected final ImmutableValue<Boolean> getValueGetter() {
+        return this.immutableValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleCatalogData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleCatalogData.java
@@ -44,13 +44,15 @@ public abstract class AbstractImmutableSingleCatalogData<E extends CatalogType, 
 
     private final Class<? extends M> mutableClass;
     private final E defaultValue;
+    private final ImmutableValue<E> immutableValue;
 
-    public AbstractImmutableSingleCatalogData(Class<I> immutableClass, E value, E defaultValue, Key<? extends BaseValue<E>> usedKey, Class<? extends M> mutableClass) {
+    protected AbstractImmutableSingleCatalogData(Class<I> immutableClass, E value, E defaultValue, Key<? extends BaseValue<E>> usedKey, Class<? extends M> mutableClass) {
         super(immutableClass, value, usedKey);
         checkArgument(!Modifier.isAbstract(mutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(mutableClass.getModifiers()), "The immutable class cannot be an interface!");
         this.mutableClass = checkNotNull(mutableClass);
         this.defaultValue = checkNotNull(defaultValue, "The default value was null! This is unacceptable! Maybe the value was not registered?");
+        this.immutableValue = ImmutableSpongeValue.cachedOf(this.usedKey, this.defaultValue, this.value);
     }
 
     @Override
@@ -60,7 +62,7 @@ public abstract class AbstractImmutableSingleCatalogData<E extends CatalogType, 
 
     @Override
     protected ImmutableValue<?> getValueGetter() {
-        return type();
+        return this.immutableValue;
     }
 
     @Override
@@ -75,6 +77,6 @@ public abstract class AbstractImmutableSingleCatalogData<E extends CatalogType, 
 
     @Override
     public ImmutableValue<E> type() {
-        return ImmutableSpongeValue.cachedOf(this.usedKey, this.defaultValue, this.value);
+        return this.immutableValue;
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleData.java
@@ -44,7 +44,7 @@ public abstract class AbstractImmutableSingleData<T, I extends ImmutableDataMani
     protected final Key<? extends BaseValue<T>> usedKey;
     protected final T value;
 
-    public AbstractImmutableSingleData(Class<I> immutableClass, T value, Key<? extends BaseValue<T>> usedKey) {
+    protected AbstractImmutableSingleData(Class<I> immutableClass, T value, Key<? extends BaseValue<T>> usedKey) {
         super(immutableClass);
         this.value = checkNotNull(value);
         this.usedKey = checkNotNull(usedKey, "Hey, the key provided is null! Please make sure it is registered!");

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleEnumData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/AbstractImmutableSingleEnumData.java
@@ -45,7 +45,7 @@ public abstract class AbstractImmutableSingleEnumData<E extends Enum<E>, I exten
     private final E defaultValue;
     protected final ImmutableValue<E> cachedValue;
 
-    public AbstractImmutableSingleEnumData(Class<I> immutableClass, E value, E defaultValue, Key<? extends BaseValue<E>> usedKey, Class<? extends M> mutableClass) {
+    protected AbstractImmutableSingleEnumData(Class<I> immutableClass, E value, E defaultValue, Key<? extends BaseValue<E>> usedKey, Class<? extends M> mutableClass) {
         super(immutableClass, value, usedKey);
         checkArgument(!Modifier.isAbstract(mutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(mutableClass.getModifiers()), "The immutable class cannot be an interface!");
@@ -59,8 +59,8 @@ public abstract class AbstractImmutableSingleEnumData<E extends Enum<E>, I exten
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return type();
+    protected final ImmutableValue<E> getValueGetter() {
+        return this.cachedValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleListData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleListData.java
@@ -31,7 +31,7 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 import org.spongepowered.common.util.ReflectionUtil;
@@ -43,19 +43,21 @@ public abstract class AbstractImmutableSingleListData<E, I extends ImmutableData
     extends AbstractImmutableSingleData<List<E>, I, M> {
 
     private final Class<? extends M> mutable;
+    private final ImmutableListValue<E> listValue;
 
-    public AbstractImmutableSingleListData(Class<I> manipulatorClass, List<E> value,
+    protected AbstractImmutableSingleListData(Class<I> manipulatorClass, List<E> value,
                                            Key<? extends BaseValue<List<E>>> usedKey,
                                            Class<? extends M> mutableClass) {
         super(manipulatorClass, ImmutableList.copyOf(value), usedKey);
         checkArgument(!Modifier.isAbstract(mutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(mutableClass.getModifiers()), "The immutable class cannot be an interface!");
         this.mutable = mutableClass;
+        this.listValue = new ImmutableSpongeListValue<>(this.usedKey, ImmutableList.copyOf(this.value));
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return new ImmutableSpongeListValue<>(this.usedKey, ImmutableList.copyOf(this.value));
+    protected final ImmutableListValue<E> getValueGetter() {
+        return this.listValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleMapData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleMapData.java
@@ -31,7 +31,7 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.immutable.ImmutableMapValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeMapValue;
 import org.spongepowered.common.util.ReflectionUtil;
@@ -43,6 +43,7 @@ public abstract class AbstractImmutableSingleMapData<K, V, M extends DataManipul
     extends AbstractImmutableSingleData<Map<K, V>, I, M> {
 
     private final Class<? extends M> mutableClass;
+    private final ImmutableMapValue<K, V> mapValue;
 
     public AbstractImmutableSingleMapData(Class<I> manipulatorClass, Map<K, V> value,
                                           Key<? extends BaseValue<Map<K, V>>> usedKey,
@@ -51,11 +52,12 @@ public abstract class AbstractImmutableSingleMapData<K, V, M extends DataManipul
         checkArgument(!Modifier.isAbstract(immutableClass.getModifiers()), "The immutable class cannot be abstract!");
         checkArgument(!Modifier.isInterface(immutableClass.getModifiers()), "The immutable class cannot be an interface!");
         this.mutableClass = immutableClass;
+        this.mapValue = new ImmutableSpongeMapValue<>(this.usedKey, ImmutableMap.copyOf(this.value));
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return new ImmutableSpongeMapValue<>(this.usedKey, ImmutableMap.copyOf(this.value));
+    protected final ImmutableMapValue<K, V> getValueGetter() {
+        return this.mapValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleSetData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/common/collection/AbstractImmutableSingleSetData.java
@@ -31,7 +31,7 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
-import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.immutable.ImmutableSetValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeSetValue;
 import org.spongepowered.common.util.ReflectionUtil;
@@ -43,8 +43,9 @@ public abstract class AbstractImmutableSingleSetData<E, I extends ImmutableDataM
     extends AbstractImmutableSingleData<Set<E>, I, M> {
 
     private final Class<? extends M> mutableClass;
+    private final ImmutableSetValue<E> immutableSetValue = new ImmutableSpongeSetValue<>(this.usedKey, ImmutableSet.copyOf(this.value));
 
-    public AbstractImmutableSingleSetData(Class<I> manipulatorClass, Set<E> value,
+    protected AbstractImmutableSingleSetData(Class<I> manipulatorClass, Set<E> value,
                                           Key<? extends BaseValue<Set<E>>> usedKey,
                                           Class<? extends M> mutableClass) {
         super(manipulatorClass, ImmutableSet.copyOf(value), usedKey);
@@ -54,8 +55,8 @@ public abstract class AbstractImmutableSingleSetData<E, I extends ImmutableDataM
     }
 
     @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return new ImmutableSpongeSetValue<>(this.usedKey, ImmutableSet.copyOf(this.value));
+    protected final ImmutableSetValue<E> getValueGetter() {
+        return this.immutableSetValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeElderData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeElderData.java
@@ -28,26 +28,18 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableElderData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ElderData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
-import org.spongepowered.common.data.ImmutableDataCachingUtil;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeElderData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeElderData extends AbstractImmutableBooleanData<ImmutableElderData, ElderData> implements ImmutableElderData {
 
-    private final ImmutableValue<Boolean> elderValue = ImmutableSpongeValue.cachedOf(Keys.ELDER_GUARDIAN, false, this.getValue());
-
     public ImmutableSpongeElderData(boolean value) {
-        super(ImmutableElderData.class, value, Keys.ELDER_GUARDIAN, SpongeElderData.class);
+        super(ImmutableElderData.class, value, Keys.ELDER_GUARDIAN, SpongeElderData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> elder() {
-        return this.elderValue;
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return elder();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFlyingAbilityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFlyingAbilityData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.FlyingAbilityData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeFlyingAbilityData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeFlyingAbilityData extends AbstractImmutableBooleanData<ImmutableFlyingAbilityData, FlyingAbilityData> implements ImmutableFlyingAbilityData {
 
     public ImmutableSpongeFlyingAbilityData(boolean value) {
-        super(ImmutableFlyingAbilityData.class, value, Keys.CAN_FLY, SpongeFlyingAbilityData.class);
+        super(ImmutableFlyingAbilityData.class, value, Keys.CAN_FLY, SpongeFlyingAbilityData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> canFly() {
-        return ImmutableSpongeValue.cachedOf(Keys.CAN_FLY, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return canFly();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFlyingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeFlyingData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.FlyingData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeFlyingData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeFlyingData extends AbstractImmutableBooleanData<ImmutableFlyingData, FlyingData> implements ImmutableFlyingData {
 
     public ImmutableSpongeFlyingData(boolean value) {
-        super(ImmutableFlyingData.class, value, Keys.IS_FLYING, SpongeFlyingData.class);
+        super(ImmutableFlyingData.class, value, Keys.IS_FLYING, SpongeFlyingData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> flying() {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_FLYING, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return flying();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeMovementSpeedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeMovementSpeedData.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.data.manipulator.immutable.entity;
 
+import static org.spongepowered.common.data.util.ComparatorUtil.doubleComparator;
+
 import com.google.common.collect.ComparisonChain;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
@@ -34,10 +36,6 @@ import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeMovementSpeedData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static org.spongepowered.common.data.util.ComparatorUtil.doubleComparator;
-import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
 
 public class ImmutableSpongeMovementSpeedData extends AbstractImmutableData<ImmutableMovementSpeedData, MovementSpeedData> implements ImmutableMovementSpeedData  {
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePigSaddleData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePigSaddleData.java
@@ -30,22 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.PigSaddleData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongePigSaddleData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongePigSaddleData extends AbstractImmutableBooleanData<ImmutablePigSaddleData, PigSaddleData> implements ImmutablePigSaddleData {
 
     public ImmutableSpongePigSaddleData(boolean value) {
-        super(ImmutablePigSaddleData.class, value, Keys.PIG_SADDLE, SpongePigSaddleData.class);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return saddle();
+        super(ImmutablePigSaddleData.class, value, Keys.PIG_SADDLE, SpongePigSaddleData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> saddle() {
-        return ImmutableSpongeValue.cachedOf(Keys.PIG_SADDLE, false, this.value);
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePlayingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongePlayingData.java
@@ -30,22 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.PlayingData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongePlayingData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongePlayingData extends AbstractImmutableBooleanData<ImmutablePlayingData, PlayingData> implements ImmutablePlayingData {
 
     public ImmutableSpongePlayingData(boolean value) {
-        super(ImmutablePlayingData.class, value, Keys.IS_PLAYING, SpongePlayingData.class);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return playing();
+        super(ImmutablePlayingData.class, value, Keys.IS_PLAYING, SpongePlayingData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> playing() {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_PLAYING, false, this.value);
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeScreamingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeScreamingData.java
@@ -30,23 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.ScreamingData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeScreamingData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeScreamingData extends AbstractImmutableBooleanData<ImmutableScreamingData, ScreamingData> implements ImmutableScreamingData {
 
-    private final ImmutableValue<Boolean> screamingValue = ImmutableSpongeValue.cachedOf(Keys.IS_SCREAMING, false, this.value);
-
     public ImmutableSpongeScreamingData(boolean value) {
-        super(ImmutableScreamingData.class, value, Keys.IS_SCREAMING, SpongeScreamingData.class);
+        super(ImmutableScreamingData.class, value, Keys.IS_SCREAMING, SpongeScreamingData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> screaming() {
-        return this.screamingValue;
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return screaming();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeShearedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeShearedData.java
@@ -30,22 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.ShearedData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeShearedData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeShearedData extends AbstractImmutableBooleanData<ImmutableShearedData, ShearedData> implements ImmutableShearedData {
 
     public ImmutableSpongeShearedData(boolean value) {
-        super(ImmutableShearedData.class, value, Keys.IS_SHEARED, SpongeShearedData.class);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return sheared();
+        super(ImmutableShearedData.class, value, Keys.IS_SHEARED, SpongeShearedData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> sheared() {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_SHEARED, false, this.value);
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSittingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSittingData.java
@@ -30,22 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.SittingData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSittingData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeSittingData extends AbstractImmutableBooleanData<ImmutableSittingData, SittingData> implements ImmutableSittingData {
 
     public ImmutableSpongeSittingData(boolean value) {
-        super(ImmutableSittingData.class, value, Keys.IS_SITTING, SpongeSittingData.class);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return sitting();
+        super(ImmutableSittingData.class, value, Keys.IS_SITTING, SpongeSittingData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> sitting() {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_SITTING, false, this.value);
+        return getValueGetter();
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSlimeData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSlimeData.java
@@ -26,26 +26,21 @@ package org.spongepowered.common.data.manipulator.immutable.entity;
 
 import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
 
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSlimeData;
 import org.spongepowered.api.data.manipulator.mutable.entity.SlimeData;
-import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBoundedComparableData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSlimeData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
-
-import java.util.Comparator;
 
 public class ImmutableSpongeSlimeData extends AbstractImmutableBoundedComparableData<Integer, ImmutableSlimeData, SlimeData> implements ImmutableSlimeData {
 
     protected ImmutableSpongeSlimeData(int value) {
-        super(ImmutableSlimeData.class, value, Keys.SLIME_SIZE, intComparator(), SpongeSlimeData.class, 0, Integer.MAX_VALUE);
+        super(ImmutableSlimeData.class, value, Keys.SLIME_SIZE, intComparator(), SpongeSlimeData.class, 0, Integer.MAX_VALUE, 0);
     }
 
     @Override
     public ImmutableValue<Integer> size() {
-        return new ImmutableSpongeBoundedValue<>(Keys.SLIME_SIZE, this.getValue(), 0, this.comparator, 0, Integer.MAX_VALUE);
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSneakingData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSneakingData.java
@@ -30,21 +30,16 @@ import org.spongepowered.api.data.manipulator.mutable.entity.SneakingData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSneakingData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeSneakingData extends AbstractImmutableBooleanData<ImmutableSneakingData, SneakingData> implements ImmutableSneakingData {
 
     public ImmutableSpongeSneakingData(boolean sneaking) {
-        super(ImmutableSneakingData.class, sneaking, Keys.IS_SNEAKING, SpongeSneakingData.class);
+        super(ImmutableSneakingData.class, sneaking, Keys.IS_SNEAKING, SpongeSneakingData.class, false);
     }
     
     @Override
     public ImmutableValue<Boolean> sneaking() {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_SNEAKING, false, this.value);
+        return getValueGetter();
     }
 
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return sneaking();
-    }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeVelocityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeVelocityData.java
@@ -35,6 +35,8 @@ import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeVelocityData extends AbstractImmutableSingleData<Vector3d, ImmutableVelocityData, VelocityData> implements ImmutableVelocityData {
 
+    private final ImmutableValue<Vector3d> immutableValue = new ImmutableSpongeValue<>(Keys.VELOCITY, Vector3d.ZERO, this.value);
+
     public ImmutableSpongeVelocityData(Vector3d value) {
         super(ImmutableVelocityData.class, value, Keys.VELOCITY);
     }
@@ -51,7 +53,7 @@ public class ImmutableSpongeVelocityData extends AbstractImmutableSingleData<Vec
 
     @Override
     public ImmutableValue<Vector3d> velocity() {
-        return new ImmutableSpongeValue<>(Keys.VELOCITY, new Vector3d(), this.value);
+        return this.immutableValue;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeVillagerZombieData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeVillagerZombieData.java
@@ -30,25 +30,15 @@ import org.spongepowered.api.data.manipulator.mutable.entity.VillagerZombieData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVillagerZombieData;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeVillagerZombieData extends AbstractImmutableBooleanData<ImmutableVillagerZombieData, VillagerZombieData> implements ImmutableVillagerZombieData {
 
     public ImmutableSpongeVillagerZombieData(boolean value) {
-        super(ImmutableVillagerZombieData.class, value, Keys.IS_VILLAGER_ZOMBIE, SpongeVillagerZombieData.class);
-    }
-
-    public ImmutableSpongeVillagerZombieData() {
-        this(false);
-    }
-
-    @Override
-    protected ImmutableValue<?> getValueGetter() {
-        return this.villagerZombie();
+        super(ImmutableVillagerZombieData.class, value, Keys.IS_VILLAGER_ZOMBIE, SpongeVillagerZombieData.class, false);
     }
 
     @Override
     public ImmutableValue<Boolean> villagerZombie() {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_VILLAGER_ZOMBIE, false, this.getValue());
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeAuthorData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeAuthorData.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeAuthorData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 public class ImmutableSpongeAuthorData extends AbstractImmutableSingleData<Text, ImmutableAuthorData, AuthorData> implements ImmutableAuthorData {
@@ -43,7 +44,7 @@ public class ImmutableSpongeAuthorData extends AbstractImmutableSingleData<Text,
 
     public ImmutableSpongeAuthorData(Text value) {
         super(ImmutableAuthorData.class, value, Keys.BOOK_AUTHOR);
-        this.author = new ImmutableSpongeValue<>(Keys.BOOK_AUTHOR, Texts.of(), value);
+        this.author = new ImmutableSpongeValue<>(Keys.BOOK_AUTHOR, DataConstants.EMPTY_TEXT, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBreakableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBreakableData.java
@@ -67,6 +67,6 @@ public class ImmutableSpongeBreakableData extends AbstractImmutableSingleSetData
     @SuppressWarnings("unchecked")
     @Override
     public ImmutableSetValue<BlockType> breakable() {
-        return (ImmutableSetValue<BlockType>) getValueGetter();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeLoreData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeLoreData.java
@@ -33,9 +33,9 @@ import org.spongepowered.api.data.manipulator.immutable.item.ImmutableLoreData;
 import org.spongepowered.api.data.manipulator.mutable.item.LoreData;
 import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeLoreData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 import org.spongepowered.common.text.SpongeTexts;
 
@@ -46,7 +46,7 @@ public class ImmutableSpongeLoreData extends AbstractImmutableData<ImmutableLore
     private final ImmutableList<Text> lore;
 
     public ImmutableSpongeLoreData() {
-        this(ImmutableList.of(Texts.of()));
+        this(ImmutableList.of(DataConstants.EMPTY_TEXT));
     }
 
     public ImmutableSpongeLoreData(List<Text> lore) {

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePagedData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePagedData.java
@@ -33,9 +33,9 @@ import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePagedData;
 import org.spongepowered.api.data.manipulator.mutable.item.PagedData;
 import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongePagedData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 import org.spongepowered.common.text.SpongeTexts;
 
@@ -46,7 +46,7 @@ public class ImmutableSpongePagedData extends AbstractImmutableData<ImmutablePag
     private final ImmutableList<Text> pages;
 
     public ImmutableSpongePagedData() {
-        this(ImmutableList.of(Texts.of()));
+        this(ImmutableList.of(DataConstants.EMPTY_TEXT));
     }
 
     public ImmutableSpongePagedData(List<Text> pages) {

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePlaceableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongePlaceableData.java
@@ -42,7 +42,7 @@ import java.util.Set;
 public class ImmutableSpongePlaceableData extends AbstractImmutableSingleSetData<BlockType, ImmutablePlaceableData, PlaceableData> implements ImmutablePlaceableData {
 
     public ImmutableSpongePlaceableData() {
-        this(ImmutableSet.<BlockType>of());
+        this(ImmutableSet.of());
     }
 
     public ImmutableSpongePlaceableData(Set<BlockType> placeable) {
@@ -67,6 +67,6 @@ public class ImmutableSpongePlaceableData extends AbstractImmutableSingleSetData
     @SuppressWarnings("unchecked")
     @Override
     public ImmutableSetValue<BlockType> placeable() {
-        return (ImmutableSetValue<BlockType>) getValueGetter();
+        return getValueGetter();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeCommandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeCommandData.java
@@ -39,6 +39,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeCommandData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeOptionalValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
@@ -84,7 +85,7 @@ public class SpongeCommandData extends AbstractData<CommandData, ImmutableComman
                 .setStoredCommand(this.getStoredCommand())
                 .setSuccessCount(this.getSuccessCount())
                 .shouldTrackOutput(this.tracks)
-                .setLastOutput(this.getLastOutput().orElse(Texts.of()));
+                .setLastOutput(this.getLastOutput().orElse(DataConstants.EMPTY_TEXT));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeDisplayNameData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeDisplayNameData.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeDisplayNameData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeDisplayNameData extends AbstractData<DisplayNameData, ImmutableDisplayNameData> implements DisplayNameData {
@@ -45,7 +46,7 @@ public class SpongeDisplayNameData extends AbstractData<DisplayNameData, Immutab
     private boolean displays = false;
 
     public SpongeDisplayNameData() {
-        this(Texts.of(), false);
+        this(DataConstants.EMPTY_TEXT, false);
     }
 
     public SpongeDisplayNameData(Text displayName) {
@@ -61,7 +62,7 @@ public class SpongeDisplayNameData extends AbstractData<DisplayNameData, Immutab
 
     @Override
     public Value<Text> displayName() {
-        return new SpongeValue<>(Keys.DISPLAY_NAME, Texts.of(), this.displayName);
+        return new SpongeValue<>(Keys.DISPLAY_NAME, DataConstants.EMPTY_TEXT, this.displayName);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeRepresentedItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/SpongeRepresentedItemData.java
@@ -50,7 +50,7 @@ public class SpongeRepresentedItemData extends AbstractSingleData<ItemStackSnaps
 
     @Override
     public Value<ItemStackSnapshot> item() {
-        return new SpongeValue<>(Keys.REPRESENTED_ITEM, this.getValue());
+        return new SpongeValue<>(Keys.REPRESENTED_ITEM, ItemStackSnapshot.NONE, this.getValue());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeAuthorData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeAuthorData.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeAuthorData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 public class SpongeAuthorData extends AbstractSingleData<Text, AuthorData, ImmutableAuthorData> implements AuthorData {
@@ -44,7 +45,7 @@ public class SpongeAuthorData extends AbstractSingleData<Text, AuthorData, Immut
     }
 
     public SpongeAuthorData() {
-        this(Texts.of());
+        this(DataConstants.EMPTY_TEXT);
     }
 
     @Override
@@ -60,7 +61,7 @@ public class SpongeAuthorData extends AbstractSingleData<Text, AuthorData, Immut
 
     @Override
     public Value<Text> author() {
-        return new SpongeValue<>(Keys.BOOK_AUTHOR, Texts.of(), this.getValue());
+        return new SpongeValue<>(Keys.BOOK_AUTHOR, DataConstants.EMPTY_TEXT, this.getValue());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeSignData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeSignData.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.text.Texts;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeSignData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeListValue;
 
 import java.util.List;
@@ -46,7 +47,7 @@ public class SpongeSignData extends AbstractData<SignData, ImmutableSignData> im
     private final List<Text> lines;
 
     public SpongeSignData() {
-        this(Lists.newArrayList(Texts.of(), Texts.of(), Texts.of(), Texts.of()));
+        this(Lists.newArrayList(DataConstants.EMPTY_TEXT, DataConstants.EMPTY_TEXT, DataConstants.EMPTY_TEXT, DataConstants.EMPTY_TEXT));
     }
 
     public SpongeSignData(List<Text> lines) {

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/HealthDataProcessor.java
@@ -76,6 +76,9 @@ public class HealthDataProcessor extends AbstractEntityDataProcessor<EntityLivin
 
     @Override
     public Optional<HealthData> fill(DataContainer container, HealthData healthData) {
+        if (!container.contains(Keys.MAX_HEALTH.getQuery()) || !container.contains(Keys.HEALTH.getQuery())) {
+            return Optional.empty();
+        }
         healthData.set(Keys.MAX_HEALTH, getData(container, Keys.MAX_HEALTH));
         healthData.set(Keys.HEALTH, getData(container, Keys.HEALTH));
         return Optional.of(healthData);

--- a/src/main/java/org/spongepowered/common/data/processor/data/tileentity/SignDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/tileentity/SignDataProcessor.java
@@ -48,6 +48,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeSignData;
 import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.text.SpongeTexts;
@@ -215,7 +216,7 @@ public class SignDataProcessor extends AbstractSpongeDataProcessor<SignData, Imm
             }
             try {
                 for (int i = 0; i < 4; i++) {
-                    ((TileEntitySign) dataHolder).signText[i] = SpongeTexts.toComponent(Texts.of());
+                    ((TileEntitySign) dataHolder).signText[i] = DataConstants.EMPTY_TEXT_COMPONENT;
                 }
                 ((TileEntitySign) dataHolder).markDirty();
             } catch (Exception e) {

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/CanFlyValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/CanFlyValueProcessor.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
@@ -50,7 +51,7 @@ public class CanFlyValueProcessor extends AbstractSpongeValueProcessor<EntityPla
 
     @Override
     protected Value<Boolean> constructValue(Boolean defaultValue) {
-        return new SpongeValue<>(this.getKey(), defaultValue);
+        return new SpongeValue<>(this.getKey(), DataConstants.CAN_FLY_DEFAULT, defaultValue);
     }
 
     @Override
@@ -67,6 +68,6 @@ public class CanFlyValueProcessor extends AbstractSpongeValueProcessor<EntityPla
 
     @Override
     protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
-        return ImmutableSpongeValue.cachedOf(Keys.CAN_FLY, false, value);
+        return ImmutableSpongeValue.cachedOf(Keys.CAN_FLY, DataConstants.CAN_FLY_DEFAULT, value);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/CareerValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/CareerValueProcessor.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.interfaces.entity.IMixinVillager;
@@ -48,7 +49,7 @@ public class CareerValueProcessor extends AbstractSpongeValueProcessor<EntityVil
 
     @Override
     public Value<Career> constructValue(Career defaultValue) {
-        return new SpongeValue<>(Keys.CAREER, defaultValue);
+        return new SpongeValue<>(Keys.CAREER, DataConstants.CAREER_DEFAULT, defaultValue);
     }
 
     @Override
@@ -69,6 +70,6 @@ public class CareerValueProcessor extends AbstractSpongeValueProcessor<EntityVil
 
     @Override
     protected ImmutableValue<Career> constructImmutableValue(Career value) {
-        return ImmutableSpongeValue.cachedOf(Keys.CAREER, Careers.FARMER, value);
+        return ImmutableSpongeValue.cachedOf(Keys.CAREER, DataConstants.CAREER_DEFAULT, value);
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/ElderValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/ElderValueProcessor.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
@@ -45,7 +46,7 @@ public class ElderValueProcessor extends AbstractSpongeValueProcessor<EntityGuar
 
     @Override
     protected Value<Boolean> constructValue(Boolean defaultValue) {
-        return new SpongeValue<>(Keys.ELDER_GUARDIAN, defaultValue);
+        return new SpongeValue<>(Keys.ELDER_GUARDIAN, DataConstants.ELDER_GUARDIAN_DEFAULT, defaultValue);
     }
 
     @Override
@@ -61,7 +62,7 @@ public class ElderValueProcessor extends AbstractSpongeValueProcessor<EntityGuar
 
     @Override
     protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
-        return ImmutableSpongeValue.cachedOf(Keys.ELDER_GUARDIAN, false, value);
+        return ImmutableSpongeValue.cachedOf(Keys.ELDER_GUARDIAN, DataConstants.ELDER_GUARDIAN_DEFAULT, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/EntityDisplayNameValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/EntityDisplayNameValueProcessor.java
@@ -36,7 +36,9 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
 
 import java.util.Optional;
 
@@ -48,7 +50,7 @@ public class EntityDisplayNameValueProcessor extends AbstractSpongeValueProcesso
 
     @Override
     protected Value<Text> constructValue(Text defaultValue) {
-        return null;
+        return new SpongeValue<>(Keys.DISPLAY_NAME, DataConstants.EMPTY_TEXT, defaultValue);
     }
 
     @SuppressWarnings("deprecation")
@@ -70,7 +72,7 @@ public class EntityDisplayNameValueProcessor extends AbstractSpongeValueProcesso
 
     @Override
     protected ImmutableValue<Text> constructImmutableValue(Text value) {
-        return new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, Texts.of(), value);
+        return new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, DataConstants.EMPTY_TEXT, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/EntityWetValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/EntityWetValueProcessor.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
@@ -77,7 +78,7 @@ public class EntityWetValueProcessor extends AbstractSpongeValueProcessor<Entity
 
     @Override
     protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
-        return ImmutableSpongeValue.cachedOf(Keys.IS_WET, false, value);
+        return ImmutableSpongeValue.cachedOf(Keys.IS_WET, DataConstants.IS_WET_DEFAULT, value);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FireTicksValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FireTicksValueProcessor.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 import java.util.Optional;
@@ -45,7 +46,7 @@ public class FireTicksValueProcessor extends AbstractSpongeValueProcessor<Entity
     @Override
     public DataTransactionResult removeFrom(ValueContainer<?> container) {
         if (container instanceof Entity) {
-            if (((Entity) container).fire > 0) {
+            if (((Entity) container).fire >= DataConstants.MINIMUM_FIRE_TICKS) {
                 final DataTransactionBuilder builder = DataTransactionBuilder.builder();
                 builder.replace(getApiValueFromContainer(container).get().asImmutable());
                 builder.replace(container.getValue(Keys.FIRE_DAMAGE_DELAY).get().asImmutable());
@@ -59,8 +60,8 @@ public class FireTicksValueProcessor extends AbstractSpongeValueProcessor<Entity
     @Override
     protected MutableBoundedValue<Integer> constructValue(Integer defaultValue) {
         return SpongeValueBuilder.boundedBuilder(Keys.FIRE_TICKS)
-            .defaultValue(10)
-            .minimum(1)
+            .defaultValue(DataConstants.DEFAULT_FIRE_TICKS)
+            .minimum(DataConstants.MINIMUM_FIRE_TICKS)
             .maximum(Integer.MAX_VALUE)
             .actualValue(defaultValue)
             .build();

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FlyingSpeedValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FlyingSpeedValueProcessor.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 import java.util.Optional;
@@ -45,7 +46,7 @@ public class FlyingSpeedValueProcessor extends AbstractSpongeValueProcessor<Enti
     @Override
     protected MutableBoundedValue<Double> constructValue(Double defaultValue) {
         return SpongeValueBuilder.boundedBuilder(Keys.FLYING_SPEED)
-            .defaultValue(0.05d)
+            .defaultValue(DataConstants.DEFAULT_FLYING_SPEED)
             .minimum(Double.MIN_VALUE)
             .maximum(Double.MAX_VALUE)
             .actualValue(defaultValue)

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodExhaustionValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodExhaustionValueProcessor.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.SpongeValueBuilder;
 
 import java.util.Optional;
@@ -45,7 +46,7 @@ public class FoodExhaustionValueProcessor extends AbstractSpongeValueProcessor<E
     @Override
     public MutableBoundedValue<Double> constructValue(Double defaultValue) {
         return SpongeValueBuilder.boundedBuilder(Keys.EXHAUSTION)
-            .defaultValue(0D)
+            .defaultValue(DataConstants.DEFAULT_EXHAUSTION)
             .minimum(0D)
             .maximum(Double.MAX_VALUE)
             .actualValue(defaultValue)

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodLevelValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodLevelValueProcessor.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.common.data.processor.value.entity;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.intComparator;
-
 import net.minecraft.entity.player.EntityPlayer;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
@@ -34,9 +32,8 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.SpongeValueBuilder;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
-import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 
 import java.util.Optional;
 
@@ -49,7 +46,7 @@ public class FoodLevelValueProcessor extends AbstractSpongeValueProcessor<Entity
     @Override
     public MutableBoundedValue<Integer> constructValue(Integer defaultValue) {
         return SpongeValueBuilder.boundedBuilder(Keys.FOOD_LEVEL)
-            .defaultValue(20)
+            .defaultValue(DataConstants.DEFAULT_FOOD_LEVEL)
             .minimum(0)
             .maximum(Integer.MAX_VALUE)
             .actualValue(defaultValue)

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodSaturationValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/FoodSaturationValueProcessor.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.common.data.processor.value.entity;
 
-import static org.spongepowered.common.data.util.ComparatorUtil.doubleComparator;
-
 import net.minecraft.entity.player.EntityPlayer;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
@@ -34,9 +32,8 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.SpongeValueBuilder;
-import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
-import org.spongepowered.common.data.value.mutable.SpongeBoundedValue;
 
 import java.util.Optional;
 
@@ -48,8 +45,8 @@ public class FoodSaturationValueProcessor extends AbstractSpongeValueProcessor<E
 
     @Override
     public MutableBoundedValue<Double> constructValue(Double defaultValue) {
-        return SpongeValueBuilder.boundedBuilder(Keys.EXHAUSTION)
-            .defaultValue(0D)
+        return SpongeValueBuilder.boundedBuilder(Keys.SATURATION)
+            .defaultValue(DataConstants.DEFAULT_SATURATION)
             .minimum(0D)
             .maximum(Double.MAX_VALUE)
             .actualValue(defaultValue)

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/GameModeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/GameModeValueProcessor.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.living.player.gamemode.GameModes;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
@@ -57,7 +58,7 @@ public class GameModeValueProcessor extends AbstractSpongeValueProcessor<EntityP
 
     @Override
     protected Value<GameMode> constructValue(GameMode defaultValue) {
-        return new SpongeValue<>(getKey(), defaultValue, GameModes.NOT_SET);
+        return new SpongeValue<>(getKey(), DataConstants.DEFAULT_GAMEMODE, defaultValue);
     }
 
     @Override
@@ -73,7 +74,7 @@ public class GameModeValueProcessor extends AbstractSpongeValueProcessor<EntityP
 
     @Override
     protected ImmutableValue<GameMode> constructImmutableValue(GameMode value) {
-        return ImmutableSpongeValue.cachedOf(getKey(), GameModes.NOT_SET, value);
+        return ImmutableSpongeValue.cachedOf(getKey(), DataConstants.DEFAULT_GAMEMODE, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/BookAuthorValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/BookAuthorValueProcessor.java
@@ -36,6 +36,7 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
@@ -85,7 +86,7 @@ public class BookAuthorValueProcessor extends AbstractSpongeValueProcessor<ItemS
 
     @Override
     protected ImmutableValue<Text> constructImmutableValue(Text value) {
-        return new ImmutableSpongeValue<>(Keys.BOOK_AUTHOR, Texts.of(), value);
+        return new ImmutableSpongeValue<>(Keys.BOOK_AUTHOR, DataConstants.EMPTY_TEXT, value);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/ItemDisplayNameValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/ItemDisplayNameValueProcessor.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
@@ -51,7 +52,7 @@ public class ItemDisplayNameValueProcessor extends AbstractSpongeValueProcessor<
 
     @Override
     protected Value<Text> constructValue(Text defaultValue) {
-        return new SpongeValue<>(Keys.DISPLAY_NAME, Texts.of(), defaultValue);
+        return new SpongeValue<>(Keys.DISPLAY_NAME, DataConstants.EMPTY_TEXT, defaultValue);
     }
 
     @SuppressWarnings("deprecation")
@@ -86,7 +87,7 @@ public class ItemDisplayNameValueProcessor extends AbstractSpongeValueProcessor<
 
     @Override
     protected ImmutableValue<Text> constructImmutableValue(Text value) {
-        return new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, Texts.of(), value);
+        return new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, DataConstants.EMPTY_TEXT, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/SignLinesValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/SignLinesValueProcessor.java
@@ -38,6 +38,7 @@ import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeListValue;
 import org.spongepowered.common.data.value.mutable.SpongeListValue;
 import org.spongepowered.common.text.SpongeTexts;
@@ -91,7 +92,7 @@ public class SignLinesValueProcessor extends AbstractSpongeValueProcessor<TileEn
             }
             try {
                 for (int i = 0; i < 4; i++) {
-                    ((TileEntitySign) container).signText[i] = SpongeTexts.toComponent(Texts.of());
+                    ((TileEntitySign) container).signText[i] = SpongeTexts.toComponent(DataConstants.EMPTY_TEXT);
                 }
                 ((TileEntitySign) container).markDirty();
                 return builder.result(DataTransactionResult.Type.SUCCESS).build();

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/TileEntityDisplayNameValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/TileEntityDisplayNameValueProcessor.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.Texts;
 import org.spongepowered.common.Sponge;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.interfaces.data.IMixinCustomNameable;
@@ -49,7 +50,7 @@ public class TileEntityDisplayNameValueProcessor extends AbstractSpongeValueProc
 
     @Override
     protected Value<Text> constructValue(Text defaultValue) {
-        return new SpongeValue<>(Keys.DISPLAY_NAME, Texts.of(), defaultValue);
+        return new SpongeValue<>(Keys.DISPLAY_NAME, DataConstants.EMPTY_TEXT, defaultValue);
     }
 
     @SuppressWarnings("deprecation")
@@ -77,7 +78,7 @@ public class TileEntityDisplayNameValueProcessor extends AbstractSpongeValueProc
 
     @Override
     protected ImmutableValue<Text> constructImmutableValue(Text value) {
-        return new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, Texts.of(), value);
+        return new ImmutableSpongeValue<>(Keys.DISPLAY_NAME, DataConstants.EMPTY_TEXT, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/util/DataConstants.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataConstants.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.util;
+
+import net.minecraft.util.IChatComponent;
+import org.spongepowered.api.data.type.BigMushroomType;
+import org.spongepowered.api.data.type.BigMushroomTypes;
+import org.spongepowered.api.data.type.BrickType;
+import org.spongepowered.api.data.type.BrickTypes;
+import org.spongepowered.api.data.type.Career;
+import org.spongepowered.api.data.type.Careers;
+import org.spongepowered.api.data.type.ComparatorType;
+import org.spongepowered.api.data.type.ComparatorTypes;
+import org.spongepowered.api.data.type.DirtType;
+import org.spongepowered.api.data.type.DirtTypes;
+import org.spongepowered.api.data.type.DisguisedBlockType;
+import org.spongepowered.api.data.type.DisguisedBlockTypes;
+import org.spongepowered.api.data.type.DoublePlantType;
+import org.spongepowered.api.data.type.DoublePlantTypes;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.living.player.gamemode.GameModes;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.Texts;
+import org.spongepowered.api.util.Axis;
+import org.spongepowered.api.util.Direction;
+import org.spongepowered.common.Sponge;
+import org.spongepowered.common.text.SpongeTexts;
+
+/**
+ * A standard class where all various "constants" for various data are stored.
+ * This is for a singular unique point of reference that can be changed
+ * for implementation requirements.
+ *
+ * <p><em>WARNING</em>: USAGE OF THESE CONSTANTS, DUE TO STATIC INITIALIZATION,
+ * IS ABSOLUTELY FORBIDDEN UNTIL THE GAME IS DURING THE POST-INIT PHASE DUE
+ * TO REGISTRATION OF CATALOG TYPES. UNTIL THE REGISTRATION IS HANDLED WHERE
+ * THE PROVIDED CATALOG TYPES ARE PROPERLY REGISTERED AND NOT <code>null</code>,
+ * ANY USE OF THIS CLASS WILL RESULT IN A GLORIOUS FAIL INDESCRIBABLE MAGNITUDES.
+ * </p>
+ */
+public final class DataConstants {
+
+    public static final Text EMPTY_TEXT = Texts.of();
+
+    public static final IChatComponent EMPTY_TEXT_COMPONENT = SpongeTexts.toComponent(Texts.of());
+    public static final Axis DEFAULT_AXIS = Axis.X;
+    public static final BigMushroomType DEFAULT_BIG_MUSHROOM_TYPE = BigMushroomTypes.ALL_OUTSIDE;
+    public static final BrickType DEFAULT_BRICK_TYPE = BrickTypes.DEFAULT;
+    public static final ComparatorType DEFAULT_COMPARATOR_TYPE = ComparatorTypes.COMPARE;
+    public static final boolean DEFAULT_DECAYABLE_VALUE = false;
+    public static final Direction DEFAULT_DIRECTION = Direction.NONE;
+    public static final DirtType DEFAULT_DIRT_TYPE = DirtTypes.DIRT;
+    public static final boolean DEFAULT_DISARMED = true;
+    public static final DisguisedBlockType DEFAULT_DISGUISED_BLOCK = DisguisedBlockTypes.STONE;
+    public static final DoublePlantType DEFAULT_DOUBLE_PLANT = DoublePlantTypes.GRASS;
+    public static final boolean DEFAULT_SHOULD_DROP = true;
+    public static final boolean DEFAULT_PISTON_EXTENDED = false;
+
+    private DataConstants() {}
+
+    // yes... we really can use this ;)
+    public static final int ZERO = 0;
+
+    // A bunch of entity defaults (for use in constructing "default" values)
+    public static final boolean CAN_FLY_DEFAULT = false;
+    public static final Career CAREER_DEFAULT = Careers.FARMER;
+    public static final boolean ELDER_GUARDIAN_DEFAULT = false;
+    public static final boolean IS_WET_DEFAULT = false;
+    public static final GameMode DEFAULT_GAMEMODE = GameModes.NOT_SET;
+    public static final boolean DEFAULT_ATTACHED = false;
+
+    public static final int DEFAULT_FIRE_TICKS = 10;
+    public static final int MINIMUM_FIRE_TICKS = 1;
+
+    public static final double DEFAULT_FLYING_SPEED = 0.05D;
+
+    public static final double DEFAULT_EXHAUSTION = ZERO;
+    public static final double MINIMUM_EXHAUSTION = ZERO;
+    public static final double DEFAULT_SATURATION = ZERO;
+    public static final int DEFAULT_FOOD_LEVEL = 20;
+
+    static {
+        Thread.dumpStack();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -47,7 +47,10 @@ import java.util.Optional;
  * data that may be stored on {@link ItemStack}s and/or {@link NBTTagCompound}s
  * used to store information.
  */
-public class NbtDataUtil {
+public final class NbtDataUtil {
+
+    private NbtDataUtil() {
+    }
 
     // These are the various tag compound id's for getting to various places
     public static final String BLOCK_ENTITY_TAG = "BlockEntityTag";


### PR DESCRIPTION
Still a WIP, but discussion is highly suggested as this just serves as a marker discussion for a topic affecting a very large part of the implementation.

Throughout the implementation of Data API, there are various "constants" thrown around and lately, I've noticed that some of these constants aren't uniform in that they aren't the same constant used for the exam same case. While normally, constants aren't really given much care in the world, they do matter.

This brings the Data implementation up to speed with using a nice uniform `DataConstants` class that is a little sensitive with regards to the `SpongeGameRegistry` having completed registration of a few `CatalogType`s, but still nonetheless sensitive to the phase of the game. As well, there's a few places where `ImmutableDataManipulator`s are actually optimized with regards to storing `ImmutableValue`s in `private final` instance fields instead of always returning new objects, but that's not the main point of this PR, let alone this change.

Pros | Cons
--- | ---
One place to store all constants | Dependent on the `GameRegistry` having finished registration
Never mistakingly using a different constant |  
Brings into uniformity with `NbtDataUtil`'s `NbtTagCompound` keys |

While I work on this, I'm still mulling over the issue of static initialization of various constants, specifically with `CatalogType` based constants, but that issue could easily be resolved if need be.

For the time being, this is still a PR that is a WIP.