### PR TITLE
Allow shutting down the server if the EULA is not accepted

### DIFF
--- a/src/main/java/org/spongepowered/common/configuration/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/common/configuration/SpongeConfig.java
@@ -97,6 +97,9 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
     // BUNGEECORD
     public static final String BUNGEECORD_IP_FORWARDING = "ip-forwarding";
 
+    // EULA
+    public static final String EULA_SHUTDOWN_SERVER = "shutdown-server";
+
     // GENERAL
     public static final String GENERAL_DISABLE_WARNINGS = "disable-warnings";
     public static final String GENERAL_CHUNK_LOAD_OVERRIDE = "chunk-load-override";
@@ -124,6 +127,7 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
     // MODULES
     public static final String MODULE_ENTITY_ACTIVATION_RANGE = "entity-activation-range";
     public static final String MODULE_BUNGEECORD = "bungeecord";
+    public static final String MODULE_SHUTDOWN_ON_EULA = "shutdown-on-eula";
 
     // WORLD
     public static final String WORLD_INFINITE_WATER_SOURCE = "infinite-water-source";
@@ -250,8 +254,15 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
         @Setting(value = MODULE_BUNGEECORD)
         private BungeeCordCategory bungeeCord = new BungeeCordCategory();
 
+        @Setting(MODULE_SHUTDOWN_ON_EULA)
+        private ShutdownOnEulaCategory eulaShutdown = new ShutdownOnEulaCategory();
+
         public BungeeCordCategory getBungeeCord() {
             return this.bungeeCord;
+        }
+
+        public ShutdownOnEulaCategory getEulaShutdown() {
+            return this.eulaShutdown;
         }
 
         public SqlCategory getSql() {
@@ -552,6 +563,17 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
 
         public boolean getIpForwarding() {
             return this.ipForwarding;
+        }
+    }
+
+    @ConfigSerializable
+    public static class ShutdownOnEulaCategory extends Category {
+
+        @Setting(value = EULA_SHUTDOWN_SERVER, comment = "If enabled, shut down the server if the EULA has not been accepted")
+        private boolean shutdownServer = true;
+
+        public boolean shouldShutdownServer() {
+            return this.shutdownServer;
         }
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/eulashutdown/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/eulashutdown/MixinDedicatedServer.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.eulashutdown;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerEula;
+import net.minecraft.server.dedicated.DedicatedServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.SpongeImpl;
+
+import java.io.File;
+import java.net.Proxy;
+
+@Mixin(DedicatedServer.class)
+public abstract class MixinDedicatedServer extends MinecraftServer {
+
+    public MixinDedicatedServer(File workDir, Proxy proxy, File profileCacheDir) {
+        super(workDir, proxy, profileCacheDir);
+    }
+
+    @Redirect(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerEula;hasAcceptedEULA()Z"))
+    public boolean onHasAcceptedEULA(ServerEula eula) {
+        boolean hasAcceptedEULA = eula.hasAcceptedEULA();
+        if (!hasAcceptedEULA && SpongeImpl.getGlobalConfig().getConfig().getEulaShutdown().shouldShutdownServer()) {
+            this.initiateShutdown();
+        }
+        return hasAcceptedEULA;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/plugin/EulaShutdownPlugin.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/EulaShutdownPlugin.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.plugin;
+
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.List;
+import java.util.Set;
+
+public class EulaShutdownPlugin implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return SpongeImpl.getGlobalConfig().getConfig().getEulaShutdown().shouldShutdownServer();
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/src/main/resources/mixins.common.eulashutdown.json
+++ b/src/main/resources/mixins.common.eulashutdown.json
@@ -1,0 +1,10 @@
+{
+  "package": "org.spongepowered.common.mixin.eulashutdown",
+  "refmap": "mixins.common.refmap.json",
+  "plugin": "org.spongepowered.common.mixin.plugin.EulaShutdownPlugin",
+  "mixins": [
+  ],
+  "server": [
+    "MixinDedicatedServer"
+  ]
+}


### PR DESCRIPTION
Currently, the dedicated servers ends up looping forever in `finalTick` if the EULA was not accepted. While this has always been vanilla behavior, it's generally undesireable, since there's no point leaving the server running in a half-initialized state.

This PR adds a new config section and option to control whether the server automatically shuts down when the EULA is not accepted (which defaults to true). The only change that needs to be made in SpongeForge and SpongeVanilla is to enable the mixin config.

Note: Forge logs a message about an unexpected transition to the state `SERVER_STOPPED` when this change is enabled. This is correct - this change is functionally equivalent to manually stopping or killing server when the EULA is not accepted, which actually does prevent some initialization from running.