### PR TITLE
Prevent creation of a size 0 itemstack when deserializing

### DIFF
--- a/src/main/java/org/spongepowered/common/config/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/common/config/SpongeConfig.java
@@ -96,6 +96,9 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
     // BUNGEECORD
     public static final String BUNGEECORD_IP_FORWARDING = "ip-forwarding";
 
+    // PATCHES
+    public static final String ITEM_STACK_PATCH = "itemstack-count-0-patch";
+
     // GENERAL
     public static final String GENERAL_DISABLE_WARNINGS = "disable-warnings";
     public static final String GENERAL_CHUNK_LOAD_OVERRIDE = "chunk-load-override";
@@ -126,6 +129,7 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
     // MODULES
     public static final String MODULE_ENTITY_ACTIVATION_RANGE = "entity-activation-range";
     public static final String MODULE_BUNGEECORD = "bungeecord";
+    public static final String MODULE_PATCHES = "patches";
 
     // WORLD
     public static final String WORLD_PVP_ENABLED = "pvp-enabled";
@@ -250,8 +254,15 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
         @Setting
         private ExploitCategory exploits = new ExploitCategory();
 
+        @Setting(MODULE_PATCHES)
+        private PatchesCategory patches = new PatchesCategory();
+
         public BungeeCordCategory getBungeeCord() {
             return this.bungeeCord;
+        }
+
+        public PatchesCategory getPatches() {
+            return this.patches;
         }
 
         public SqlCategory getSql() {
@@ -563,6 +574,18 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
 
         public boolean getIpForwarding() {
             return this.ipForwarding;
+        }
+    }
+
+    @ConfigSerializable
+    public static class PatchesCategory extends Category {
+
+        @Setting(value = ITEM_STACK_PATCH, comment = "If enabled, use a Count of 1 when deserializing an ItemStack with no 'Count' tag, "
+                + "preventing the creation of an ItemStack with a Count of 0.")
+        private boolean stackPatch = true;
+
+        public boolean shouldItemStackPatch() {
+            return this.stackPatch;
         }
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/itemstackpatch/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/common/mixin/itemstackpatch/MixinItemStack.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.itemstackpatch;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.SpongeImpl;
+
+@Mixin(ItemStack.class)
+public class MixinItemStack {
+
+    @Redirect(method = "readFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;getByte(Ljava/lang/String;)B", ordinal = 0))
+    public byte onGetByte(NBTTagCompound compound, String string) {
+        byte b = compound.getByte(string);
+
+        if (b == 0 && SpongeImpl.getGlobalConfig().getConfig().getPatches().shouldItemStackPatch()) {
+            return 1;
+        }
+        return b;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/plugin/ItemStackPatchPlugin.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/ItemStackPatchPlugin.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.plugin;
+
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.List;
+import java.util.Set;
+
+public class ItemStackPatchPlugin implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return SpongeImpl.getGlobalConfig().getConfig().getPatches().shouldItemStackPatch();
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/src/main/resources/mixins.common.itemstackpatch.json
+++ b/src/main/resources/mixins.common.itemstackpatch.json
@@ -1,0 +1,8 @@
+{
+  "package": "org.spongepowered.common.mixin.itemstackpatch",
+  "refmap": "mixins.common.refmap.json",
+  "plugin": "org.spongepowered.common.mixin.plugin.ItemStackPatchPlugin",
+  "mixins": [
+      "MixinItemStack"
+  ]
+}


### PR DESCRIPTION
This resolves https://github.com/SpongePowered/SpongeForge/issues/483.

When an `ItemStack` is being deserialized from NBT, it will have a size of 0 if the `Count` tag isn't present. This usually happens when using `/summon`, as in the linked issue.

Vanilla usually doesn't care about this, however, our damage event code expects that an `ItemStack` has a size of 0 when it breaks. This means that the first time an entity wearing a size-0 `ItemStack` takes damage, our code removes the `ItemStack` from its inventory.

I've added a config option, in case this causes unexpected behavior with mods and/or Forge.