### PR TITLE
Implement NoteData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
@@ -106,6 +106,7 @@ import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePagedData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutablePlaceableData;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableBrewingStandData;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableFurnaceData;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableNoteData;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableSignData;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.manipulator.mutable.RepresentedItemData;
@@ -168,6 +169,7 @@ import org.spongepowered.api.data.manipulator.mutable.item.PagedData;
 import org.spongepowered.api.data.manipulator.mutable.item.PlaceableData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.BrewingStandData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.FurnaceData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.NoteData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.SignData;
 import org.spongepowered.api.data.meta.ItemEnchantment;
 import org.spongepowered.api.data.meta.PatternLayer;
@@ -261,6 +263,7 @@ import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeP
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongePlaceableData;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeBrewingStandData;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeFurnaceData;
+import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeNoteData;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeSignData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeDisplayNameData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeRepresentedItemData;
@@ -323,6 +326,7 @@ import org.spongepowered.common.data.manipulator.mutable.item.SpongePagedData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongePlaceableData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeBrewingStandData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeFurnaceData;
+import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeNoteData;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeSignData;
 import org.spongepowered.common.data.processor.data.DisplayNameDataProcessor;
 import org.spongepowered.common.data.processor.data.RepresentedItemDataProcessor;
@@ -386,6 +390,7 @@ import org.spongepowered.common.data.processor.data.item.ItemWetDataProcessor;
 import org.spongepowered.common.data.processor.data.item.PlaceableDataProcessor;
 import org.spongepowered.common.data.processor.data.tileentity.BrewingStandDataProcessor;
 import org.spongepowered.common.data.processor.data.tileentity.FurnaceDataProcessor;
+import org.spongepowered.common.data.processor.data.tileentity.NoteDataProcessor;
 import org.spongepowered.common.data.processor.data.tileentity.SignDataProcessor;
 import org.spongepowered.common.data.processor.data.tileentity.SkullRepresentedPlayerDataProcessor;
 import org.spongepowered.common.data.processor.value.DisplayNameVisibleValueProcessor;
@@ -463,6 +468,7 @@ import org.spongepowered.common.data.processor.value.item.ItemWetValueProcessor;
 import org.spongepowered.common.data.processor.value.item.PlaceableValueProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.MaxBurnTimeValueProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.MaxCookTimeValueProcessor;
+import org.spongepowered.common.data.processor.value.tileentity.NoteValueProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.PassedBurnTimeValueProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.PassedCookTimeValueProcessor;
 import org.spongepowered.common.data.processor.value.tileentity.RemainingBrewTimeValueProcessor;
@@ -769,6 +775,10 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerDataProcessorAndImpl(BrewingStandData.class, SpongeBrewingStandData.class, ImmutableBrewingStandData.class,
                 ImmutableSpongeBrewingStandData.class, brewingStandDataProcessor);
 
+        final NoteDataProcessor noteDataProcessor = new NoteDataProcessor();
+        dataRegistry.registerDataProcessorAndImpl(NoteData.class, SpongeNoteData.class, ImmutableNoteData.class,
+                ImmutableSpongeNoteData.class, noteDataProcessor);
+
         // Values
         dataRegistry.registerValueProcessor(Keys.HEALTH, new HealthValueProcessor());
         dataRegistry.registerValueProcessor(Keys.MAX_HEALTH, new MaxHealthValueProcessor());
@@ -852,6 +862,7 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerValueProcessor(Keys.DOUBLE_PLANT_TYPE, new DoublePlantTypeValueProcessor());
         dataRegistry.registerValueProcessor(Keys.BIG_MUSHROOM_TYPE, new BigMushroomTypeValueProcessor());
         dataRegistry.registerValueProcessor(Keys.DISGUISED_BLOCK_TYPE, new DisguisedBlockTypeValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.NOTE_PITCH, new NoteValueProcessor());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -54,6 +54,7 @@ import org.spongepowered.api.data.type.HorseColor;
 import org.spongepowered.api.data.type.HorseStyle;
 import org.spongepowered.api.data.type.HorseVariant;
 import org.spongepowered.api.data.type.LogAxis;
+import org.spongepowered.api.data.type.NotePitch;
 import org.spongepowered.api.data.type.PistonType;
 import org.spongepowered.api.data.type.PlantType;
 import org.spongepowered.api.data.type.PortionType;
