### PR TITLE
Implement stuck arrows API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SpongeAPI"]
 	path = SpongeAPI
-	url = https://github.com/SpongePowered/SpongeAPI.git
+	url = https://github.com/kashike/SpongeAPI.git

--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -830,6 +830,11 @@ public class DataRegistrar {
                 ImmutableSpongeSprintData.class, sprintDataProcessor);
         dataManager.registerValueProcessor(Keys.IS_SPRINTING, sprintDataProcessor);
 
+        final StuckArrowsDataDualProcessor stuckArrowsDataDualProcessor = new StuckArrowsDataDualProcessor();
+        dataManager.registerDataProcessorAndImpl(StuckArrowsData.class, SpongeStuckArrowsData.class, ImmutableStuckArrowsData.class,
+                ImmutableSpongeStuckArrowsData.class, stuckArrowsDataDualProcessor);
+        dataManager.registerValueProcessor(Keys.STUCK_ARROWS, stuckArrowsDataDualProcessor);
+
         // Properties
         final PropertyRegistry propertyRegistry = SpongePropertyRegistry.getInstance();
 

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -277,6 +277,7 @@ public class KeyRegistry {
         keyMap.put("persists", makeSingleKey(Boolean.class, Value.class, of("Persists")));
         keyMap.put("stored_enchantments", makeListKey(ItemEnchantment.class, of("StoredEnchantments")));
         keyMap.put("is_sprinting", makeSingleKey(Boolean.class, Value.class, of("Sprinting")));
+        keyMap.put("stuck_arrows", makeSingleKey(Integer.class, MutableBoundedValue.class, of("StuckArrows")));
     }
 
     @SuppressWarnings("unused") // Used in DataTestUtil.generateKeyMap

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeStuckArrowsData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeStuckArrowsData.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableStuckArrowsData;
+import org.spongepowered.api.data.manipulator.mutable.entity.StuckArrowsData;
+import org.spongepowered.api.data.value.immutable.ImmutableBoundedValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableIntData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeStuckArrowsData;
+
+public class ImmutableSpongeStuckArrowsData extends AbstractImmutableIntData<ImmutableStuckArrowsData, StuckArrowsData> implements ImmutableStuckArrowsData {
+
+    public ImmutableSpongeStuckArrowsData(int arrows) {
+        super(ImmutableStuckArrowsData.class, arrows, Keys.STUCK_ARROWS, SpongeStuckArrowsData.class, 0, Integer.MAX_VALUE, 0);
+    }
+
+    @Override
+    public ImmutableBoundedValue<Integer> stuckArrows() {
+        return this.getValueGetter();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeStuckArrowsData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeStuckArrowsData.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ComparisonChain;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableStuckArrowsData;
+import org.spongepowered.api.data.manipulator.mutable.entity.StuckArrowsData;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeStuckArrowsData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractIntData;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+
+public class SpongeStuckArrowsData extends AbstractIntData<StuckArrowsData, ImmutableStuckArrowsData> implements StuckArrowsData {
+
+    public SpongeStuckArrowsData() {
+        this(0);
+    }
+
+    public SpongeStuckArrowsData(int arrows) {
+        super(StuckArrowsData.class, arrows, Keys.STUCK_ARROWS);
+    }
+
+    @Override
+    protected Value<?> getValueGetter() {
+        return this.stuckArrows();
+    }
+
+    @Override
+    public MutableBoundedValue<Integer> stuckArrows() {
+        return SpongeValueFactory.boundedBuilder(Keys.STUCK_ARROWS)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(0)
+                .actualValue(this.getValue())
+                .build();
+    }
+
+    @Override
+    public StuckArrowsData setValue(Integer value) {
+        checkArgument(value >= 0, "Stuck arrows must be greater than or equal to zero");
+        return super.setValue(value);
+    }
+
+    @Override
+    public StuckArrowsData copy() {
+        return new SpongeStuckArrowsData(this.getValue());
+    }
+
+    @Override
+    public ImmutableStuckArrowsData asImmutable() {
+        return new ImmutableSpongeStuckArrowsData(this.getValue());
+    }
+
+    @Override
+    public int compareTo(StuckArrowsData o) {
+        return ComparisonChain.start()
+                .compare((int) this.getValue(), o.stuckArrows().get().intValue())
+                .result();
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return new MemoryDataContainer()
+                .set(Keys.STUCK_ARROWS, this.getValue());
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/AbstractSpongeValueProcessor.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 public abstract class AbstractSpongeValueProcessor<C, E, V extends BaseValue<E>> implements ValueProcessor<E, V> {
 
     private final Class<C> containerClass;
-    private final Key<V> key;
+    protected final Key<V> key;
 
     protected AbstractSpongeValueProcessor(Class<C> containerClass, Key<V> key) {
         this.key = checkNotNull(key, "The key is null!");

--- a/src/main/java/org/spongepowered/common/data/processor/dual/entity/StuckArrowsDataDualProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/dual/entity/StuckArrowsDataDualProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.dual.entity;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import net.minecraft.entity.EntityLivingBase;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableStuckArrowsData;
+import org.spongepowered.api.data.manipulator.mutable.entity.StuckArrowsData;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeStuckArrowsData;
+import org.spongepowered.common.data.processor.dual.common.AbstractSingleTargetDualProcessor;
+import org.spongepowered.common.data.util.ComparatorUtil;
+import org.spongepowered.common.data.value.SpongeValueFactory;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeBoundedValue;
+
+import java.util.Optional;
+
+public class StuckArrowsDataDualProcessor extends AbstractSingleTargetDualProcessor<EntityLivingBase, Integer, MutableBoundedValue<Integer>, StuckArrowsData,
+        ImmutableStuckArrowsData> {
+
+    public StuckArrowsDataDualProcessor() {
+        super(EntityLivingBase.class, Keys.STUCK_ARROWS);
+    }
+
+    @Override
+    protected MutableBoundedValue<Integer> constructValue(Integer actualValue) {
+        return SpongeValueFactory.boundedBuilder(this.key)
+                .minimum(0)
+                .maximum(Integer.MAX_VALUE)
+                .defaultValue(0)
+                .actualValue(actualValue)
+                .build();
+    }
+
+    @Override
+    protected boolean set(EntityLivingBase entity, Integer arrows) {
+        checkArgument(arrows >= 0, "Stuck arrows must be greater than or equal to zero");
+        entity.setArrowCountInEntity(arrows);
+        return true;
+    }
+
+    @Override
+    protected Optional<Integer> getVal(EntityLivingBase entity) {
+        return Optional.of(entity.getArrowCountInEntity());
+    }
+
+    @Override
+    protected ImmutableValue<Integer> constructImmutableValue(Integer value) {
+        return new ImmutableSpongeBoundedValue<>(this.key, 0, value, ComparatorUtil.intComparator(), 0, Integer.MAX_VALUE);
+    }
+
+    @Override
+    protected StuckArrowsData createManipulator() {
+        return new SpongeStuckArrowsData();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+}


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/994) | [**Common**](https://github.com/SpongePowered/SpongeCommon/pull/375)

Implementation of `StuckArrowsData`.
- [x] Registration of field getters and setters
- [x] Accurately used the appropriate `AbstractData` implementation

Implementation of `ImmutableStuckArrowsData`
- [x] Accurately extended the appropriate `AbstractImmutableData` implementation
- [x] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [x] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

Implementation of the `StuckArrowsValueProcessor`(s):
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [x] Registered the `Key` correctly by `stuck_arrows` in the `KeyRegistry`
- [x] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `DataRegistrar`
- [x] Registered the `ValueProcessor`s in the `DataRegistrar`

Test Plugin: https://gist.github.com/kashike/523321545eb37dc7edf6
