### PR TITLE
Changes to implement GameStoppingEvent and GameStoppedEvent in SpongeForge.

### DIFF
--- a/src/main/java/org/spongepowered/common/SpongeGame.java
+++ b/src/main/java/org/spongepowered/common/SpongeGame.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Platform;
+import org.spongepowered.api.GameState;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.command.SimpleCommandManager;
 import org.spongepowered.api.config.ConfigManager;
@@ -64,6 +65,8 @@ public abstract class SpongeGame implements Game {
     private final TeleportHelper teleportHelper;
     private final ConfigManager configManager;
     private final CommandManager commandManager;
+
+    private GameState state = GameState.CONSTRUCTION;
 
     protected SpongeGame(Platform platform, PluginManager pluginManager, EventManager eventManager, SpongeGameRegistry gameRegistry,
             ServiceManager serviceManager, TeleportHelper teleportHelper, Logger logger) {
@@ -143,6 +146,15 @@ public abstract class SpongeGame implements Game {
         return Objects.toStringHelper(this)
                 .add("platform", this.platform)
                 .toString();
+    }
+
+    @Override
+    public GameState getState() {
+        return this.state;
+    }
+
+    public void setState(GameState state) {
+        this.state = checkNotNull(state);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/SpongeImpl.java
+++ b/src/main/java/org/spongepowered/common/SpongeImpl.java
@@ -32,9 +32,15 @@ import com.google.inject.Injector;
 import org.apache.logging.log4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongepowered.api.Game;
+import org.spongepowered.api.GameState;
 import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.SpongeEventFactoryUtils;
+import org.spongepowered.api.event.game.state.GameStateEvent;
+import org.spongepowered.api.event.game.state.GameStoppedEvent;
+import org.spongepowered.api.event.game.state.GameStoppingEvent;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.common.config.SpongeConfig;
+import org.spongepowered.common.event.SpongeEventManager;
 import org.spongepowered.common.launch.SpongeLaunch;
 import org.spongepowered.common.registry.SpongeGameRegistry;
 
@@ -149,6 +155,16 @@ public class SpongeImpl {
         }
 
         return globalConfig;
+    }
+
+    public static void postState(Class<? extends GameStateEvent> type, GameState state) {
+        getGame().setState(state);
+        ((SpongeEventManager) getGame().getEventManager()).post(SpongeEventFactoryUtils.createState(type, getGame()), true);
+    }
+    
+    public static void postShutdownEvents() {
+        postState(GameStoppingEvent.class, GameState.GAME_STOPPING);
+        postState(GameStoppedEvent.class, GameState.GAME_STOPPED);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeEventManager.java
@@ -257,6 +257,10 @@ public class SpongeEventManager implements EventManager {
     public boolean post(Event event) {
         return post(event, getHandlerCache(event).getListeners());
     }
+    
+    public boolean post(Event event, boolean allowClientThread) {
+        return post(event);
+    }
 
     public boolean post(Event event, Order order) {
         return post(event, getHandlerCache(event).getListenersByOrder(order));

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
@@ -29,6 +29,10 @@ import net.minecraft.server.dedicated.DedicatedServer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.SpongeImpl;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
@@ -57,6 +61,11 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
     public void setGuiEnabled() {
         //MinecraftServerGui.createServerGui(this);
         this.guiIsEnabled = false;
+    }
+
+    @Inject(method = "systemExitNow", at = @At("HEAD"))
+    public void postGameStoppingEvent(CallbackInfo ci) {
+        SpongeImpl.postShutdownEvents();
     }
 
 }


### PR DESCRIPTION
**SpongeCommon PR** | [SpongeForge PR](https://github.com/SpongePowered/SpongeForge/pull/425) | [SpongeVanilla PR](https://github.com/SpongePowered/SpongeVanilla/pull/188)

- Moves `GameStoppingEvent` and `GameStoppedEvent` firing in `DedicatedServer` from SpongeVanilla to SpongeCommon.
- Moves `SpongeVanilla.postState()` to `SpongeImpl`.
- Moves `SpongeModGame.getState()`/`VanillaGame.getState()` and `SpongeModGame.setState()`/`VanillaGame.setState()` to `SpongeGame`.