### PR TITLE
Make arrows consistent

### DIFF
--- a/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
@@ -160,6 +160,8 @@ abstract class ActivePagination {
         TextBuilder ret = Texts.builder();
         if (hasPrevious) {
             ret.append(this.prevPageText).append(DIVIDER_TEXT);
+        } else {
+            ret.append(Texts.of("«")).append(DIVIDER_TEXT);
         }
         boolean needsDiv = false;
         int totalPages = getTotalPages();
@@ -172,6 +174,11 @@ abstract class ActivePagination {
                 ret.append(DIVIDER_TEXT);
             }
             ret.append(this.nextPageText);
+        } else {
+            if (needsDiv) {
+                ret.append(DIVIDER_TEXT);
+            }
++           ret.append(Texts.of("»"));
         }
         if (this.title != null) {
             ret.color(this.title.getColor());

--- a/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
@@ -178,7 +178,7 @@ abstract class ActivePagination {
             if (needsDiv) {
                 ret.append(DIVIDER_TEXT);
             }
-+           ret.append(Texts.of("»"));
+            ret.append(Texts.of("»"));
         }
         if (this.title != null) {
             ret.color(this.title.getColor());


### PR DESCRIPTION
instead of selectively removing the arrows on the first / last page,
keep the arrows there, but gray them out so the bottom line is constant across all pages