### PR TITLE
Quiet the watchdog on the first run

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/server/dedicated/MixinServerHangWatchdog.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/dedicated/MixinServerHangWatchdog.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.server.dedicated;
+
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.dedicated.ServerHangWatchdog;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerHangWatchdog.class)
+public abstract class MixinServerHangWatchdog {
+
+    @Shadow private long maxTickTime;
+    private long originalMaxTickTime;
+    private boolean skip = true;
+
+    @Inject(method = "<init>(Lnet/minecraft/server/dedicated/DedicatedServer;)V", at = @At("RETURN"))
+    public void construct(DedicatedServer server, CallbackInfo ci) {
+        this.originalMaxTickTime = this.maxTickTime;
+    }
+
+    @Inject(method = "run()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;getCurrentTime()J", shift = At.Shift.BEFORE))
+    public void quiet(CallbackInfo ci) {
+        if (this.skip) {
+            this.maxTickTime = Integer.MAX_VALUE;
+            this.skip = false;
+        }
+    }
+
+    @Inject(method = "run()V", at = @At(value = "FIELD", target = "Lnet/minecraft/server/dedicated/ServerHangWatchdog;maxTickTime:J",
+            opcode = Opcodes.GETFIELD, shift = At.Shift.BEFORE))
+    public void restoreOriginalMaxTickTime(CallbackInfo ci) {
+        this.maxTickTime = this.originalMaxTickTime;
+    }
+
+}

--- a/src/main/resources/common_at.cfg
+++ b/src/main/resources/common_at.cfg
@@ -81,6 +81,7 @@ public-f net.minecraft.scoreboard.Score *
 public-f net.minecraft.scoreboard.ScorePlayerTeam *
 
 public net.minecraft.server.dedicated.DedicatedServer field_71339_n # theRConThreadMain
+private-f net.minecraft.server.dedicated.ServerHangWatchdog field_180250_c # maxTickTime
 
 public net.minecraft.server.management.BanEntry func_73682_e()Z # hasBanExpired
 public net.minecraft.server.management.BanList addressToString(Ljava/net/SocketAddress;)Ljava/lang/String; # addressToString

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -411,6 +411,7 @@
     ],
     "server": [
         "server.MixinDedicatedServer",
+        "server.dedicated.MixinServerHangWatchdog",
         "network.rcon.MixinRConConsoleSource",
         "network.rcon.MixinRConThreadClient"
     ]


### PR DESCRIPTION
Prevents:
```
[23:28:04] [Server thread/INFO]: Done (10.520s)! For help, type "help" or "?"
[23:28:04] [Server Watchdog/FATAL]: A single server tick took 71.62 seconds (should be max 0.05)
[23:28:04] [Server Watchdog/FATAL]: Considering it to be crashed, server will forcibly shutdown.
[23:28:04] [Server Watchdog/ERROR]: This crash report has been saved to: /home/github/SpongePowered/SpongeForge/run/./crash-reports/crash-2015-12-30_23.28.04-server.txt
[23:28:06] [Server thread/WARN]: Can't keep up! Did the system time change, or is the server overloaded? Running 2034ms behind, skipping 40 tick(s)
```