### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     compile 'com.zaxxer:HikariCP:2.4.1'
 
-    runtime 'org.mariadb.jdbc:mariadb-java-client:1.2.3'
+    runtime 'org.mariadb.jdbc:mariadb-java-client:1.3.2'
     runtime 'com.h2database:h2:1.4.190'
     runtime 'org.xerial:sqlite-jdbc:3.8.11.2'
 }


### PR DESCRIPTION
Upgrade to newer version of the MariaDB Connector/J

This fixes numerous issues, I encountered it when attempting to use `PreparedStatement.RETURN_GENERATED_KEYS` which would throw a `StringIndexOutOfBoundsException` internally in the MariaDB driver. This was fixed with the 1.3.2 release of `mariadb-java-client`.