### PR TITLE
Implement BreedableData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -317,6 +317,9 @@ public class DataRegistrar {
         dataManager.registerDualProcessor(StuckArrowsData.class, SpongeStuckArrowsData.class, ImmutableStuckArrowsData.class,
                 ImmutableSpongeStuckArrowsData.class, new StuckArrowsDataProcessor());
 
+        dataManager.registerDualProcessor(BreedableData.class, SpongeBreedableData.class, ImmutableBreedableData.class,
+                ImmutableSpongeBreedableData.class, new BreedableDataProcessor());
+
         // Item Processors
 
         dataManager.registerDualProcessor(FireworkEffectData.class, SpongeFireworkEffectData.class,

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -280,6 +280,7 @@ public class KeyRegistry {
         keyMap.put("invisibility_ignores_collision", makeSingleKey(Boolean.class, Value.class, of("InvisiblityIgnoresCollision")));
         keyMap.put("invisibility_prevents_targeting", makeSingleKey(Boolean.class, Value.class, of("InvisibilityPreventsTargeting")));
         keyMap.put("is_aflame", makeSingleKey(Boolean.class, Value.class, of("IsAflame")));
+        keyMap.put("can_breed", makeSingleKey(Boolean.class, Value.class, of("CanBreed")));
     }
 
     @SuppressWarnings("unused") // Used in DataTestUtil.generateKeyMap

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeBreedableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeBreedableData.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableBreedableData;
+import org.spongepowered.api.data.manipulator.mutable.entity.BreedableData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeBreedableData;
+
+public class ImmutableSpongeBreedableData extends AbstractImmutableBooleanData<ImmutableBreedableData, BreedableData> implements ImmutableBreedableData {
+
+    public ImmutableSpongeBreedableData(boolean value) {
+        super(ImmutableBreedableData.class, value, Keys.CAN_BREED, SpongeBreedableData.class, false);
+    }
+
+    @Override
+    public ImmutableValue<Boolean> breedable() {
+        return getValueGetter();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeBreedableData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeBreedableData.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableBreedableData;
+import org.spongepowered.api.data.manipulator.mutable.entity.BreedableData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeBreedableData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
+
+public class SpongeBreedableData extends AbstractBooleanData<BreedableData, ImmutableBreedableData> implements BreedableData {
+
+    public SpongeBreedableData() {
+        this(false);
+    }
+
+    public SpongeBreedableData(Boolean value) {
+        super(BreedableData.class, value, Keys.CAN_BREED, ImmutableSpongeBreedableData.class, false);
+    }
+
+    @Override
+    public Value<Boolean> breedable() {
+        return getValueGetter();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/BreedableDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/BreedableDataProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.entity;
+
+import net.minecraft.entity.EntityAgeable;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableBreedableData;
+import org.spongepowered.api.data.manipulator.mutable.entity.BreedableData;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeBreedableData;
+import org.spongepowered.common.data.processor.common.AbstractSingleDataSingleTargetProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+import java.util.Optional;
+
+public class BreedableDataProcessor extends AbstractSingleDataSingleTargetProcessor<EntityAgeable, Boolean, Value<Boolean>, BreedableData, ImmutableBreedableData> {
+
+    public BreedableDataProcessor() {
+        super(Keys.CAN_BREED, EntityAgeable.class);
+    }
+
+    @Override
+    protected boolean set(EntityAgeable entity, Boolean value) {
+        if (entity.getGrowingAge() < 0) {
+            return false;
+        }
+        else if (value) {
+            entity.setGrowingAge(0);
+        } else {
+            entity.setGrowingAge(6000);
+        }
+        return true;
+    }
+
+    @Override
+    protected Optional<Boolean> getVal(EntityAgeable entity) {
+        return Optional.of(entity.getGrowingAge() == 0);
+    }
+
+    @Override
+    protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
+        return ImmutableSpongeValue.cachedOf(this.key, false, value);
+    }
+
+    @Override
+    protected BreedableData createManipulator() {
+        return new SpongeBreedableData();
+    }
+
+    @Override
+    protected Value<Boolean> constructValue(Boolean actualValue) {
+        return new SpongeValue<>(this.key, false, actualValue);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+
+}


### PR DESCRIPTION
Implementation of `SpongeBreedableData`.
- [x] Registration of field getters and setters
- [x] Accurately used the appropriate `AbstractData` implementation

Implementation of `ImmutableSpongeBreedableData`
- [x] Accurately extended the appropriate `AbstractImmutableData` implementation
- [x] Accurately instantiating final instance fields with an `ImmutableValue` counter part for any value getters
- [x] If necessary, creating a new `ImmutableValue` for a value that should not be cached, or, using the existing caching utils.

Implementation of the `BreedableDataDualProcessor`(s):
- [x] Appropriately extended `AbstractSpongeValueProcessor`
- [x] Individual processors for each source type possible (one for `ItemStack`/`TileEntity`/`Entity` as necessary).

Registration:
- [x] Registered the `Key` correctly by `CAN_BREED` in the `KeyRegistry`
- [x] Registered the `DataProcessor`s and `DataManipulatorBuilder` in `SpongeSerializationRegistry`
- [x] Registered the `ValueProcessor`s in the `SpongeSerializationRegistry`

Test Plugin code:

```java
@Plugin(id="breedable", name="breedable", version="1.0")
public class Breedable {

    @Inject
    Logger logger;

    @Listener
    public void onPunch(DamageEntityEvent event){
        if(!(event.getTargetEntity() instanceof Animal)) return;
        Animal entity = (Animal) event.getTargetEntity();
        Optional<BreedableData> canBreed = entity.get(BreedableData.class);
        if(canBreed.isPresent()){
            logger.info("CanBreed = " + canBreed.get().breedable());
        }
    }

}
```

Notes:
Your test plugin should test using all possible value related methods with your `DataManipulator`s and also test the serialization and deserialization of your `DataManipulator`s.
