### PR TITLE
Implement ClientConnectionEvent.Prepare

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SpongeAPI"]
 	path = SpongeAPI
-	url = https://github.com/SpongePowered/SpongeAPI.git
+	url = https://github.com/kashike/SpongeAPI.git


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1020) | [**Common**](https://github.com/SpongePowered/SpongeCommon/pull/408)

This implements the `ClientConnectionEvent.Prepare` event, which fires _after_ the `ClientConnectionEvent.Login` event but _before_ the `ClientConnectionEvent.Join`.

This change is required for https://github.com/SpongePowered/SpongeAPI/pull/945 (https://github.com/SpongePowered/SpongeCommon/pull/304) to work properly.