### PR TITLE
Implement TargetedLocationData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -500,6 +500,10 @@ public class DataRegistrar {
         dataManager.registerDataProcessorAndImpl(VehicleData.class, SpongeVehicleData.class, ImmutableVehicleData.class,
                 ImmutableSpongeVehicleData.class, vehicleDataProcessor);
 
+        final TargetedLocationDataProcessor targetedLocationDataProcessor = new TargetedLocationDataProcessor();
+        dataManager.registerDataProcessorAndImpl(TargetedLocationData.class, SpongeTargetedLocationData.class,
+                ImmutableTargetedLocationData.class, ImmutableSpongeTargetedLocationData.class, targetedLocationDataProcessor);
+
         dataManager.registerDataProcessorAndImpl(LockableData.class, SpongeLockableData.class,
                 ImmutableLockableData.class, ImmutableSpongeLockableData.class, new TileEntityLockableDataProcessor());
         dataManager.registerDataProcessorAndImpl(LockableData.class, SpongeLockableData.class,

--- a/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
@@ -1,0 +1,83 @@
+package org.spongepowered.common.data.processor.data;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.item.EntityEnderEye;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.pathfinding.PathPoint;
+import net.minecraft.util.BlockPos;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableTargetedLocationData;
+import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+import org.spongepowered.common.data.manipulator.mutable.SpongeTargetedLocationData;
+import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
+import org.spongepowered.common.interfaces.IMixinEntityPlayer;
+
+import java.util.Optional;
+
+public class TargetedLocationDataProcessor extends AbstractSpongeDataProcessor<TargetedLocationData, ImmutableTargetedLocationData> {
+
+    @Override
+    public boolean supports(DataHolder dataHolder) {
+        return dataHolder instanceof EntityEnderEye || dataHolder instanceof EntityLiving;
+    }
+
+    @Override
+    public Optional<TargetedLocationData> from(DataHolder dataHolder) {
+        if(dataHolder instanceof EntityPlayer) {
+            EntityPlayer player = (EntityPlayer) dataHolder;
+            IMixinEntityPlayer mixinPlayer = (IMixinEntityPlayer) dataHolder;
+            BlockPos pos = mixinPlayer.getCompassLocation();
+            if(pos == null) pos = player.getEntityWorld().getSpawnPoint();
+            final TargetedLocationData data = new SpongeTargetedLocationData(new Location<>((World) player.getEntityWorld(), pos.getX(), pos.getY(), pos.getZ()));
+            return Optional.of(data);
+        } else if(dataHolder instanceof EntityLiving) {
+            final EntityLiving entity = (EntityLiving) dataHolder;
+            final PathPoint path = entity.getNavigator().getPath().getFinalPathPoint();
+            if(path == null) {
+                return Optional.empty();
+            }
+            final TargetedLocationData data = new SpongeTargetedLocationData(new Location<>((World) entity.getEntityWorld(), path.xCoord, path.yCoord, path.zCoord));
+            return Optional.of(data);
+        } else if(dataHolder instanceof EntityEnderEye) {
+            // TODO
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TargetedLocationData> createFrom(DataHolder dataHolder) {
+        return null;
+    }
+
+    @Override
+    public Optional<TargetedLocationData> fill(DataHolder dataHolder, TargetedLocationData manipulator, MergeFunction overlap) {
+        return null;
+    }
+
+    @Override
+    public Optional<TargetedLocationData> fill(DataContainer container, TargetedLocationData targetedLocationData) {
+        return null;
+    }
+
+    @Override
+    public DataTransactionResult set(DataHolder dataHolder, TargetedLocationData manipulator, MergeFunction function) {
+        return null;
+    }
+
+    @Override
+    public Optional<ImmutableTargetedLocationData> with(Key<? extends BaseValue<?>> key, Object value, ImmutableTargetedLocationData immutable) {
+        return null;
+    }
+
+    @Override
+    public DataTransactionResult remove(DataHolder dataHolder) {
+        return null;
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
@@ -24,57 +24,67 @@
  */
 package org.spongepowered.common.data.processor.data;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.item.EntityEnderEye;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.pathfinding.PathEntity;
 import net.minecraft.pathfinding.PathPoint;
 import net.minecraft.util.BlockPos;
-import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionResult;
-import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableTargetedLocationData;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
-import org.spongepowered.api.data.merge.MergeFunction;
-import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.SpongeImpl;
-import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeTargetedLocationData;
-import org.spongepowered.common.data.manipulator.mutable.SpongeTargetedLocationData;
-import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
-import org.spongepowered.common.data.util.DataUtil;
+import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.interfaces.IMixinEntityPlayer;
+import org.spongepowered.common.util.VecHelper;
 
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+public class TargetedLocationDataProcessor extends AbstractEntitySingleDataProcessor<net.minecraft.entity.Entity, Location<World>, Value<Location<World>>, TargetedLocationData, ImmutableTargetedLocationData> {
 
-public class TargetedLocationDataProcessor extends AbstractSpongeDataProcessor<TargetedLocationData, ImmutableTargetedLocationData> {
-
-    @Override
-    public boolean supports(DataHolder dataHolder) {
-        return dataHolder instanceof EntityEnderEye || dataHolder instanceof EntityLiving;
+    public TargetedLocationDataProcessor() {
+        super(net.minecraft.entity.Entity.class, Keys.TARGETED_LOCATION);
     }
 
     @Override
-    public Optional<TargetedLocationData> from(DataHolder dataHolder) {
+    protected boolean set(Entity dataHolder, Location<World> value) {
+        if(dataHolder instanceof EntityPlayer) {
+            ((IMixinEntityPlayer) dataHolder).setCompassLocation(VecHelper.toBlockPos(value));
+            return true;
+        } else if(dataHolder instanceof EntityLiving) {
+            final EntityLiving entity = (EntityLiving) dataHolder;
+            entity.getNavigator().clearPathEntity();
+            entity.getNavigator().setPath(new PathEntity(new PathPoint[]{new PathPoint(value.getBlockX(), value.getBlockY(), value.getBlockZ())}), entity.getAIMoveSpeed());
+            return true;
+        } else if(dataHolder instanceof EntityEnderEye) {
+            // TODO
+        }
+        return false;
+    }
+
+    @Override
+    protected Optional<Location<World>> getVal(Entity dataHolder) {
         if(dataHolder instanceof EntityPlayer) {
             EntityPlayer player = (EntityPlayer) dataHolder;
             IMixinEntityPlayer mixinPlayer = (IMixinEntityPlayer) dataHolder;
             BlockPos pos = mixinPlayer.getCompassLocation();
             if(pos == null) pos = player.getEntityWorld().getSpawnPoint();
-            final TargetedLocationData data = new SpongeTargetedLocationData(new Location<>((World) player.getEntityWorld(), pos.getX(), pos.getY(), pos.getZ()));
-            return Optional.of(data);
+            return Optional.of(new Location<>((World) player.getEntityWorld(), pos.getX(), pos.getY(), pos.getZ()));
         } else if(dataHolder instanceof EntityLiving) {
             final EntityLiving entity = (EntityLiving) dataHolder;
             final PathPoint path = entity.getNavigator().getPath().getFinalPathPoint();
             if(path == null) {
                 return Optional.empty();
             }
-            final TargetedLocationData data = new SpongeTargetedLocationData(new Location<>((World) entity.getEntityWorld(), path.xCoord, path.yCoord, path.zCoord));
-            return Optional.of(data);
+            return Optional.of(new Location<>((World) entity.getEntityWorld(), path.xCoord, path.yCoord, path.zCoord));
         } else if(dataHolder instanceof EntityEnderEye) {
             // TODO
         }
@@ -82,50 +92,19 @@ public class TargetedLocationDataProcessor extends AbstractSpongeDataProcessor<T
     }
 
     @Override
-    public Optional<TargetedLocationData> createFrom(DataHolder dataHolder) {
-        if (dataHolder instanceof EntityPlayer) {
-            return from(dataHolder);
-        } else if (dataHolder instanceof EntityLiving) {
-            if (((EntityLiving) dataHolder).getNavigator().getPath() != null) {
-                return from(dataHolder);
-            } else {
-                return Optional.empty();
-            }
-        } else if (dataHolder instanceof EntityEnderEye) {
-            return from(dataHolder);
-        }
-        return Optional.empty();
-        // just from method?
+    protected ImmutableValue<Location<World>> constructImmutableValue(Location<World> value) {
+        return new ImmutableSpongeValue<>(Keys.TARGETED_LOCATION, value);
     }
 
     @Override
-    public Optional<TargetedLocationData> fill(DataHolder dataHolder, TargetedLocationData manipulator, MergeFunction overlap) {
-        if (supports(dataHolder)) {
-            final TargetedLocationData data = from(dataHolder).orElse(null);
-            final TargetedLocationData newData = checkNotNull(overlap.merge(checkNotNull(manipulator), data));
-            final Location location = newData.target().get();
-            return Optional.of(manipulator.set(Keys.TARGETED_LOCATION, location));
-        }
-        return Optional.empty();
+    public boolean supports(DataHolder dataHolder) {
+        return dataHolder instanceof EntityEnderEye || dataHolder instanceof EntityLiving;
     }
 
     @Override
-    public Optional<TargetedLocationData> fill(DataContainer container, TargetedLocationData targetedLocationData) {
-        final Location location = DataUtil.getData(container, Keys.TARGETED_LOCATION, Location.class);
-        return Optional.of(targetedLocationData.set(Keys.TARGETED_LOCATION, location));
-    }
-
-    @Override
-    public DataTransactionResult set(DataHolder dataHolder, TargetedLocationData manipulator, MergeFunction function) {
-        return DataTransactionResult.failResult(manipulator.getValues());
-    }
-
-    @Override
-    public Optional<ImmutableTargetedLocationData> with(Key<? extends BaseValue<?>> key, Object value, ImmutableTargetedLocationData immutable) {
-        if (key == Keys.TARGETED_LOCATION) {
-            return Optional.<ImmutableTargetedLocationData>of(new ImmutableSpongeTargetedLocationData(immutable.target().get()));
-        }
-        return Optional.empty();
+    protected TargetedLocationData createManipulator() {
+        //return new SpongeTargetedLocationData(new Location<World>()); what there?
+        return null;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.common.data.processor.data;
 
 import net.minecraft.entity.EntityLiving;
@@ -9,17 +33,23 @@ import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.ImmutableTargetedLocationData;
 import org.spongepowered.api.data.manipulator.mutable.TargetedLocationData;
 import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.data.manipulator.immutable.ImmutableSpongeTargetedLocationData;
 import org.spongepowered.common.data.manipulator.mutable.SpongeTargetedLocationData;
 import org.spongepowered.common.data.processor.common.AbstractSpongeDataProcessor;
+import org.spongepowered.common.data.util.DataUtil;
 import org.spongepowered.common.interfaces.IMixinEntityPlayer;
 
 import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TargetedLocationDataProcessor extends AbstractSpongeDataProcessor<TargetedLocationData, ImmutableTargetedLocationData> {
 
@@ -53,31 +83,69 @@ public class TargetedLocationDataProcessor extends AbstractSpongeDataProcessor<T
 
     @Override
     public Optional<TargetedLocationData> createFrom(DataHolder dataHolder) {
-        return null;
+        if (dataHolder instanceof EntityPlayer) {
+            return from(dataHolder);
+        } else if (dataHolder instanceof EntityLiving) {
+            if (((EntityLiving) dataHolder).getNavigator().getPath() != null) {
+                return from(dataHolder);
+            } else {
+                return Optional.empty();
+            }
+        } else if (dataHolder instanceof EntityEnderEye) {
+            return from(dataHolder);
+        }
+        return Optional.empty();
+        // just from method?
     }
 
     @Override
     public Optional<TargetedLocationData> fill(DataHolder dataHolder, TargetedLocationData manipulator, MergeFunction overlap) {
-        return null;
+        if (supports(dataHolder)) {
+            final TargetedLocationData data = from(dataHolder).orElse(null);
+            final TargetedLocationData newData = checkNotNull(overlap.merge(checkNotNull(manipulator), data));
+            final Location location = newData.target().get();
+            return Optional.of(manipulator.set(Keys.TARGETED_LOCATION, location));
+        }
+        return Optional.empty();
     }
 
     @Override
     public Optional<TargetedLocationData> fill(DataContainer container, TargetedLocationData targetedLocationData) {
-        return null;
+        final Location location = DataUtil.getData(container, Keys.TARGETED_LOCATION, Location.class);
+        return Optional.of(targetedLocationData.set(Keys.TARGETED_LOCATION, location));
     }
 
     @Override
     public DataTransactionResult set(DataHolder dataHolder, TargetedLocationData manipulator, MergeFunction function) {
-        return null;
+        return DataTransactionResult.failResult(manipulator.getValues());
     }
 
     @Override
     public Optional<ImmutableTargetedLocationData> with(Key<? extends BaseValue<?>> key, Object value, ImmutableTargetedLocationData immutable) {
-        return null;
+        if (key == Keys.TARGETED_LOCATION) {
+            return Optional.<ImmutableTargetedLocationData>of(new ImmutableSpongeTargetedLocationData(immutable.target().get()));
+        }
+        return Optional.empty();
     }
 
     @Override
     public DataTransactionResult remove(DataHolder dataHolder) {
-        return null;
+        if (dataHolder instanceof EntityLiving) {
+            final DataTransactionResult.Builder builder = DataTransactionResult.builder();
+            final Optional<TargetedLocationData> optional = from(dataHolder);
+            if (optional.isPresent()) {
+                try {
+                    EntityLiving living = (EntityLiving) dataHolder;
+                    living.getNavigator().clearPathEntity();
+                    return builder.replace(optional.get().getValues()).result(DataTransactionResult.Type.SUCCESS).build();
+                } catch (Exception e) {
+                    SpongeImpl.getLogger().error("There was an issue resetting the target location on an entity!", e);
+                    return builder.result(DataTransactionResult.Type.ERROR).build();
+                }
+            } else {
+                return builder.result(DataTransactionResult.Type.SUCCESS).build();
+            }
+        }
+        return DataTransactionResult.failNoData();
     }
 }

--- a/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/TargetedLocationDataProcessor.java
@@ -24,6 +24,7 @@
  */
 package org.spongepowered.common.data.processor.data;
 
+import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.item.EntityEnderEye;
@@ -44,6 +45,7 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.interfaces.IMixinEntityPlayer;
+import org.spongepowered.common.interfaces.entity.IMixinEntityEnderEye;
 import org.spongepowered.common.util.VecHelper;
 
 import java.util.Optional;
@@ -65,7 +67,8 @@ public class TargetedLocationDataProcessor extends AbstractEntitySingleDataProce
             entity.getNavigator().setPath(new PathEntity(new PathPoint[]{new PathPoint(value.getBlockX(), value.getBlockY(), value.getBlockZ())}), entity.getAIMoveSpeed());
             return true;
         } else if(dataHolder instanceof EntityEnderEye) {
-            // TODO
+            ((IMixinEntityEnderEye) dataHolder).setTargetLoc(value.getX(), value.getY(), value.getZ());
+            return true;
         }
         return false;
     }
@@ -86,7 +89,8 @@ public class TargetedLocationDataProcessor extends AbstractEntitySingleDataProce
             }
             return Optional.of(new Location<>((World) entity.getEntityWorld(), path.xCoord, path.yCoord, path.zCoord));
         } else if(dataHolder instanceof EntityEnderEye) {
-            // TODO
+            Vector3d vec = ((IMixinEntityEnderEye) dataHolder).getTargetLoc();
+            return Optional.of(new Location<>((World) dataHolder.getEntityWorld(), vec.getX(), vec.getY(), vec.getZ()));
         }
         return Optional.empty();
     }

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinEntityPlayer.java
@@ -34,4 +34,9 @@ public interface IMixinEntityPlayer {
     boolean affectsSpawning();
 
     void setAffectsSpawning(boolean affectsSpawning);
+
+    BlockPos getCompassLocation();
+
+    void setCompassLocation(BlockPos blockPos);
+
 }

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntityEnderEye.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntityEnderEye.java
@@ -1,0 +1,11 @@
+package org.spongepowered.common.interfaces.entity;
+
+import com.flowpowered.math.vector.Vector3d;
+
+public interface IMixinEntityEnderEye {
+
+    Vector3d getTargetLoc();
+
+    void setTargetLoc(double x, double y, double z);
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderEye.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderEye.java
@@ -24,16 +24,23 @@
  */
 package org.spongepowered.common.mixin.core.entity.item;
 
+import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.entity.item.EntityEnderEye;
 import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.api.entity.projectile.EyeOfEnder;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.common.entity.projectile.ProjectileSourceSerializer;
+import org.spongepowered.common.interfaces.entity.IMixinEntityEnderEye;
 import org.spongepowered.common.mixin.core.entity.MixinEntity;
 
 @Mixin(EntityEnderEye.class)
-public abstract class MixinEntityEnderEye extends MixinEntity implements EyeOfEnder {
+public abstract class MixinEntityEnderEye extends MixinEntity implements EyeOfEnder, IMixinEntityEnderEye {
+
+    @Shadow private double targetX;
+    @Shadow private double targetY;
+    @Shadow private double targetZ;
 
     private ProjectileSource projectileSource = ProjectileSource.UNKNOWN;
 
@@ -59,4 +66,15 @@ public abstract class MixinEntityEnderEye extends MixinEntity implements EyeOfEn
         ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, null);
     }
 
+    @Override
+    public Vector3d getTargetLoc() {
+        return new Vector3d(targetX, targetY, targetZ);
+    }
+
+    @Override
+    public void setTargetLoc(double x, double y, double z) {
+        this.targetX = x;
+        this.targetY = y;
+        this.targetZ = z;
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
@@ -26,8 +26,10 @@ package org.spongepowered.common.mixin.core.entity.player;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.PlayerCapabilities;
 import net.minecraft.inventory.Container;
+import net.minecraft.network.play.server.S05PacketSpawnPosition;
 import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.FoodStats;
@@ -64,6 +66,7 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
     @Shadow private BlockPos playerLocation;
     @Shadow protected FoodStats foodStats;
     private boolean affectsSpawning = true;
+    private BlockPos compassLocation;
 
     // utility method for getting the total experience at an arbitrary level
     // the formulas here are basically (slightly modified) integrals of those of EntityPlayer#xpBarCap()
@@ -134,5 +137,25 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
     @Override
     public void setAffectsSpawning(boolean affectsSpawning) {
         this.affectsSpawning = affectsSpawning;
+    }
+
+    @Override
+    public BlockPos getCompassLocation() {
+        return compassLocation;
+    }
+
+    @Override
+    public void setCompassLocation(BlockPos compassLocation) {
+
+        if(compassLocation == null) {
+            compassLocation = worldObj.getSpawnPoint();
+        }
+
+        if(((Object) this) instanceof EntityPlayerMP) {
+            ((EntityPlayerMP) (Object) this).playerNetServerHandler.sendPacket(new S05PacketSpawnPosition(compassLocation));
+        } else if(!worldObj.isRemote) {
+            worldObj.setSpawnPoint(compassLocation);
+        }
+        this.compassLocation = compassLocation;
     }
 }


### PR DESCRIPTION
@gabizou 
```
An {@link DataManipulator} handling the supposed targetted
{@link Location}. Usually for the case of {@link EnderPearl}s, the
targeted {@link Location} is where the {@link EnderPearl} will
move towards until it's expiration time. In the case of
{@link ItemStack}s of type {@link ItemTypes#COMPASS}, the targeted
{@link Location} is where the compass will point towards.
```
1. EntityLiving with target location.
2. EnderPearl mean EntityEnderEye?
3. Player with compass target.