### PR TITLE
Implement SprintData

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SpongeAPI"]
 	path = SpongeAPI
-	url = https://github.com/SpongePowered/SpongeAPI.git
+	url = https://github.com/kashike/SpongeAPI.git

--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -810,6 +810,11 @@ public class DataRegistrar {
                 ImmutableSpongeTradeOfferData.class, tradeOfferDualProcessor);
         dataManager.registerValueProcessor(Keys.TRADE_OFFERS, tradeOfferDualProcessor);
 
+        final SprintDataProcessor sprintDataProcessor = new SprintDataProcessor();
+        dataManager.registerDataProcessorAndImpl(SprintData.class, SpongeSprintData.class, ImmutableSprintData.class,
+                ImmutableSpongeSprintData.class, sprintDataProcessor);
+        dataManager.registerValueProcessor(Keys.IS_SPRINTING, sprintDataProcessor);
+
         // Properties
         final PropertyRegistry propertyRegistry = SpongePropertyRegistry.getInstance();
 

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -273,6 +273,7 @@ public class KeyRegistry {
         keyMap.put("critical_hit", makeSingleKey(Boolean.class, Value.class, of("CriticalHit")));
         keyMap.put("generation", makeSingleKey(Integer.class, MutableBoundedValue.class, of("Generation")));
         keyMap.put("passenger", makeSingleKey(EntitySnapshot.class, Value.class, of("PassengerSnapshot")));
+        keyMap.put("is_sprinting", makeSingleKey(Boolean.class, Value.class, of("Sprinting")));
     }
 
     @SuppressWarnings("unused") // Used in DataTestUtil.generateKeyMap

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSprintData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeSprintData.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSprintData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SprintData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSprintData;
+
+public class ImmutableSpongeSprintData extends AbstractImmutableBooleanData<ImmutableSprintData, SprintData> implements ImmutableSprintData {
+
+    public ImmutableSpongeSprintData(boolean value) {
+        super(ImmutableSprintData.class, value, Keys.IS_SPRINTING, SpongeSprintData.class, false);
+    }
+
+    @Override
+    public ImmutableValue<Boolean> sprinting() {
+        return this.getValueGetter();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSprintData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeSprintData.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSprintData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SprintData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeSprintData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
+
+public class SpongeSprintData extends AbstractBooleanData<SprintData, ImmutableSprintData> implements SprintData {
+
+    public SpongeSprintData() {
+        this(false);
+    }
+
+    public SpongeSprintData(boolean value) {
+        super(SprintData.class, value, Keys.IS_SPRINTING, ImmutableSpongeSprintData.class, false);
+    }
+
+    @Override
+    public Value<Boolean> sprinting() {
+        return this.getValueGetter();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/dual/entity/SprintDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/dual/entity/SprintDataProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.dual.entity;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableSprintData;
+import org.spongepowered.api.data.manipulator.mutable.entity.SprintData;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeSprintData;
+import org.spongepowered.common.data.processor.dual.common.AbstractSingleTargetDualProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+import java.util.Optional;
+
+public class SprintDataProcessor extends AbstractSingleTargetDualProcessor<Entity, Boolean, Value<Boolean>, SprintData, ImmutableSprintData> {
+
+    public SprintDataProcessor() {
+        super(Entity.class, Keys.IS_SPRINTING);
+    }
+
+    @Override
+    protected Value<Boolean> constructValue(Boolean actualValue) {
+        return new SpongeValue<>(this.key, actualValue);
+    }
+
+    @Override
+    protected boolean set(Entity entity, Boolean value) {
+        entity.setSprinting(value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Boolean> getVal(Entity entity) {
+        return Optional.of(entity.isSprinting());
+    }
+
+    @Override
+    protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
+        return new ImmutableSpongeValue<>(this.key, false, value);
+    }
+
+    @Override
+    protected SprintData createManipulator() {
+        return new SpongeSprintData();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+}


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/996) | [**Common**](https://github.com/SpongePowered/SpongeCommon/pull/378)

Implementation of `SprintData`.
- [x] Registration of field getters and setters
- [x] Accurately used the appropriate `AbstractData` implementation

Implementation of `ImmutableSprintData`
- [x] Accurately extended the appropriate `AbstractImmutableData` implementation
- [x] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [x] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

Implementation of the `SprintValueProcessor`(s):
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [x] Registered the `Key` correctly by `is_sprinting` in the `KeyRegistry`
- [x] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `DataRegistrar`
- [x] Registered the `ValueProcessor`s in the `DataRegistrar`

Test Plugin: https://gist.github.com/kashike/6e8fd9b5326f894d9d6f