### PR TITLE
Implement BlockItemData.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeSerializationRegistry.java
@@ -124,6 +124,7 @@ import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableVehicleD
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableVelocityData;
 import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableVillagerZombieData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutableAuthorData;
+import org.spongepowered.api.data.manipulator.immutable.item.ImmutableBlockItemData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutableBreakableData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutableCoalData;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutableCookedFishData;
@@ -219,6 +220,7 @@ import org.spongepowered.api.data.manipulator.mutable.entity.VehicleData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VelocityData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VillagerZombieData;
 import org.spongepowered.api.data.manipulator.mutable.item.AuthorData;
+import org.spongepowered.api.data.manipulator.mutable.item.BlockItemData;
 import org.spongepowered.api.data.manipulator.mutable.item.BreakableData;
 import org.spongepowered.api.data.manipulator.mutable.item.CoalData;
 import org.spongepowered.api.data.manipulator.mutable.item.CookedFishData;
@@ -375,6 +377,7 @@ import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpong
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeVelocityData;
 import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeVillagerZombieData;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeAuthorData;
+import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeBlockItemData;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeBreakableData;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeCoalData;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeCookedFishData;
@@ -469,6 +472,7 @@ import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVehicleDat
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVelocityData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVillagerZombieData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeAuthorData;
+import org.spongepowered.common.data.manipulator.mutable.item.SpongeBlockItemData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeBreakableData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeCoalData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeCookedFishData;
@@ -563,6 +567,7 @@ import org.spongepowered.common.data.processor.data.entity.VelocityDataProcessor
 import org.spongepowered.common.data.processor.data.entity.VillagerZombieProcessor;
 import org.spongepowered.common.data.processor.data.entity.WitherTargetLivingDataProcessor;
 import org.spongepowered.common.data.processor.data.entity.WolfWetDataProcessor;
+import org.spongepowered.common.data.processor.data.item.BlockItemDataProcessor;
 import org.spongepowered.common.data.processor.data.item.BreakableDataProcessor;
 import org.spongepowered.common.data.processor.data.item.CoalDataProcessor;
 import org.spongepowered.common.data.processor.data.item.CookedFishDataProcessor;
@@ -678,6 +683,7 @@ import org.spongepowered.common.data.processor.value.entity.VelocityValueProcess
 import org.spongepowered.common.data.processor.value.entity.VillagerZombieValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.WalkingSpeedValueProcessor;
 import org.spongepowered.common.data.processor.value.entity.WitherTargetsValueProcessor;
+import org.spongepowered.common.data.processor.value.item.BlockItemValueProcessor;
 import org.spongepowered.common.data.processor.value.item.BookAuthorValueProcessor;
 import org.spongepowered.common.data.processor.value.item.BookPagesValueProcessor;
 import org.spongepowered.common.data.processor.value.item.BreakableValueProcessor;
@@ -1166,6 +1172,10 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerDataProcessorAndImpl(FireworkEffectData.class, SpongeFireworkEffectData.class,
                 ImmutableFireworkEffectData.class, ImmutableSpongeFireworkEffectData.class, fireworkEffectDataProcessor);
 
+        final BlockItemDataProcessor blockItemDataProcessor = new BlockItemDataProcessor();
+        dataRegistry.registerDataProcessorAndImpl(BlockItemData.class, SpongeBlockItemData.class, ImmutableBlockItemData.class,
+                ImmutableSpongeBlockItemData.class, blockItemDataProcessor);
+
         final FireworkRocketDataProcessor fireworkRocketDataProcessor = new FireworkRocketDataProcessor();
         dataRegistry.registerDataProcessorAndImpl(FireworkRocketData.class, SpongeFireworkRocketData.class,
                 ImmutableFireworkRocketData.class, ImmutableSpongeFireworkRocketData.class, fireworkRocketDataProcessor);
