### PR TITLE
Implement the setBlockX(notifyNeighbors) series

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -1504,8 +1504,13 @@ public abstract class MixinWorld implements World, IMixinWorld {
 
     @Override
     public void setBlock(int x, int y, int z, BlockState block) {
+        setBlock(x, y, z, block, true);
+    }
+
+    @Override
+    public void setBlock(int x, int y, int z, BlockState block, boolean notifyNeighbors) {
         checkBlockBounds(x, y, z);
-        SpongeHooks.setBlockState(((net.minecraft.world.World) (Object) this), x, y, z, block);
+        SpongeHooks.setBlockState(((net.minecraft.world.World) (Object) this), x, y, z, block, notifyNeighbors);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/extent/MixinExtent.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/extent/MixinExtent.java
@@ -95,7 +95,12 @@ public abstract class MixinExtent implements Extent {
 
     @Override
     public void setBlock(Vector3i position, BlockState block) {
-        setBlock(position.getX(), position.getY(), position.getZ(), block);
+        setBlock(position, block, true);
+    }
+
+    @Override
+    public void setBlock(Vector3i position, BlockState block, boolean notifyNeighbors) {
+        setBlock(position.getX(), position.getY(), position.getZ(), block, notifyNeighbors);
     }
 
     @Override
@@ -105,12 +110,22 @@ public abstract class MixinExtent implements Extent {
 
     @Override
     public void setBlockType(Vector3i position, BlockType type) {
-        setBlockType(position.getX(), position.getY(), position.getZ(), type);
+        setBlockType(position, type, true);
+    }
+
+    @Override
+    public void setBlockType(Vector3i position, BlockType type, boolean notifyNeighbors) {
+        setBlockType(position.getX(), position.getY(), position.getZ(), type, notifyNeighbors);
     }
 
     @Override
     public void setBlockType(int x, int y, int z, BlockType type) {
-        setBlock(x, y, z, type.getDefaultState());
+        setBlockType(x, y, z, type, true);
+    }
+
+    @Override
+    public void setBlockType(int x, int y, int z, BlockType type, boolean notifyNeighbors) {
+        setBlock(x, y, z, type.getDefaultState(), notifyNeighbors);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/common/util/SpongeHooks.java
@@ -426,14 +426,13 @@ public class SpongeHooks {
         return SpongeImpl.getGlobalConfig();
     }
 
-    public static void setBlockState(World world, int x, int y, int z, BlockState state) {
-        setBlockState(world, new BlockPos(x, y, z), state);
+    public static void setBlockState(World world, int x, int y, int z, BlockState state, boolean notifyNeighbors) {
+        setBlockState(world, new BlockPos(x, y, z), state, notifyNeighbors);
     }
 
-    public static void setBlockState(World world, BlockPos position, BlockState state) {
+    public static void setBlockState(World world, BlockPos position, BlockState state, boolean notifyNeighbors) {
         if (state instanceof IBlockState) {
-            // Notify neighbours or not?
-            world.setBlockState(position, (IBlockState) state);
+            world.setBlockState(position, (IBlockState) state, notifyNeighbors ? 3 : 2);
         } else {
             // TODO: Need to figure out what is sensible for other BlockState implementing classes.
             throw new UnsupportedOperationException("Custom BlockState implementations are not supported");


### PR DESCRIPTION
Originally, only the setBlockX series of functions worked if the
parameter notifyNeighbors is omitted. This commit adds support for
the notifyNeighbors flag in these several related functions.

Future work: adding support for applications using Chunk as their
extent.