### PR TITLE
Improve velocity behavior.

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/VelocityDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/VelocityDataProcessor.java
@@ -42,16 +42,12 @@ import org.spongepowered.api.data.manipulator.mutable.entity.VelocityData;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeVelocityData;
 import org.spongepowered.common.data.processor.common.AbstractEntityDataProcessor;
 import org.spongepowered.common.data.util.DataQueries;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
 
 import java.util.Map;
 import java.util.Optional;
 
 public class VelocityDataProcessor extends AbstractEntityDataProcessor<Entity, VelocityData, ImmutableVelocityData> {
-
-    // EntityLivingBase.moveEntityWithHeading sets y-velocity at this value when
-    // entity is at rest. Value is -0.08 * 0.9800000190734863. See
-    // https://github.com/SpongePowered/SpongeCommon/issues/149#issuecomment-158832297
-    public static final double ENTITY_REST_Y_VEL = -0.0784000015258789D;
 
     public VelocityDataProcessor() {
         super(Entity.class);
@@ -69,20 +65,13 @@ public class VelocityDataProcessor extends AbstractEntityDataProcessor<Entity, V
 
     @Override
     protected boolean set(Entity entity, Map<Key<?>, Object> keyValues) {
-        final Vector3d velocity = (Vector3d) keyValues.get(Keys.VELOCITY);
-        entity.motionX = velocity.getX();
-        entity.motionY = velocity.getY();
-        entity.motionZ = velocity.getZ();
-        entity.velocityChanged = true;
+        ((IMixinEntity) entity).setVelocity((Vector3d) keyValues.get(Keys.VELOCITY));
         return true;
     }
 
     @Override
     protected Map<Key<?>, ?> getValues(Entity entity) {
-        final double xVel = entity.motionX;
-        final double yVel = entity.motionY == ENTITY_REST_Y_VEL ? 0 : entity.motionY;
-        final double zVel = entity.motionZ;
-        return ImmutableMap.<Key<?>, Object>of(Keys.VELOCITY, new Vector3d(xVel, yVel, zVel));
+        return ImmutableMap.<Key<?>, Object>of(Keys.VELOCITY, ((IMixinEntity) entity).getVelocity());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/VelocityValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/VelocityValueProcessor.java
@@ -33,9 +33,9 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
-import org.spongepowered.common.data.processor.data.entity.VelocityDataProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.interfaces.entity.IMixinEntity;
 
 import java.util.Optional;
 
@@ -52,17 +52,13 @@ public class VelocityValueProcessor extends AbstractSpongeValueProcessor<Entity,
 
     @Override
     protected boolean set(Entity container, Vector3d value) {
-        container.motionX = value.getX();
-        container.motionY = value.getY();
-        container.motionZ = value.getZ();
-        container.velocityChanged = true;
+        ((IMixinEntity) container).setVelocity(value);
         return true;
     }
 
     @Override
     protected Optional<Vector3d> getVal(Entity container) {
-        final double velY = container.motionY == VelocityDataProcessor.ENTITY_REST_Y_VEL ? 0 : container.motionY;
-        return Optional.of(new Vector3d(container.motionX, velY, container.motionZ));
+        return Optional.of(((IMixinEntity) container).getVelocity());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayerMP.java
@@ -24,7 +24,10 @@
  */
 package org.spongepowered.common.interfaces;
 
+import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.entity.living.player.User;
+
+import javax.annotation.Nullable;
 
 public interface IMixinEntityPlayerMP {
 
@@ -33,5 +36,7 @@ public interface IMixinEntityPlayerMP {
     boolean usesCustomClient();
 
     User getUserObject();
+    
+    void setVelocityOverride(@Nullable Vector3d velocity);
 
 }

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.interfaces.entity;
 
+import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.data.manipulator.DataManipulator;
@@ -73,5 +74,9 @@ public interface IMixinEntity {
      * @param compound The SpongeData compound to write to
      */
     void writeToNbt(NBTTagCompound compound);
+    
+    Vector3d getVelocity();
+    
+    void setVelocity(Vector3d velocity);
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -114,6 +114,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
     @Shadow public double motionX;
     @Shadow public double motionY;
     @Shadow public double motionZ;
+    @Shadow public boolean velocityChanged;
     @Shadow public double prevPosX;
     @Shadow public double prevPosY;
     @Shadow public double prevPosZ;
@@ -818,5 +819,18 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
             // player is not online, get user from storage if one exists
             return SpongeImpl.getGame().getServiceManager().provide(UserStorage.class).get().get(uuid);
         }
+    }
+    
+    @Override
+    public Vector3d getVelocity() {
+        return new Vector3d(this.motionX, this.motionY, this.motionZ);
+    }
+    
+    @Override
+    public void setVelocity(Vector3d velocity) {
+        this.motionX = velocity.getX();
+        this.motionY = velocity.getY();
+        this.motionZ = velocity.getZ();
+        this.velocityChanged = true;
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -92,6 +92,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 @NonnullByDefault
 @Mixin(EntityPlayerMP.class)
 public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements Player, IMixinSubject, IMixinEntityPlayerMP, IMixinCommandSender,
@@ -113,6 +115,8 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     private Scoreboard spongeScoreboard = ((World) this.worldObj).getScoreboard();
 
     private net.minecraft.scoreboard.Scoreboard mcScoreboard = this.worldObj.getScoreboard();
+    
+    @Nullable private Vector3d velocityOverride = null;
 
     @Inject(method = "removeEntity", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/network/NetHandlerPlayServer;sendPacket(Lnet/minecraft/network/Packet;)V"))
@@ -407,5 +411,24 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     @Override
     public void setSleepingIgnored(boolean sleepingIgnored) {
         this.sleepingIgnored = sleepingIgnored;
+    }
+    
+    @Override
+    public Vector3d getVelocity() {
+        if (this.velocityOverride != null) {
+            return this.velocityOverride;
+        }
+        return super.getVelocity();
+    }
+    
+    @Override
+    public void setVelocity(Vector3d velocity) {
+        super.setVelocity(velocity);
+        this.velocityOverride = null;
+    }
+    
+    @Override
+    public void setVelocityOverride(@Nullable Vector3d velocity) {
+        this.velocityOverride = velocity;
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
@@ -92,6 +92,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplFactory;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.interfaces.IMixinContainer;
+import org.spongepowered.common.interfaces.IMixinEntityPlayerMP;
 import org.spongepowered.common.interfaces.IMixinNetworkManager;
 import org.spongepowered.common.interfaces.IMixinPacketResourcePackSend;
 import org.spongepowered.common.interfaces.network.IMixinC08PacketPlayerBlockPlacement;
@@ -308,6 +309,8 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
                 // Correct the new rotation to match the old rotation
                 torot = fromrot;
             }
+            
+            ((IMixinEntityPlayerMP) this.playerEntity).setVelocityOverride(to.getPosition().sub(from.getPosition()));
 
             double deltaSquared = to.getPosition().distanceSquared(from.getPosition());
             double deltaAngleSquared = fromrot.distanceSquared(torot);
@@ -323,15 +326,18 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
                 if (event.isCancelled()) {
                     player.setTransform(fromTransform);
                     this.lastMoveLocation = from;
+                    ((IMixinEntityPlayerMP) this.playerEntity).setVelocityOverride(null);
                     ci.cancel();
                 } else if (!event.getToTransform().equals(toTransform)) {
                     player.setTransform(event.getToTransform());
                     this.lastMoveLocation = event.getToTransform().getLocation();
+                    ((IMixinEntityPlayerMP) this.playerEntity).setVelocityOverride(null);
                     ci.cancel();
                 } else if (!from.equals(player.getLocation()) && this.justTeleported) {
                     this.lastMoveLocation = player.getLocation();
                     // Prevent teleports during the move event from causing odd behaviors
                     this.justTeleported = false;
+                    ((IMixinEntityPlayerMP) this.playerEntity).setVelocityOverride(null);
                     ci.cancel();
                 } else {
                     this.lastMoveLocation = event.getToTransform().getLocation();


### PR DESCRIPTION
No longer requires magic values. Works properly with players, but haven't tested with non-player `EntityLivingBase`s.

See the discussion in #149.

Code:
```java
package jbyoshi.sponge.test;

import org.slf4j.Logger;
import org.spongepowered.api.data.key.Keys;
import org.spongepowered.api.event.Listener;
import org.spongepowered.api.event.entity.DisplaceEntityEvent;
import org.spongepowered.api.plugin.Plugin;
import org.spongepowered.api.service.scheduler.Task;

import javax.inject.Inject;

@Plugin(id = "jbyoshi.sponge.test", name="JBYoshi Sponge Test")
public final class SpongeTestPlugin {
    
    @Inject private Logger logger;
    
    @Listener
    public void playerMoved(DisplaceEntityEvent.TargetPlayer event) {
        this.logger.info(event.getToTransform().getPosition().sub(event.getFromTransform().getPosition()).toString());
        event.getGame().getScheduler().createTaskBuilder().execute(() -> {
            this.logger.info("-> " + event.getTargetEntity().get(Keys.VELOCITY).get());
        }).submit(this);
    }
}
```