@@ -200,6 +201,7 @@ public class KeyRegistry {
         keyMap.put("wall_type", makeSingleKey(WallType.class, Value.class, of("WallType")));
         keyMap.put("double_plant_type", makeSingleKey(DoublePlantType.class, Value.class, of("DoublePlantType")));
         keyMap.put("big_mushroom_type", makeSingleKey(BigMushroomType.class, Value.class, of("BigMushroomType")));
+        keyMap.put("note_pitch", makeSingleKey(NotePitch.class, Value.class, of("Note")));
 
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/tileentity/ImmutableSpongeNoteData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/tileentity/ImmutableSpongeNoteData.java
@@ -1,0 +1,54 @@
+package org.spongepowered.common.data.manipulator.immutable.tileentity;
+
+import com.google.common.collect.ComparisonChain;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableNoteData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.NoteData;
+import org.spongepowered.api.data.type.NotePitch;
+import org.spongepowered.api.data.type.NotePitches;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeNoteData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+public class ImmutableSpongeNoteData extends AbstractImmutableSingleData<NotePitch, ImmutableNoteData, NoteData> implements ImmutableNoteData {
+
+    private final ImmutableValue<NotePitch> cachedValue = ImmutableSpongeValue.cachedOf(Keys.NOTE_PITCH, NotePitches.F_SHARP0, this.value);
+
+    public ImmutableSpongeNoteData() {
+        this(NotePitches.F_SHARP0);
+    }
+
+    public ImmutableSpongeNoteData(NotePitch note) {
+        super(ImmutableNoteData.class, note, Keys.NOTE_PITCH);
+    }
+
+    @Override
+    protected ImmutableValue<?> getValueGetter() {
+        return note();
+    }
+
+    @Override
+    public ImmutableValue<NotePitch> note() {
+        return this.cachedValue;
+    }
+
+    @Override
+    public NoteData asMutable() {
+        return new SpongeNoteData(this.value);
+    }
+
+    @Override
+    public int compareTo(ImmutableNoteData o) {
+        return ComparisonChain.start()
+                .compare(note().get().getId(), o.note().get().getId())
+                .result();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer().set(Keys.NOTE_PITCH, getValue());
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeNoteData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/tileentity/SpongeNoteData.java
@@ -1,0 +1,57 @@
+package org.spongepowered.common.data.manipulator.mutable.tileentity;
+
+import com.google.common.collect.ComparisonChain;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableNoteData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.NoteData;
+import org.spongepowered.api.data.type.NotePitch;
+import org.spongepowered.api.data.type.NotePitches;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.tileentity.ImmutableSpongeNoteData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+public class SpongeNoteData extends AbstractSingleData<NotePitch, NoteData, ImmutableNoteData> implements NoteData {
+
+    public SpongeNoteData() {
+        this(NotePitches.F_SHARP0);
+    }
+
+    public SpongeNoteData(NotePitch note) {
+        super(NoteData.class, note, Keys.NOTE_PITCH);
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return note();
+    }
+
+    @Override
+    public ImmutableNoteData asImmutable() {
+        return new ImmutableSpongeNoteData(this.getValue());
+    }
+
+    @Override
+    public int compareTo(NoteData o) {
+        return ComparisonChain.start()
+                .compare(note().get().getId(), o.note().get().getId())
+                .result();
+    }
+
+    @Override
+    public Value<NotePitch> note() {
+        return new SpongeValue<>(Keys.NOTE_PITCH, NotePitches.F_SHARP0, getValue());
+    }
+
+    @Override
+    public NoteData copy() {
+        return new SpongeNoteData(getValue());
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer().set(Keys.NOTE_PITCH, getValue());
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/common/NoteUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/NoteUtils.java
@@ -46,4 +46,9 @@ public class NoteUtils {
         return ((SpongeNotePitch) note).getByteId();
     }
 
+    public static NotePitch getNext(NotePitch note) {
+        byte value = (byte) (((SpongeNotePitch) note).getByteId() + 1);
+        return getPitch(value); // Ensure wrapping at edge
+    }
+
 }

--- a/src/main/java/org/spongepowered/common/data/processor/common/NoteUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/NoteUtils.java
@@ -1,0 +1,49 @@
+package org.spongepowered.common.data.processor.common;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.api.data.type.NotePitch;
+import org.spongepowered.common.data.type.SpongeNotePitch;
+
+import java.util.Map;
+
+public class NoteUtils {
+
+    // Dammit Mojang
+    public final static Map<Byte, SpongeNotePitch> pitchMappings = ImmutableMap.<Byte, SpongeNotePitch>builder()
+            .put((byte) 0, new SpongeNotePitch((byte) 0, "F_SHARP0"))
+            .put((byte) 1, new SpongeNotePitch((byte) 1, "G0"))
+            .put((byte) 2, new SpongeNotePitch((byte) 2, "G_SHARP0"))
+            .put((byte) 3, new SpongeNotePitch((byte) 3, "A1"))
+            .put((byte) 4, new SpongeNotePitch((byte) 4, "A_SHARP1"))
+            .put((byte) 5, new SpongeNotePitch((byte) 5, "B1"))
+            .put((byte) 6, new SpongeNotePitch((byte) 6, "C1"))
+            .put((byte) 7, new SpongeNotePitch((byte) 7, "C_SHARP1"))
+            .put((byte) 8, new SpongeNotePitch((byte) 8, "D1"))
+            .put((byte) 9, new SpongeNotePitch((byte) 9, "D_SHARP1"))
+            .put((byte) 10, new SpongeNotePitch((byte) 10, "E1"))
+            .put((byte) 11, new SpongeNotePitch((byte) 11, "F1"))
+            .put((byte) 12, new SpongeNotePitch((byte) 12, "F_SHARP1"))
+            .put((byte) 13, new SpongeNotePitch((byte) 13, "G1"))
+            .put((byte) 14, new SpongeNotePitch((byte) 14, "G_SHARP1"))
+            .put((byte) 15, new SpongeNotePitch((byte) 15, "A2"))
+            .put((byte) 16, new SpongeNotePitch((byte) 16, "A_SHARP2"))
+            .put((byte) 17, new SpongeNotePitch((byte) 17, "B2"))
+            .put((byte) 18, new SpongeNotePitch((byte) 18, "C2"))
+            .put((byte) 19, new SpongeNotePitch((byte) 19, "C_SHARP2"))
+            .put((byte) 20, new SpongeNotePitch((byte) 20, "D2"))
+            .put((byte) 21, new SpongeNotePitch((byte) 21, "D_SHARP2"))
+            .put((byte) 22, new SpongeNotePitch((byte) 22, "E2"))
+            .put((byte) 23, new SpongeNotePitch((byte) 23, "F2"))
+            .put((byte) 24, new SpongeNotePitch((byte) 24, "F_SHARP2"))
+            .build();
+
+    public static NotePitch getPitch(byte note) {
+        note = (byte) (note % 25);
+        return pitchMappings.get(note);
+    }
+
+    public static byte getPitch(NotePitch note) {
+        return ((SpongeNotePitch) note).getByteId();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/tileentity/NoteDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/tileentity/NoteDataProcessor.java
@@ -1,0 +1,54 @@
+package org.spongepowered.common.data.processor.data.tileentity;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.tileentity.TileEntityNote;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableNoteData;
+import org.spongepowered.api.data.manipulator.mutable.tileentity.NoteData;
+import org.spongepowered.api.data.type.NotePitch;
+import org.spongepowered.api.data.type.NotePitches;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeNoteData;
+import org.spongepowered.common.data.processor.common.AbstractTileEntitySingleDataProcessor;
+import org.spongepowered.common.data.processor.common.NoteUtils;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+import java.util.Optional;
+
+public class NoteDataProcessor extends AbstractTileEntitySingleDataProcessor<TileEntityNote, NotePitch, Value<NotePitch>, NoteData, ImmutableNoteData> {
+
+    public NoteDataProcessor() {
+        super(TileEntityNote.class, Keys.NOTE_PITCH);
+    }
+
+    @Override
+    protected boolean set(TileEntityNote entity, NotePitch value) {
+        entity.note = NoteUtils.getPitch(Preconditions.checkNotNull(value));
+        entity.markDirty();
+        return true;
+    }
+
+    @Override
+    protected Optional<NotePitch> getVal(TileEntityNote entity) {
+        return Optional.of(NoteUtils.getPitch(entity.note));
+    }
+
+    @Override
+    protected ImmutableValue<NotePitch> constructImmutableValue(NotePitch value) {
+        return ImmutableSpongeValue.cachedOf(Keys.NOTE_PITCH, NotePitches.F_SHARP0, value);
+    }
+
+    @Override
+    protected NoteData createManipulator() {
+        return new SpongeNoteData();
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionBuilder.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/NoteValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/NoteValueProcessor.java
@@ -1,0 +1,52 @@
+package org.spongepowered.common.data.processor.value.tileentity;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.tileentity.TileEntityNote;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.type.NotePitch;
+import org.spongepowered.api.data.type.NotePitches;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.processor.common.NoteUtils;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+import java.util.Optional;
+
+public class NoteValueProcessor extends AbstractSpongeValueProcessor<TileEntityNote, NotePitch, Value<NotePitch>> {
+
+    public NoteValueProcessor() {
+        super(TileEntityNote.class, Keys.NOTE_PITCH);
+    }
+
+    @Override
+    protected Value<NotePitch> constructValue(NotePitch value) {
+        return new SpongeValue<>(Keys.NOTE_PITCH, NotePitches.F_SHARP0, value);
+    }
+
+    @Override
+    protected boolean set(TileEntityNote container, NotePitch value) {
+        container.note = NoteUtils.getPitch(Preconditions.checkNotNull(value));
+        container.markDirty();
+        return true;
+    }
+
+    @Override
+    protected Optional<NotePitch> getVal(TileEntityNote container) {
+        return Optional.of(NoteUtils.getPitch(container.note));
+    }
+
+    @Override
+    protected ImmutableValue<NotePitch> constructImmutableValue(NotePitch value) {
+        return ImmutableSpongeValue.cachedOf(Keys.NOTE_PITCH, NotePitches.F_SHARP0, value);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/type/SpongeNotePitch.java
+++ b/src/main/java/org/spongepowered/common/data/type/SpongeNotePitch.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.data.type;
 
 import com.google.common.base.Objects;
 import org.spongepowered.api.data.type.NotePitch;
+import org.spongepowered.common.data.processor.common.NoteUtils;
 
 public class SpongeNotePitch implements NotePitch {
 
@@ -53,7 +54,7 @@ public class SpongeNotePitch implements NotePitch {
 
     @Override
     public NotePitch cycleNext() {
-        return null;
+        return NoteUtils.getNext(this);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/SpongeGameRegistry.java
@@ -312,6 +312,7 @@ import org.spongepowered.common.configuration.SpongeConfig;
 import org.spongepowered.common.data.SpongeDataRegistry;
 import org.spongepowered.common.data.SpongeImmutableRegistry;
 import org.spongepowered.common.data.SpongeSerializationRegistry;
+import org.spongepowered.common.data.processor.common.NoteUtils;
 import org.spongepowered.common.data.property.SpongePropertyRegistry;
 import org.spongepowered.common.data.property.store.block.BlastResistancePropertyStore;
 import org.spongepowered.common.data.property.store.block.GravityAffectedPropertyStore;
@@ -406,6 +407,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public abstract class SpongeGameRegistry implements GameRegistry {
 
@@ -1792,11 +1794,15 @@ public abstract class SpongeGameRegistry implements GameRegistry {
     }
 
     private void setNotePitches() {
-        RegistryHelper.mapFields(NotePitches.class, input -> {
-            NotePitch pitch = new SpongeNotePitch((byte) SpongeGameRegistry.this.notePitchMappings.size(), input);
-            SpongeGameRegistry.this.notePitchMappings.put(input.toLowerCase(), pitch);
-            return pitch;
-        });
+        this.notePitchMappings.putAll(
+                NoteUtils.pitchMappings.values()
+                .stream()
+                .collect(Collectors.toMap(
+                        note -> note.getId().toLowerCase(),
+                        Function.identity())
+                ));
+
+        RegistryHelper.mapFields(NotePitches.class, this.notePitchMappings);
     }
 
     private void setSkullTypes() {


### PR DESCRIPTION
Implementation of `NoteData`.
- [x] Registration of field getters and setters
- [ ] Accurately used the appropriate `AbstractData` implementation

Implementation of `ImmutableNoteData`
- [ ] Accurately extended the appropriate `AbstractImmutableData` implementation
- [x] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [x] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

Implementation of the `NoteDataProcessor`(s):
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [x] Registered the `Key` correctly by `NOTE_PITCH` in the `KeyRegistry`
- [x] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `SpongeSerializationRegistry`
- [x] Registered the `ValueProcessor`s in the `SpongeSerializationRegistry`

Test Plugin code:

Wrap your plugin code with ```java
// PUT CODE IN HERE

And at the end of your plugin ```

Notes:
Your test plugin should test using all possible value related methods with your `DataManipulator`s and also test the serialization and deserialization of your `DataManipulator`s.
