### PR TITLE
Implementation of Fluid API

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -47,6 +47,8 @@ import org.spongepowered.api.data.property.block.*;
 import org.spongepowered.api.data.property.entity.*;
 import org.spongepowered.api.data.property.item.*;
 import org.spongepowered.api.entity.EntitySnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidItemData;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidItemData;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -70,16 +72,19 @@ import org.spongepowered.common.data.key.KeyRegistry;
 import org.spongepowered.common.data.manipulator.immutable.*;
 import org.spongepowered.common.data.manipulator.immutable.block.*;
 import org.spongepowered.common.data.manipulator.immutable.entity.*;
+import org.spongepowered.common.data.manipulator.immutable.extra.ImmutableSpongeFluidItemData;
 import org.spongepowered.common.data.manipulator.immutable.item.*;
 import org.spongepowered.common.data.manipulator.immutable.tileentity.*;
 import org.spongepowered.common.data.manipulator.mutable.*;
 import org.spongepowered.common.data.manipulator.mutable.block.*;
 import org.spongepowered.common.data.manipulator.mutable.entity.*;
+import org.spongepowered.common.data.manipulator.mutable.extra.SpongeFluidItemData;
 import org.spongepowered.common.data.manipulator.mutable.item.*;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.*;
 import org.spongepowered.common.data.processor.data.*;
 import org.spongepowered.common.data.processor.data.block.*;
 import org.spongepowered.common.data.processor.data.entity.*;
+import org.spongepowered.common.data.processor.data.extra.FluidItemDataProcessor;
 import org.spongepowered.common.data.processor.data.item.*;
 import org.spongepowered.common.data.processor.data.tileentity.*;
 import org.spongepowered.common.data.processor.multi.block.*;