@@ -1300,6 +1310,7 @@ public class SpongeSerializationRegistry {
         dataRegistry.registerValueProcessor(Keys.IN_WALL, new InWallValueProcessor());
         dataRegistry.registerValueProcessor(Keys.AXIS, new AxisValueProcessor());
         dataRegistry.registerValueProcessor(Keys.DELAY, new DelayValueProcessor());
+        dataRegistry.registerValueProcessor(Keys.ITEM_BLOCKSTATE, new BlockItemValueProcessor());
 
         // Properties
         final PropertyRegistry propertyRegistry = SpongePropertyRegistry.getInstance();

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -237,6 +237,7 @@ public class KeyRegistry {
         keyMap.put("decayable", makeSingleKey(Boolean.class, Value.class, of("Decayable")));
         keyMap.put("in_wall", makeSingleKey(Boolean.class, Value.class, of("InWall")));
         keyMap.put("delay", makeSingleKey(Integer.class, MutableBoundedValue.class, of("Delay")));
+        keyMap.put("item_blockstate", makeSingleKey(BlockState.class, Value.class, of("ItemBlockState")));
     }
 
     private static Map<String, Key<?>> getKeyMap() {

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBlockItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBlockItemData.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.item;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.item.ImmutableBlockItemData;
+import org.spongepowered.api.data.manipulator.mutable.item.BlockItemData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.mutable.item.SpongeBlockItemData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+public class ImmutableSpongeBlockItemData extends AbstractImmutableSingleData<BlockState, ImmutableBlockItemData, BlockItemData>
+        implements ImmutableBlockItemData {
+
+    private final ImmutableValue<BlockState> state;
+
+    public ImmutableSpongeBlockItemData(BlockState value) {
+        super(ImmutableBlockItemData.class, value, Keys.ITEM_BLOCKSTATE);
+        this.state = new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), value);
+    }
+
+    @Override
+    public ImmutableValue<BlockState> state() {
+        return this.state;
+    }
+
+    @Override
+    protected ImmutableValue<?> getValueGetter() {
+        return state();
+    }
+
+    @Override
+    public BlockItemData asMutable() {
+        return new SpongeBlockItemData(this.getValue());
+    }
+
+    @Override
+    public int compareTo(ImmutableBlockItemData o) {
+        return 0;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBlockItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBlockItemData.java
@@ -25,13 +25,13 @@
 package org.spongepowered.common.data.manipulator.immutable.item;
 
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.item.ImmutableBlockItemData;
 import org.spongepowered.api.data.manipulator.mutable.item.BlockItemData;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeBlockItemData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.util.BlockUtil;
 
@@ -42,7 +42,7 @@ public class ImmutableSpongeBlockItemData extends AbstractImmutableSingleData<Bl
 
     public ImmutableSpongeBlockItemData(BlockState value) {
         super(ImmutableBlockItemData.class, value, Keys.ITEM_BLOCKSTATE);
-        this.state = new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), value);
+        this.state = new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, DataConstants.DEFAULT_BLOCK_STATE, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBlockItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/item/ImmutableSpongeBlockItemData.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeBlockItemData;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.util.BlockUtil;
 
 public class ImmutableSpongeBlockItemData extends AbstractImmutableSingleData<BlockState, ImmutableBlockItemData, BlockItemData>
         implements ImmutableBlockItemData {
@@ -61,7 +62,7 @@ public class ImmutableSpongeBlockItemData extends AbstractImmutableSingleData<Bl
 
     @Override
     public int compareTo(ImmutableBlockItemData o) {
-        return 0;
+        return BlockUtil.BLOCK_STATE_COMPARATOR.compare(getValue(), o.get(Keys.ITEM_BLOCKSTATE).get());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeBlockItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeBlockItemData.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.item;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.item.ImmutableBlockItemData;
+import org.spongepowered.api.data.manipulator.mutable.item.BlockItemData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeBlockItemData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+public class SpongeBlockItemData extends AbstractSingleData<BlockState, BlockItemData, ImmutableBlockItemData> implements BlockItemData {
+
+    public SpongeBlockItemData(BlockState value) {
+        super(BlockItemData.class, value, Keys.ITEM_BLOCKSTATE);
+    }
+
+    public SpongeBlockItemData() {
+        this(BlockTypes.STONE.getDefaultState());
+    }
+
+    @Override
+    public BlockItemData copy() {
+        return new SpongeBlockItemData(this.getValue());
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer().set(Keys.ITEM_BLOCKSTATE, this.getValue());
+    }
+
+    @Override
+    public Value<BlockState> state() {
+        return new SpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), this.getValue());
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return state();
+    }
+
+    @Override
+    public ImmutableBlockItemData asImmutable() {
+        return new ImmutableSpongeBlockItemData(this.getValue());
+    }
+
+    @Override
+    public int compareTo(BlockItemData o) {
+        return 0;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeBlockItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeBlockItemData.java
@@ -25,7 +25,6 @@
 package org.spongepowered.common.data.manipulator.mutable.item;
 
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.MemoryDataContainer;
 import org.spongepowered.api.data.key.Keys;
@@ -34,6 +33,7 @@ import org.spongepowered.api.data.manipulator.mutable.item.BlockItemData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeBlockItemData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 import org.spongepowered.common.util.BlockUtil;
 
@@ -44,7 +44,7 @@ public class SpongeBlockItemData extends AbstractSingleData<BlockState, BlockIte
     }
 
     public SpongeBlockItemData() {
-        this(BlockTypes.STONE.getDefaultState());
+        this(DataConstants.DEFAULT_BLOCK_STATE);
     }
 
     @Override
@@ -59,7 +59,7 @@ public class SpongeBlockItemData extends AbstractSingleData<BlockState, BlockIte
 
     @Override
     public Value<BlockState> state() {
-        return new SpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), this.getValue());
+        return new SpongeValue<>(Keys.ITEM_BLOCKSTATE, DataConstants.DEFAULT_BLOCK_STATE, this.getValue());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeBlockItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/item/SpongeBlockItemData.java
@@ -35,6 +35,7 @@ import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.immutable.item.ImmutableSpongeBlockItemData;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.util.BlockUtil;
 
 public class SpongeBlockItemData extends AbstractSingleData<BlockState, BlockItemData, ImmutableBlockItemData> implements BlockItemData {
 
@@ -73,7 +74,7 @@ public class SpongeBlockItemData extends AbstractSingleData<BlockState, BlockIte
 
     @Override
     public int compareTo(BlockItemData o) {
-        return 0;
+        return BlockUtil.BLOCK_STATE_COMPARATOR.compare(getValue(), o.get(Keys.ITEM_BLOCKSTATE).get());
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/BlockItemDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/BlockItemDataProcessor.java
@@ -29,7 +29,6 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
@@ -40,6 +39,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.mutable.item.SpongeBlockItemData;
 import org.spongepowered.common.data.processor.common.AbstractItemSingleDataProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 
 import java.util.Optional;
@@ -76,7 +76,7 @@ public class BlockItemDataProcessor extends AbstractItemSingleDataProcessor<Bloc
 
     @Override
     protected ImmutableValue<BlockState> constructImmutableValue(BlockState value) {
-        return new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), value);
+        return new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, DataConstants.DEFAULT_BLOCK_STATE, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/BlockItemDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/BlockItemDataProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.item;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.item.ImmutableBlockItemData;
+import org.spongepowered.api.data.manipulator.mutable.item.BlockItemData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.item.SpongeBlockItemData;
+import org.spongepowered.common.data.processor.common.AbstractItemSingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+
+import java.util.Optional;
+
+public class BlockItemDataProcessor extends AbstractItemSingleDataProcessor<BlockState, Value<BlockState>, BlockItemData, ImmutableBlockItemData> {
+
+    public BlockItemDataProcessor() {
+        super(stack -> stack.getItem() instanceof ItemBlock, Keys.ITEM_BLOCKSTATE);
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    protected boolean set(ItemStack stack, BlockState value) {
+        final IBlockState blockState = (IBlockState) value;
+        final Block baseBlock = blockState.getBlock();
+        if (Block.getBlockFromItem(stack.getItem()) != baseBlock) {
+            // Invalid state for this stack.
+            return false;
+        }
+        stack.setItemDamage(baseBlock.damageDropped(blockState));
+        return true;
+    }
+
+    @Override
+    protected Optional<BlockState> getVal(ItemStack stack) {
+        final Block block = ((ItemBlock) stack.getItem()).getBlock();
+        final int blockMeta = stack.getItem().getMetadata(stack.getItemDamage());
+        return Optional.of((BlockState) block.getStateFromMeta(blockMeta));
+    }
+
+    @Override
+    protected ImmutableValue<BlockState> constructImmutableValue(BlockState value) {
+        return new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), value);
+    }
+
+    @Override
+    protected BlockItemData createManipulator() {
+        return new SpongeBlockItemData();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/BlockItemValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/BlockItemValueProcessor.java
@@ -29,7 +29,6 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.DataTransactionBuilder;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
@@ -37,6 +36,7 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
 
@@ -84,7 +84,7 @@ public class BlockItemValueProcessor extends AbstractSpongeValueProcessor<ItemSt
 
     @Override
     protected ImmutableValue<BlockState> constructImmutableValue(BlockState value) {
-        return new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), value);
+        return new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, DataConstants.DEFAULT_BLOCK_STATE, value);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/BlockItemValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/BlockItemValueProcessor.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.value.item;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.DataTransactionBuilder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+import java.util.Optional;
+
+public class BlockItemValueProcessor extends AbstractSpongeValueProcessor<ItemStack, BlockState, Value<BlockState>> {
+
+    public BlockItemValueProcessor() {
+        super(ItemStack.class, Keys.ITEM_BLOCKSTATE);
+    }
+    
+    @Override
+    protected boolean supports(ItemStack container) {
+        return container.getItem() instanceof ItemBlock;
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionBuilder.failNoData();
+    }
+
+    @Override
+    protected Value<BlockState> constructValue(BlockState defaultValue) {
+        return new SpongeValue<>(Keys.ITEM_BLOCKSTATE, defaultValue);
+    }
+
+    @Override
+    protected boolean set(ItemStack stack, BlockState value) {
+        final IBlockState blockState = (IBlockState) value;
+        final Block baseBlock = blockState.getBlock();
+        if (Block.getBlockFromItem(stack.getItem()) != baseBlock) {
+            // Invalid state for this stack.
+            return false;
+        }
+        stack.setItemDamage(baseBlock.damageDropped(blockState));
+        return true;
+    }
+
+    @Override
+    protected Optional<BlockState> getVal(ItemStack stack) {
+        final Block block = ((ItemBlock) stack.getItem()).getBlock();
+        final int blockMeta = stack.getItem().getMetadata(stack.getItemDamage());
+        return Optional.of((BlockState) block.getStateFromMeta(blockMeta));
+    }
+
+    @Override
+    protected ImmutableValue<BlockState> constructImmutableValue(BlockState value) {
+        return new ImmutableSpongeValue<>(Keys.ITEM_BLOCKSTATE, BlockTypes.STONE.getDefaultState(), value);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/util/DataConstants.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataConstants.java
@@ -25,6 +25,8 @@
 package org.spongepowered.common.data.util;
 
 import net.minecraft.util.IChatComponent;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.type.BigMushroomType;
 import org.spongepowered.api.data.type.BigMushroomTypes;
 import org.spongepowered.api.data.type.BrickType;
@@ -99,6 +101,8 @@ public final class DataConstants {
     public static final double MINIMUM_EXHAUSTION = ZERO;
     public static final double DEFAULT_SATURATION = ZERO;
     public static final int DEFAULT_FOOD_LEVEL = 20;
+
+    public static final BlockState DEFAULT_BLOCK_STATE = BlockTypes.STONE.getDefaultState();
 
 
 }

--- a/src/main/java/org/spongepowered/common/util/BlockUtil.java
+++ b/src/main/java/org/spongepowered/common/util/BlockUtil.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.util;
+
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.Maps;
+import net.minecraft.block.state.IBlockState;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.trait.BlockTrait;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class BlockUtil {
+
+    private static final class BlockStateComparator implements Comparator<BlockState> {
+
+        @Override
+        public int compare(BlockState spongeA, BlockState spongeB) {
+            IBlockState a = (IBlockState) spongeA;
+            IBlockState b = (IBlockState) spongeB;
+            ComparisonChain chain = ComparisonChain.start();
+            // compare IDs
+            chain = chain.compare(a.getBlock().getUnlocalizedName(), b.getBlock().getUnlocalizedName());
+            // compare block traits
+            Map<BlockTrait<?>, ?> aTraits = spongeA.getTraitMap();
+            Map<BlockTrait<?>, ?> bTraits = spongeA.getTraitMap();
+            chain = chain.compare(aTraits.size(), bTraits.size());
+            if (chain.result() != 0) {
+                // avoid potentially expensive ops
+                return chain.result();
+            }
+            MapDifference<BlockTrait<?>, ?> diff = Maps.difference(aTraits, bTraits);
+            if (diff.areEqual()) {
+                // When the Maps are equal the end-result is 0, so chain.result
+                // is the same
+                return chain.result();
+            }
+            // Check the keys, see if they match
+            int onLeft = diff.entriesOnlyOnLeft().size();
+            int onRight = diff.entriesOnlyOnRight().size();
+            chain = chain.compare(onLeft, onRight);
+            if (chain.result() != 0) {
+                // avoid potentially expensive ops
+                return chain.result();
+            }
+            // Ok, keys match. Check values. Guaranteed difference here due to
+            // equality check above.
+            List<BlockTrait<?>> checkOrder = sortTraits(diff.entriesDiffering().keySet());
+            for (BlockTrait<?> trait : checkOrder) {
+                Comparable<?> aTraitValue = (Comparable<?>) aTraits.get(trait);
+                Comparable<?> bTraitValue = (Comparable<?>) bTraits.get(trait);
+                chain = chain.compare(aTraitValue, bTraitValue);
+                if (chain.result() != 0) {
+                    return chain.result();
+                }
+            }
+            // Impossible.
+            throw new IllegalStateException("Some object's equals() violates contract!");
+        }
+
+        /**
+         * Sorts {@code traits} by the trait IDs.
+         */
+        private List<BlockTrait<?>> sortTraits(Set<BlockTrait<?>> traits) {
+            return traits.stream().sorted((a, b) -> a.getId().compareTo(b.getId())).collect(Collectors.toList());
+        }
+
+    }
+
+    public static final Comparator<BlockState> BLOCK_STATE_COMPARATOR = new BlockStateComparator();
+
+}


### PR DESCRIPTION
Implementation of `BlockItemData`.
- [X] Registration of field getters and setters
- [X] Accurately used the appropriate `AbstractData` implementation

Implementation of `ImmutableBlockItemData`
- [X] Accurately extended the appropriate `AbstractImmutableData` implementation
- [X] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [X] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

Implementation of the `BlockItemDataProcessor`(s):
- [X] Appropriately extended `AbstractSpongeValueProcessor`
- [X] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [X] Registered the `Key` correctly by `item_blockstate` in the `KeyRegistry`
- [X] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `SpongeSerializationRegistry`
- [X] Registered the `ValueProcessor`s in the `SpongeSerializationRegistry`

Test Plugin code: [100% *AWESOME* since 11/9](https://github.com/kenzierocks/SpongePlugins/blob/master/src/main/java/me/kenzierocks/plugins/TestSpongeBlockItemData.java)