@@ -393,6 +398,9 @@ public class DataRegistrar {
 
         dataManager.registerDualProcessor(StoredEnchantmentData.class, SpongeStoredEnchantmentData.class,
                 ImmutableStoredEnchantmentData.class, ImmutableSpongeStoredEnchantmentData.class, new StoredEnchantmentDataProcessor());
+
+        dataManager.registerDualProcessor(FluidItemData.class, SpongeFluidItemData.class, ImmutableFluidItemData.class,
+                ImmutableSpongeFluidItemData.class, new FluidItemDataProcessor());
 
         // Block Processors
 

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -87,6 +87,7 @@ import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.merchant.TradeOffer;
@@ -98,6 +99,7 @@ import org.spongepowered.api.util.rotation.Rotation;
 import org.spongepowered.common.registry.RegistryHelper;
 
 import java.awt.Color;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -281,6 +283,8 @@ public class KeyRegistry {
         keyMap.put("invisibility_prevents_targeting", makeSingleKey(Boolean.class, Value.class, of("InvisibilityPreventsTargeting")));
         keyMap.put("is_aflame", makeSingleKey(Boolean.class, Value.class, of("IsAflame")));
         keyMap.put("can_breed", makeSingleKey(Boolean.class, Value.class, of("CanBreed")));
+        keyMap.put("fluid_item_stack", makeSingleKey(FluidStackSnapshot.class, Value.class, of("FluidItemContainerSnapshot")));
+        keyMap.put("fluid_tank_contents", makeMapKey(Direction.class, List.class, of("FluidTankContents")));
     }
 
     @SuppressWarnings("unused") // Used in DataTestUtil.generateKeyMap

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/extra/ImmutableSpongeFluidItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/extra/ImmutableSpongeFluidItemData.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.extra;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidItemData;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidItemData;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.common.data.manipulator.mutable.extra.SpongeFluidItemData;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.extra.fluid.SpongeFluidStackSnapshot;
+
+public class ImmutableSpongeFluidItemData extends AbstractImmutableSingleData<FluidStackSnapshot, ImmutableFluidItemData, FluidItemData> implements ImmutableFluidItemData {
+
+    public ImmutableSpongeFluidItemData(FluidStackSnapshot value) {
+        super(ImmutableFluidItemData.class, value, Keys.FLUID_ITEM_STACK);
+    }
+
+    @Override
+    protected ImmutableValue<FluidStackSnapshot> getValueGetter() {
+        return new ImmutableSpongeValue<>(Keys.FLUID_ITEM_STACK, SpongeFluidStackSnapshot.DEFAULT, this.value);
+    }
+
+    @Override
+    public FluidItemData asMutable() {
+        return new SpongeFluidItemData(this.value);
+    }
+
+    @Override
+    public int compareTo(ImmutableFluidItemData o) {
+        return 0;
+    }
+
+    @Override
+    public ImmutableValue<FluidStackSnapshot> fluid() {
+        return getValueGetter();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/extra/ImmutableSpongeFluidTankData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/extra/ImmutableSpongeFluidTankData.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.extra;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.immutable.ImmutableMapValue;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidTankData;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidTankData;
+import org.spongepowered.api.util.Direction;
+import org.spongepowered.common.data.manipulator.immutable.common.collection.AbstractImmutableSingleMapData;
+import org.spongepowered.common.data.manipulator.mutable.extra.SpongeFluidTankData;
+
+import java.util.List;
+import java.util.Map;
+
+public class ImmutableSpongeFluidTankData extends AbstractImmutableSingleMapData<Direction, List<FluidStackSnapshot>, ImmutableFluidTankData, FluidTankData>
+        implements ImmutableFluidTankData {
+
+    public ImmutableSpongeFluidTankData() {
+        this(ImmutableMap.of());
+    }
+
+    public ImmutableSpongeFluidTankData(Map<Direction, List<FluidStackSnapshot>> value) {
+        super(ImmutableFluidTankData.class, value, Keys.FLUID_TANK_CONTENTS, SpongeFluidTankData.class);
+    }
+
+    @Override
+    public ImmutableMapValue<Direction, List<FluidStackSnapshot>> fluids() {
+        return getValueGetter();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/extra/package-info.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/extra/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.data.manipulator.immutable.extra;

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/collection/AbstractSingleMapData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/common/collection/AbstractSingleMapData.java
@@ -31,6 +31,7 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.mutable.MapValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
 import org.spongepowered.common.data.value.mutable.SpongeMapValue;
@@ -64,7 +65,7 @@ public abstract class AbstractSingleMapData<K, V, M extends DataManipulator<M, I
     }
 
     @Override
-    protected Value<?> getValueGetter() {
+    protected MapValue<K, V> getValueGetter() {
         return new SpongeMapValue<>(this.usedKey, getValue());
     }
 

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/extra/SpongeFluidItemData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/extra/SpongeFluidItemData.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.extra;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidItemData;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidItemData;
+import org.spongepowered.common.data.manipulator.immutable.extra.ImmutableSpongeFluidItemData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.common.data.util.ImplementationRequiredForTest;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.extra.fluid.SpongeFluidStackSnapshot;
+
+public class SpongeFluidItemData extends AbstractSingleData<FluidStackSnapshot, FluidItemData, ImmutableFluidItemData> implements FluidItemData {
+
+    public SpongeFluidItemData() {
+        this(SpongeFluidStackSnapshot.DEFAULT);
+    }
+
+    public SpongeFluidItemData(FluidStackSnapshot value) {
+        super(FluidItemData.class, value, Keys.FLUID_ITEM_STACK);
+    }
+
+    @Override
+    protected Value<FluidStackSnapshot> getValueGetter() {
+        return new SpongeValue<>(Keys.FLUID_ITEM_STACK, SpongeFluidStackSnapshot.DEFAULT, this.getValue());
+    }
+
+    @Override
+    public FluidItemData copy() {
+        return new SpongeFluidItemData(this.getValue());
+    }
+
+    @Override
+    public ImmutableFluidItemData asImmutable() {
+        return new ImmutableSpongeFluidItemData(this.getValue());
+    }
+
+    @Override
+    public int compareTo(FluidItemData o) {
+        return 0;
+    }
+
+    @Override
+    public Value<FluidStackSnapshot> fluid() {
+        return getValueGetter();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/extra/SpongeFluidTankData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/extra/SpongeFluidTankData.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.extra;
+
+import com.google.common.collect.ImmutableMap;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.mutable.MapValue;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidTankData;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidTankData;
+import org.spongepowered.api.util.Direction;
+import org.spongepowered.common.data.manipulator.immutable.extra.ImmutableSpongeFluidTankData;
+import org.spongepowered.common.data.manipulator.mutable.common.collection.AbstractSingleMapData;
+
+import java.util.List;
+import java.util.Map;
+
+public class SpongeFluidTankData extends AbstractSingleMapData<Direction, List<FluidStackSnapshot>, FluidTankData, ImmutableFluidTankData> implements FluidTankData {
+
+    public SpongeFluidTankData() {
+        this(ImmutableMap.of());
+    }
+
+    public SpongeFluidTankData(Map<Direction, List<FluidStackSnapshot>> value) {
+        super(FluidTankData.class, value, Keys.FLUID_TANK_CONTENTS, ImmutableSpongeFluidTankData.class);
+    }
+
+    @Override
+    public int compareTo(FluidTankData o) {
+        return 0;
+    }
+
+    @Override
+    public MapValue<Direction, List<FluidStackSnapshot>> fluids() {
+        return getValueGetter();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/extra/package-info.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/extra/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.data.manipulator.mutable.extra;

--- a/src/main/java/org/spongepowered/common/data/processor/data/extra/FluidItemDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/extra/FluidItemDataProcessor.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.extra;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.FluidType;
+import org.spongepowered.api.extra.fluid.FluidTypes;
+import org.spongepowered.api.extra.fluid.data.manipulator.immutable.ImmutableFluidItemData;
+import org.spongepowered.api.extra.fluid.data.manipulator.mutable.FluidItemData;
+import org.spongepowered.common.data.manipulator.mutable.extra.SpongeFluidItemData;
+import org.spongepowered.common.data.processor.common.AbstractItemSingleDataProcessor;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+import org.spongepowered.common.extra.fluid.SpongeFluidStackBuilder;
+import org.spongepowered.common.extra.fluid.SpongeFluidStackSnapshot;
+
+import java.util.Optional;
+
+public class FluidItemDataProcessor extends AbstractItemSingleDataProcessor<FluidStackSnapshot, Value<FluidStackSnapshot>, FluidItemData,
+        ImmutableFluidItemData> {
+
+    private static final FluidStackSnapshot WATER = new SpongeFluidStackBuilder().fluid(FluidTypes.WATER).volume(1000).build().createSnapshot();
+    private static final FluidStackSnapshot LAVA = new SpongeFluidStackBuilder().fluid(FluidTypes.LAVA).volume(1000).build().createSnapshot();
+
+    public FluidItemDataProcessor() {
+        super((item) -> item.getItem() == Items.bucket || item.getItem() == Items.water_bucket || item.getItem() == Items.lava_bucket, Keys.FLUID_ITEM_STACK);
+    }
+
+    @Override
+    protected boolean set(ItemStack dataHolder, FluidStackSnapshot value) {
+        FluidType fluidType = value.getFluid();
+        if (fluidType == FluidTypes.WATER) {
+            dataHolder.setItem(Items.water_bucket);
+            return true;
+        } else if (fluidType == FluidTypes.LAVA) {
+            dataHolder.setItem(Items.lava_bucket);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    protected Optional<FluidStackSnapshot> getVal(ItemStack dataHolder) {
+        if (dataHolder.getItem() == Items.water_bucket) {
+            return Optional.of(WATER);
+        } else if (dataHolder.getItem() == Items.lava_bucket) {
+            return Optional.of(LAVA);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected ImmutableValue<FluidStackSnapshot> constructImmutableValue(FluidStackSnapshot value) {
+        return new ImmutableSpongeValue<>(Keys.FLUID_ITEM_STACK, SpongeFluidStackSnapshot.DEFAULT, value);
+    }
+
+    @Override
+    protected Value<FluidStackSnapshot> constructValue(FluidStackSnapshot actualValue) {
+        return new SpongeValue<>(Keys.FLUID_ITEM_STACK, SpongeFluidStackSnapshot.DEFAULT, actualValue);
+    }
+
+    @Override
+    protected FluidItemData createManipulator() {
+        return new SpongeFluidItemData();
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        if (container instanceof ItemStack) {
+            final ItemStack itemStack = (ItemStack) container;
+            if (itemStack.getItem() == Items.water_bucket) {
+                itemStack.setItem(Items.bucket);
+                return DataTransactionResult.successRemove(constructImmutableValue(WATER));
+            } else if (itemStack.getItem() == Items.lava_bucket) {
+                itemStack.setItem(Items.bucket);
+                return DataTransactionResult.successRemove(constructImmutableValue(LAVA));
+            }
+        }
+        return DataTransactionResult.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/data/extra/package-info.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/extra/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.data.processor.data.extra;

--- a/src/main/java/org/spongepowered/common/data/type/SpongeCommonFluidType.java
+++ b/src/main/java/org/spongepowered/common/data/type/SpongeCommonFluidType.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.type;
+
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.property.PropertyStore;
+import org.spongepowered.api.extra.fluid.FluidType;
+import org.spongepowered.common.SpongeCatalogType;
+import org.spongepowered.common.data.property.SpongePropertyRegistry;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public final class SpongeCommonFluidType extends SpongeCatalogType implements FluidType {
+
+    @Nullable private final BlockType base;
+
+    public SpongeCommonFluidType(String id) {
+        this(id, null);
+    }
+
+    public SpongeCommonFluidType(String id, BlockType base) {
+        super(id);
+        this.base = base;
+    }
+
+    @Override
+    public Optional<BlockType> getBlockTypeBase() {
+        return Optional.ofNullable(this.base);
+    }
+
+    @Override
+    public <T extends Property<?, ?>> Optional<T> getProperty(Class<T> propertyClass) {
+        final Optional<PropertyStore<T>> optional = SpongePropertyRegistry.getInstance().getStore(propertyClass);
+        if (optional.isPresent()) {
+            return optional.get().getFor(this);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<Property<?, ?>> getApplicableProperties() {
+        return SpongePropertyRegistry.getInstance().getPropertiesFor(this);
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/util/DataQueries.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataQueries.java
@@ -146,5 +146,9 @@ public final class DataQueries {
     public static final DataQuery FIREWORK_TRAILS = of("Trails");
     public static final DataQuery FIREWORK_FLICKERS = of("Flickers");
 
+    // Fluids
+    public static final DataQuery FLUID_TYPE = of("FluidType");
+    public static final DataQuery FLUID_VOLUME = of("FluidVolume");
+
     private DataQueries() { }
 }

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
@@ -1,0 +1,222 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.extra.fluid;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.Queries;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.FluidType;
+import org.spongepowered.api.util.persistence.InvalidDataException;
+import org.spongepowered.common.data.util.DataQueries;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+public class SpongeFluidStack implements FluidStack {
+
+    private FluidType fluidType;
+    private int volume;
+    @Nullable private DataContainer extraData;
+
+    SpongeFluidStack(SpongeFluidStackBuilder builder) {
+        this.fluidType = builder.fluidType;
+        this.volume = builder.volume;
+        this.extraData = builder.extra == null ? null : builder.extra.copy();
+    }
+
+    @Override
+    public FluidType getFluid() {
+        return this.fluidType;
+    }
+
+    @Override
+    public int getVolume() {
+        return this.volume;
+    }
+
+    @Override
+    public FluidStack setVolume(int volume) {
+        checkArgument(volume > 0, "Volume must be at least 0!");
+        this.volume = volume;
+        return this;
+    }
+
+    @Override
+    public FluidStackSnapshot createSnapshot() {
+        return new SpongeFluidStackSnapshotBuilder().from(this).build();
+    }
+
+    @Override
+    public boolean validateRawData(DataContainer container) {
+        return container.contains(Queries.CONTENT_VERSION, DataQueries.FLUID_TYPE, DataQueries.FLUID_VOLUME);
+    }
+
+    @Override
+    public void setRawData(DataContainer container) throws InvalidDataException {
+        try {
+            final int contentVersion = container.getInt(Queries.CONTENT_VERSION).get();
+            if (contentVersion != this.getContentVersion()) {
+                throw new InvalidDataException("Older content found! Cannot set raw data of older content!");
+            }
+            final String fluidId = container.getString(DataQueries.FLUID_TYPE).get();
+            final int volume = container.getInt(DataQueries.FLUID_VOLUME).get();
+            final Optional<FluidType> fluidType = Sponge.getRegistry().getType(FluidType.class, fluidId);
+            if (!fluidType.isPresent()) {
+                throw new InvalidDataException("Unknown FluidType found! Requested: " + fluidId + "but got none.");
+            }
+            this.fluidType = fluidType.get();
+            this.volume = volume;
+            if (container.contains(DataQueries.UNSAFE_NBT)) {
+                this.extraData = container.getView(DataQueries.UNSAFE_NBT).get().copy();
+            }
+        } catch (Exception e) {
+            throw new InvalidDataException("DataContainer contained invalid data!", e);
+        }
+    }
+
+    @Override
+    public <T extends DataManipulator<?, ?>> Optional<T> get(Class<T> containerClass) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T extends DataManipulator<?, ?>> Optional<T> getOrCreate(Class<T> containerClass) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean supports(Class<? extends DataManipulator<?, ?>> holderClass) {
+        return false;
+    }
+
+    @Override
+    public <E> DataTransactionResult offer(Key<? extends BaseValue<E>> key, E value) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult offer(DataManipulator<?, ?> valueContainer, MergeFunction function) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult remove(Class<? extends DataManipulator<?, ?>> containerClass) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult remove(Key<?> key) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult undo(DataTransactionResult result) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult copyFrom(DataHolder that, MergeFunction function) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public Collection<DataManipulator<?, ?>> getContainers() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int getContentVersion() {
+        return 1;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = new MemoryDataContainer()
+            .set(Queries.CONTENT_VERSION, this.getContentVersion())
+            .set(DataQueries.FLUID_TYPE, this.fluidType.getId())
+            .set(DataQueries.FLUID_VOLUME, this.volume);
+        if (this.extraData != null) {
+            container.set(DataQueries.UNSAFE_NBT, this.extraData);
+        }
+        return container;
+    }
+
+    @Override
+    public <T extends Property<?, ?>> Optional<T> getProperty(Class<T> propertyClass) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<Property<?, ?>> getApplicableProperties() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <E> Optional<E> get(Key<? extends BaseValue<E>> key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean supports(Key<?> key) {
+        return false;
+    }
+
+    @Override
+    public DataHolder copy() {
+        return FluidStack.builder().from(this).build();
+    }
+
+    @Override
+    public Set<Key<?>> getKeys() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ImmutableValue<?>> getValues() {
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackBuilder.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.extra.fluid;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.Queries;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.FluidType;
+import org.spongepowered.api.util.persistence.InvalidDataException;
+import org.spongepowered.common.data.builder.AbstractDataBuilder;
+import org.spongepowered.common.data.util.DataQueries;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public class SpongeFluidStackBuilder extends AbstractDataBuilder<FluidStack> implements FluidStack.Builder {
+
+    FluidType fluidType;
+    int volume = 1;
+    @Nullable DataContainer extra; // we have to retain this information
+
+    public SpongeFluidStackBuilder() {
+        super(FluidStack.class, 1);
+    }
+
+    @Override
+    public FluidStack.Builder fluid(FluidType fluidType) {
+        this.fluidType = checkNotNull(fluidType, "FluidType cannot be null!");
+        return this;
+    }
+
+    @Override
+    public FluidStack.Builder volume(int volume) {
+        checkArgument(volume > 0, "A FluidStack's volume has to be greater than zero!");
+        this.volume = volume;
+        return this;
+    }
+
+    @Override
+    public FluidStack.Builder from(FluidStackSnapshot fluidStackSnapshot) {
+        checkArgument(fluidStackSnapshot instanceof SpongeFluidStackSnapshot, "Invalid implementation found of FluidStackSnapshot!");
+        this.fluidType = fluidStackSnapshot.getFluid();
+        this.volume = fluidStackSnapshot.getVolume();
+        final DataContainer container = fluidStackSnapshot.toContainer();
+        if (container.contains(DataQueries.UNSAFE_NBT)) {
+            this.extra = container.getView(DataQueries.UNSAFE_NBT).get().copy();
+        }
+        return this;
+    }
+
+    @Override
+    public FluidStack build() {
+        checkNotNull(this.fluidType, "Fluidtype cannot be null!");
+        checkState(this.volume >= 0, "Volume must be at least zero!");
+        return new SpongeFluidStack(this);
+    }
+
+    @Override
+    public FluidStack.Builder from(FluidStack value) {
+        this.fluidType = value.getFluid();
+        this.volume = value.getVolume();
+        final DataContainer container = value.toContainer();
+        if (container.contains(DataQueries.UNSAFE_NBT)) {
+            this.extra = container.getView(DataQueries.UNSAFE_NBT).get().copy();
+        }
+        return this;
+    }
+
+    @Override
+    protected Optional<FluidStack> buildContent(DataView container) throws InvalidDataException {
+        if (!container.contains(DataQueries.FLUID_TYPE, DataQueries.FLUID_VOLUME)) {
+            return Optional.empty();
+        }
+        reset();
+        final String fluidId = container.getString(DataQueries.FLUID_TYPE).get();
+        final Optional<FluidType> fluidType = Sponge.getRegistry().getType(FluidType.class, fluidId);
+        if (!fluidType.isPresent()) {
+            throw new InvalidDataException("Invalid fluid id found: " + fluidId);
+        }
+        this.fluidType = fluidType.get();
+        this.volume = container.getInt(DataQueries.FLUID_VOLUME).get();
+        if (container.contains(DataQueries.UNSAFE_NBT)) {
+            this.extra = container.getView(DataQueries.UNSAFE_NBT).get().copy();
+        } else {
+            this.extra = null;
+        }
+        return Optional.of(build());
+    }
+
+    @Override
+    public FluidStack.Builder reset() {
+        this.fluidType = null;
+        this.volume = 0;
+        this.extra = null;
+        return this;
+    }
+}

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackSnapshot.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackSnapshot.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.extra.fluid;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.MemoryDataContainer;
+import org.spongepowered.api.data.Property;
+import org.spongepowered.api.data.Queries;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.FluidType;
+import org.spongepowered.api.extra.fluid.FluidTypes;
+import org.spongepowered.common.data.util.DataQueries;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+public class SpongeFluidStackSnapshot implements FluidStackSnapshot {
+
+    public static final FluidStackSnapshot DEFAULT = new SpongeFluidStackSnapshotBuilder()
+        .fluid(FluidTypes.WATER).volume(1000).build();
+
+    private final FluidType fluidType;
+    private final int volume;
+    @Nullable private final DataContainer extraData;
+
+    SpongeFluidStackSnapshot(SpongeFluidStackSnapshotBuilder builder) {
+        this.fluidType = builder.fluidType;
+        this.volume = builder.volume;
+        this.extraData = builder.container == null ? null : builder.container.copy();
+    }
+
+    @Override
+    public FluidType getFluid() {
+        return this.fluidType;
+    }
+
+    @Override
+    public int getVolume() {
+        return this.volume;
+    }
+
+    @Override
+    public FluidStack createStack() {
+        return new SpongeFluidStackBuilder().from(this).build();
+    }
+
+    @Override
+    public List<ImmutableDataManipulator<?, ?>> getManipulators() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int getContentVersion() {
+        return 1;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        DataContainer container = new MemoryDataContainer()
+            .set(Queries.CONTENT_VERSION, this.getContentVersion())
+            .set(DataQueries.FLUID_TYPE, this.fluidType.getId())
+            .set(DataQueries.FLUID_VOLUME, this.volume);
+        if (this.extraData != null) {
+            container.set(DataQueries.UNSAFE_NBT, this.extraData);
+        }
+        return container;
+    }
+
+    @Override
+    public <T extends ImmutableDataManipulator<?, ?>> Optional<T> get(Class<T> containerClass) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T extends ImmutableDataManipulator<?, ?>> Optional<T> getOrCreate(Class<T> containerClass) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean supports(Class<? extends ImmutableDataManipulator<?, ?>> containerClass) {
+        return false;
+    }
+
+    @Override
+    public <E> Optional<FluidStackSnapshot> transform(Key<? extends BaseValue<E>> key, Function<E, E> function) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <E> Optional<FluidStackSnapshot> with(Key<? extends BaseValue<E>> key, E value) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<FluidStackSnapshot> with(BaseValue<?> value) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<FluidStackSnapshot> with(ImmutableDataManipulator<?, ?> valueContainer) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<FluidStackSnapshot> with(Iterable<ImmutableDataManipulator<?, ?>> valueContainers) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<FluidStackSnapshot> without(Class<? extends ImmutableDataManipulator<?, ?>> containerClass) {
+        return Optional.empty();
+    }
+
+    @Override
+    public FluidStackSnapshot merge(FluidStackSnapshot that) {
+        return this;
+    }
+
+    @Override
+    public FluidStackSnapshot merge(FluidStackSnapshot that, MergeFunction function) {
+        return this;
+    }
+
+    @Override
+    public List<ImmutableDataManipulator<?, ?>> getContainers() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <T extends Property<?, ?>> Optional<T> getProperty(Class<T> propertyClass) {
+        return this.fluidType.getProperty(propertyClass);
+    }
+
+    @Override
+    public Collection<Property<?, ?>> getApplicableProperties() {
+        return this.fluidType.getApplicableProperties();
+    }
+
+    @Override
+    public <E> Optional<E> get(Key<? extends BaseValue<E>> key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <E, V extends BaseValue<E>> Optional<V> getValue(Key<V> key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean supports(Key<?> key) {
+        return false;
+    }
+
+    @Override
+    public FluidStackSnapshot copy() {
+        return this;
+    }
+
+    @Override
+    public Set<Key<?>> getKeys() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ImmutableValue<?>> getValues() {
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackSnapshotBuilder.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStackSnapshotBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.extra.fluid;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.FluidType;
+import org.spongepowered.api.util.persistence.InvalidDataException;
+import org.spongepowered.common.data.builder.AbstractDataBuilder;
+import org.spongepowered.common.data.util.DataQueries;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public class SpongeFluidStackSnapshotBuilder extends AbstractDataBuilder<FluidStackSnapshot> implements FluidStackSnapshot.Builder {
+
+    FluidType fluidType;
+    int volume;
+    @Nullable DataView container;
+
+    public SpongeFluidStackSnapshotBuilder() {
+        super(FluidStackSnapshot.class, 1);
+    }
+
+    @Override
+    public FluidStackSnapshot.Builder fluid(FluidType fluidType) {
+        this.fluidType = checkNotNull(fluidType, "FluidType cannot be null!");
+        return this;
+    }
+
+    @Override
+    public FluidStackSnapshot.Builder volume(int volume) {
+        this.volume = volume;
+        return this;
+    }
+
+    @Override
+    public FluidStackSnapshot.Builder from(FluidStack fluidStack) {
+        this.fluidType = fluidStack.getFluid();
+        this.volume = fluidStack.getVolume();
+        DataContainer datacontainer = fluidStack.toContainer();
+        this.container = null;
+        if (datacontainer.contains(DataQueries.UNSAFE_NBT)) {
+            this.container = datacontainer.getView(DataQueries.UNSAFE_NBT).get();
+        }
+        return this;
+    }
+
+    @Override
+    public FluidStackSnapshot.Builder add(DataManipulator<?, ?> manipulator) {
+        return this;
+    }
+
+    @Override
+    public FluidStackSnapshot.Builder add(ImmutableDataManipulator<?, ?> manipulator) {
+        return this;
+    }
+
+    @Override
+    public FluidStackSnapshot.Builder from(FluidStackSnapshot holder) {
+        checkNotNull(holder, "FluidStackSnapshot cannot be null!");
+        this.fluidType = checkNotNull(holder.getFluid(), "Invalid FluidStackSnapshot! FluidType cannot be null!");
+        return null;
+    }
+
+    @Override
+    public FluidStackSnapshot build() {
+        checkState(this.fluidType != null, "FluidType cannot be null!");
+        checkState(this.volume >= 0, "The fluid volume must be at least 0!");
+        return new SpongeFluidStackSnapshot(this);
+    }
+
+    @Override
+    protected Optional<FluidStackSnapshot> buildContent(DataView container) throws InvalidDataException {
+        try {
+            if (container.contains(DataQueries.FLUID_TYPE, DataQueries.FLUID_VOLUME)) {
+                final String fluidId = container.getString(DataQueries.FLUID_TYPE).get();
+                final Optional<FluidType> type = Sponge.getRegistry().getType(FluidType.class, fluidId);
+                if (!type.isPresent()) {
+                    throw new InvalidDataException("Unknown fluid id found: " + fluidId);
+                }
+                final FluidType fluidType = type.get();
+                final int volume = container.getInt(DataQueries.FLUID_VOLUME).get();
+                SpongeFluidStackSnapshotBuilder builder = new SpongeFluidStackSnapshotBuilder();
+                builder.fluid(fluidType)
+                        .volume(volume);
+                if (container.contains(DataQueries.UNSAFE_NBT)) {
+                    builder.container = container.getView(DataQueries.UNSAFE_NBT).get().copy();
+                }
+                return Optional.of(builder.build());
+            }
+        } catch (Exception e) {
+            throw new InvalidDataException("Something went wrong deserializing.", e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public FluidStackSnapshot.Builder reset() {
+        this.fluidType = null;
+        this.volume = 0;
+        this.container = null;
+        return this;
+    }
+}

--- a/src/main/java/org/spongepowered/common/extra/fluid/package-info.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.extra.fluid;

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
@@ -121,6 +121,13 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
         }
     }
 
+    @Inject(method = "setTagCompound", at = @At("RETURN"))
+    private void onSet(NBTTagCompound compound, CallbackInfo callbackInfo) {
+        if (hasTagCompound() && getTagCompound().hasKey(NbtDataUtil.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
+            readFromNbt(getTagCompound().getCompoundTag(NbtDataUtil.SPONGE_DATA));
+        }
+    }
+
     @Override
     public ItemType getItem() {
         return (ItemType) shadow$getItem();

--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -55,6 +55,9 @@ import org.spongepowered.api.event.cause.entity.damage.source.DamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.EntityDamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.FallingBlockDamageSource;
 import org.spongepowered.api.event.cause.entity.damage.source.IndirectEntityDamageSource;
+import org.spongepowered.api.extra.fluid.FluidStack;
+import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
+import org.spongepowered.api.extra.fluid.FluidType;
 import org.spongepowered.api.item.Enchantment;
 import org.spongepowered.api.item.FireworkEffect;
 import org.spongepowered.api.item.FireworkShape;
@@ -111,6 +114,8 @@ import org.spongepowered.common.event.SpongeDamageSourceBuilder;
 import org.spongepowered.common.event.SpongeEntityDamageSourceBuilder;
 import org.spongepowered.common.event.SpongeFallingBlockDamgeSourceBuilder;
 import org.spongepowered.common.event.SpongeIndirectEntityDamageSourceBuilder;
+import org.spongepowered.common.extra.fluid.SpongeFluidStackBuilder;
+import org.spongepowered.common.extra.fluid.SpongeFluidStackSnapshotBuilder;
 import org.spongepowered.common.item.SpongeFireworkEffectBuilder;
 import org.spongepowered.common.item.inventory.SpongeItemStackBuilder;
 import org.spongepowered.common.item.merchant.SpongeTradeOfferBuilder;
@@ -121,6 +126,7 @@ import org.spongepowered.common.registry.type.economy.TransactionTypeRegistryMod
 import org.spongepowered.common.registry.type.effect.*;
 import org.spongepowered.common.registry.type.entity.*;
 import org.spongepowered.common.registry.type.event.*;
+import org.spongepowered.common.registry.type.extra.FluidTypeRegistryModule;
 import org.spongepowered.common.registry.type.item.*;
 import org.spongepowered.common.registry.type.scoreboard.*;
 import org.spongepowered.common.registry.type.text.*;
@@ -229,6 +235,8 @@ public final class CommonModuleRegistry {
             .registerBuilderSupplier(Vine.Builder.class, VineBuilder::new)
             .registerBuilderSupplier(WaterLily.Builder.class, WaterLilyBuilder::new)
             .registerBuilderSupplier(Ban.Builder.class, SpongeBanBuilder::new)
+            .registerBuilderSupplier(FluidStack.Builder.class, SpongeFluidStackBuilder::new)
+            .registerBuilderSupplier(FluidStackSnapshot.Builder.class, SpongeFluidStackSnapshotBuilder::new)
         ;
     }
 
@@ -268,6 +276,7 @@ public final class CommonModuleRegistry {
             .registerModule(EquipmentType.class, new EquipmentTypeRegistryModule())
             .registerModule(FireworkShape.class, new FireworkShapeRegistryModule())
             .registerModule(Fish.class, new FishRegistryModule())
+            .registerModule(FluidType.class, FluidTypeRegistryModule.getInstance())
             .registerModule(GameMode.class, new GameModeRegistryModule())
             .registerModule(GeneratorType.class, new GeneratorRegistryModule())
             .registerModule(GoalType.class, GoalTypeModule.getInstance())

--- a/src/main/java/org/spongepowered/common/registry/type/entity/AITaskTypeModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/entity/AITaskTypeModule.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AITaskTypeModule implements AlternateCatalogRegistryModule<AITaskType> {
 
@@ -57,7 +58,7 @@ public class AITaskTypeModule implements AlternateCatalogRegistryModule<AITaskTy
     }
 
     @RegisterCatalog(AITaskTypes.class)
-    private final Map<String, AITaskType> aiTaskTypes = new HashMap<>();
+    private final Map<String, AITaskType> aiTaskTypes = new ConcurrentHashMap<>();
 
     @Override
     public Map<String, AITaskType> provideCatalogMap() {

--- a/src/main/java/org/spongepowered/common/registry/type/extra/FluidTypeRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/extra/FluidTypeRegistryModule.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.registry.type.extra;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.extra.fluid.FluidType;
+import org.spongepowered.api.extra.fluid.FluidTypes;
+import org.spongepowered.api.registry.util.RegisterCatalog;
+import org.spongepowered.api.registry.util.RegistrationDependency;
+import org.spongepowered.common.data.type.SpongeCommonFluidType;
+import org.spongepowered.common.registry.SpongeAdditionalCatalogRegistryModule;
+import org.spongepowered.common.registry.type.BlockTypeRegistryModule;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RegistrationDependency(BlockTypeRegistryModule.class)
+public final class FluidTypeRegistryModule implements SpongeAdditionalCatalogRegistryModule<FluidType> {
+
+    public static FluidTypeRegistryModule getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    @RegisterCatalog(FluidTypes.class)
+    private final Map<String, FluidType> fluidTypeMap = new HashMap<>();
+
+    @Override
+    public boolean allowsApiRegistration() {
+        return false;
+    }
+
+    @Override
+    public void registerAdditionalCatalog(FluidType extraCatalog) {
+
+    }
+
+    public void registerForge(FluidType fluidType) {
+        checkNotNull(fluidType, "Someone is registering a null FluidType!");
+        this.fluidTypeMap.put(fluidType.getId(), fluidType);
+    }
+
+    @Override
+    public Optional<FluidType> getById(String id) {
+        return Optional.ofNullable(this.fluidTypeMap.get(checkNotNull(id, "FluidType id cannot be null!").toLowerCase()));
+    }
+
+    @Override
+    public Collection<FluidType> getAll() {
+        return ImmutableSet.copyOf(this.fluidTypeMap.values());
+    }
+
+    @Override
+    public void registerDefaults() {
+        if (!this.fluidTypeMap.containsKey("water")) {
+            this.fluidTypeMap.put("water", new SpongeCommonFluidType("water", BlockTypes.WATER));
+        }
+        if (!this.fluidTypeMap.containsKey("lava")) {
+            this.fluidTypeMap.put("lava", new SpongeCommonFluidType("lava", BlockTypes.LAVA));
+        }
+    }
+
+    private FluidTypeRegistryModule() {
+    }
+
+    private static final class Holder {
+        private static final FluidTypeRegistryModule INSTANCE = new FluidTypeRegistryModule();
+    }
+}

--- a/src/main/java/org/spongepowered/common/registry/type/extra/package-info.java
+++ b/src/main/java/org/spongepowered/common/registry/type/extra/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.registry.type.extra;

--- a/src/main/resources/common_at.cfg
+++ b/src/main/resources/common_at.cfg
@@ -270,6 +270,8 @@ public-f org.spongepowered.api.event.cause.entity.damage.DamageTypes *
 
 public-f org.spongepowered.api.event.cause.entity.damage.source.DamageSources *
 
+public-f org.spongepowered.api.extra.fluid.FluidTypes *
+
 public-f org.spongepowered.api.item.Enchantments *
 public-f org.spongepowered.api.item.FireworkShapes *
 public-f org.spongepowered.api.item.ItemTypes *

--- a/src/test/java/org/spongepowered/common/data/manipulator/DataTestUtil.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/DataTestUtil.java
@@ -31,10 +31,12 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.DataManipulatorBuilder;
+import org.spongepowered.api.extra.fluid.FluidTypes;
 import org.spongepowered.common.SpongeGame;
 import org.spongepowered.common.data.DataRegistrar;
 import org.spongepowered.common.data.SpongeDataManager;
 import org.spongepowered.common.data.key.KeyRegistry;
+import org.spongepowered.common.data.type.SpongeCommonFluidType;
 import org.spongepowered.common.data.util.DataProcessorDelegate;
 import org.spongepowered.common.data.util.ImplementationRequiredForTest;
 
@@ -52,6 +54,7 @@ final class DataTestUtil {
     @SuppressWarnings("unchecked")
     static List<Object[]> generateManipulatorTestObjects() throws Exception {
         generateKeyMap();
+        setupCatalogTypes();
         SpongeGame mockGame = mock(SpongeGame.class);
 
         when(mockGame.getDataManager()).thenReturn(SpongeDataManager.getInstance());
@@ -102,4 +105,26 @@ final class DataTestUtil {
         return (Map<Class<? extends DataManipulator<?, ?>>, DataManipulatorBuilder<?, ?>>) builderMap.get(SpongeDataManager.getInstance());
     }
 
+
+    public static void setStaticFinalField(Field field, Object value) throws ReflectiveOperationException {
+        field.setAccessible(true);
+
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+        field.set(null, value);
+    }
+
+    private static void setupCatalogTypes() {
+        for (Field field : FluidTypes.class.getDeclaredFields()) {
+            try {
+                setStaticFinalField(field, new SpongeCommonFluidType(field.getName().toLowerCase()));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+
+    }
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1024) | SpongeCommon | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/489)

This implements the vanilla aspects of FluidStacks and the like. Allowing for native implementation so that SpongeVanilla doesn't have to do anything extra.

The Forge modules will be handling things in SpongeForge (for obvious reason).