### PR TITLE
Add 'require' argument to injectors

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/damage/MixinAbstractDamageSource.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/damage/MixinAbstractDamageSource.java
@@ -44,7 +44,7 @@ import org.spongepowered.common.event.damage.SpongeCommonDamageSource;
 @Mixin(AbstractDamageSource.class)
 public abstract class MixinAbstractDamageSource implements DamageSource {
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstruct(CallbackInfo callbackInfo) {
         ((SpongeCommonDamageSource) (Object) this).setDamageType(getType().getId());
         if (isAbsolute()) {

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/damage/MixinAbstractEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/damage/MixinAbstractEntityDamageSource.java
@@ -48,7 +48,7 @@ import org.spongepowered.common.event.damage.SpongeCommonEntityDamageSource;
 @Mixin(AbstractEntityDamageSource.class)
 public abstract class MixinAbstractEntityDamageSource implements EntityDamageSource {
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstruct(CallbackInfo callbackInfo) {
         ((SpongeCommonEntityDamageSource) (Object) this).setDamageType(getType().getId());
         ((SpongeCommonEntityDamageSource) (Object) this).setEntitySource((Entity) getSource());

--- a/src/main/java/org/spongepowered/common/mixin/api/event/cause/damage/MixinAbstractIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/mixin/api/event/cause/damage/MixinAbstractIndirectEntityDamageSource.java
@@ -48,7 +48,7 @@ import org.spongepowered.common.event.damage.SpongeCommonIndirectEntityDamageSou
 @Mixin(AbstractIndirectEntityDamageSource.class)
 public abstract class MixinAbstractIndirectEntityDamageSource implements IndirectEntityDamageSource {
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstruct(CallbackInfo callbackInfo) {
         ((SpongeCommonIndirectEntityDamageSource) (Object) this).setDamageType(getType().getId());
         ((SpongeCommonIndirectEntityDamageSource) (Object) this).setEntitySource((Entity) getSource());

--- a/src/main/java/org/spongepowered/common/mixin/bungee/network/MixinNetHandlerHandshakeTCP.java
+++ b/src/main/java/org/spongepowered/common/mixin/bungee/network/MixinNetHandlerHandshakeTCP.java
@@ -50,7 +50,7 @@ public abstract class MixinNetHandlerHandshakeTCP {
 
     @Shadow private NetworkManager networkManager;
 
-    @Inject(method = "processHandshake", at = @At(value = "HEAD"), cancellable = true)
+    @Inject(method = "processHandshake", at = @At(value = "HEAD"), cancellable = true, require = 1)
     public void onProcessHandshakeStart(C00Handshake packetIn, CallbackInfo ci) {
         if (SpongeImpl.getGlobalConfig().getConfig().getBungeeCord().getIpForwarding() && packetIn.getRequestedState().equals(EnumConnectionState.LOGIN)) {
             String[] split = packetIn.ip.split("\00\\|", 2)[0].split("\00"); // ignore any extra data

--- a/src/main/java/org/spongepowered/common/mixin/bungee/network/packet/MixinC00Handshake.java
+++ b/src/main/java/org/spongepowered/common/mixin/bungee/network/packet/MixinC00Handshake.java
@@ -37,7 +37,7 @@ public abstract class MixinC00Handshake {
 
     @Shadow public String ip;
 
-    @Redirect(method = "readPacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readStringFromBuffer(I)Ljava/lang/String;"))
+    @Redirect(method = "readPacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readStringFromBuffer(I)Ljava/lang/String;"), require = 1)
     public String onReadPacketData(PacketBuffer buf, int value) {
         if (!SpongeImpl.getGlobalConfig().getConfig().getModules().usePluginBungeeCord()
                 || !SpongeImpl.getGlobalConfig().getConfig().getBungeeCord().getIpForwarding()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/MixinBootstrapAnonInner7.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/MixinBootstrapAnonInner7.java
@@ -40,7 +40,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class MixinBootstrapAnonInner7 {
 
     @Redirect(method = "dispenseStack(Lnet/minecraft/dispenser/IBlockSource;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntityInWorld(Lnet/minecraft/entity/Entity;)Z"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntityInWorld(Lnet/minecraft/entity/Entity;)Z"), require = 1)
     public boolean onSpawnEntityInWorld(World world, Entity firework, IBlockSource source, ItemStack stack) {
         ((Firework) firework).setShooter((ProjectileSource) source.getBlockTileEntity());
         return world.spawnEntityInWorld(firework);

--- a/src/main/java/org/spongepowered/common/mixin/core/MixinBootstrapAnonInner8.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/MixinBootstrapAnonInner8.java
@@ -40,7 +40,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class MixinBootstrapAnonInner8 {
 
     @Redirect(method = "dispenseStack(Lnet/minecraft/dispenser/IBlockSource;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntityInWorld(Lnet/minecraft/entity/Entity;)Z"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntityInWorld(Lnet/minecraft/entity/Entity;)Z"), require = 1)
     public boolean onSpawnEntityInWorld(World world, Entity smallFireball, IBlockSource source, ItemStack stack) {
         ((SmallFireball) smallFireball).setShooter((ProjectileSource) source.getBlockTileEntity());
         return world.spawnEntityInWorld(smallFireball);

--- a/src/main/java/org/spongepowered/common/mixin/core/ban/MixinBanEntry.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/ban/MixinBanEntry.java
@@ -63,7 +63,7 @@ public abstract class MixinBanEntry extends UserListEntry implements Ban {
     private Optional<CommandSource> commandSource = Optional.empty();
 
     @SuppressWarnings("deprecation")
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onInit(CallbackInfo ci) {
         this.spongeReason = Text.of();
         this.source = Text.of();

--- a/src/main/java/org/spongepowered/common/mixin/core/ban/MixinIPBanEntry.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/ban/MixinIPBanEntry.java
@@ -48,12 +48,12 @@ public abstract class MixinIPBanEntry extends BanEntry implements Ban.Ip {
 
     private InetAddress address;
 
-    @Inject(method = "<init>(Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;)V", at = @At("RETURN"))
+    @Inject(method = "<init>(Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;)V", at = @At("RETURN"), require = 1)
     public void onInit(CallbackInfo ci) {
         this.setAddress();
     }
 
-    @Inject(method = "<init>(Lcom/google/gson/JsonObject;)V", at = @At("RETURN"))
+    @Inject(method = "<init>(Lcom/google/gson/JsonObject;)V", at = @At("RETURN"), require = 1)
     public void onInit(JsonObject object, CallbackInfo ci) {
         this.setAddress();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/ban/MixinUserList.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/ban/MixinUserList.java
@@ -37,7 +37,7 @@ public abstract class MixinUserList {
 
     @Shadow public abstract String getObjectKey(Object obj);
 
-    @Redirect(method = "removeExpired", at = @At(value = "INVOKE", target = "Ljava/util/ArrayList;add(Ljava/lang/Object;)Z"))
+    @Redirect(method = "removeExpired", at = @At(value = "INVOKE", target = "Ljava/util/ArrayList;add(Ljava/lang/Object;)Z"), require = 1)
     public boolean onAdd(ArrayList<Object> list, Object object) {
         return list.add(this.getObjectKey(object)); // Mojang didn't implement this correctly, so we'll fix it
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlock.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlock.java
@@ -80,7 +80,7 @@ public abstract class MixinBlock implements BlockType, IMixinBlock {
     @Shadow(prefix = "shadow$")
     public abstract IBlockState shadow$getDefaultState();
 
-    @Inject(method = "registerBlock", at = @At("RETURN"))
+    @Inject(method = "registerBlock", at = @At("RETURN"), require = 1)
     private static void onRegisterBlock(int id, ResourceLocation location, Block block, CallbackInfo ci) {
         BlockTypeRegistryModule.getInstance().registerFromGameData(location.getResourcePath(), (BlockType) block);
     }
@@ -121,7 +121,7 @@ public abstract class MixinBlock implements BlockType, IMixinBlock {
         this.needsRandomTick = tickRandomly;
     }
 
-    @Inject(method = "randomTick", at = @At(value = "HEAD"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
+    @Inject(method = "randomTick", at = @At(value = "HEAD"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true, require = 1)
     public void callRandomTickEvent(net.minecraft.world.World world, BlockPos pos, IBlockState state, Random rand, CallbackInfo ci) {
         BlockSnapshot blockSnapshot = ((World) world).createSnapshot(VecHelper.toVector(pos));
         final TickBlockEvent event = SpongeEventFactory.createTickBlockEvent(Cause.of(NamedCause.source(world)), blockSnapshot);
@@ -155,7 +155,7 @@ public abstract class MixinBlock implements BlockType, IMixinBlock {
     public BlockState getDefaultBlockState() {
         return getDefaultState();
     }
-    
+
     @Override
     public boolean forceUpdateBlockState() {
         return false;
@@ -171,14 +171,14 @@ public abstract class MixinBlock implements BlockType, IMixinBlock {
         return getDefaultBlockState().getTrait(blockTrait);
     }
 
-    @Inject(method = "dropBlockAsItemWithChance", at = @At(value = "HEAD"))
+    @Inject(method = "dropBlockAsItemWithChance", at = @At(value = "HEAD"), require = 1)
     public void onDropBlockAsItemWithChance(net.minecraft.world.World worldIn, BlockPos pos, IBlockState state, float chance, int fortune, CallbackInfo ci) {
         if (((IMixinWorld) worldIn).restoringBlocks()) {
             return;
         }
     }
 
-    @Inject(method = "spawnAsEntity", at = @At(value = "HEAD"))
+    @Inject(method = "spawnAsEntity", at = @At(value = "HEAD"), require = 1)
     private static void onSpawnAsEntity(net.minecraft.world.World worldIn, BlockPos pos, net.minecraft.item.ItemStack stack, CallbackInfo ci) {
         if (((IMixinWorld) worldIn).restoringBlocks()) {
             return;

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockCactus.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockCactus.java
@@ -57,7 +57,7 @@ public abstract class MixinBlockCactus extends MixinBlock {
 
     private DamageSource originalCactus;
 
-    @Inject(method = "onEntityCollidedWithBlock", at = @At(value = "FIELD", target = CACTUS_DAMAGE_FIELD, opcode = Opcodes.GETSTATIC))
+    @Inject(method = "onEntityCollidedWithBlock", at = @At(value = "FIELD", target = CACTUS_DAMAGE_FIELD, opcode = Opcodes.GETSTATIC), require = 1)
     public void preSetOnFire(net.minecraft.world.World worldIn, BlockPos pos, IBlockState state, Entity entityIn, CallbackInfo callbackInfo) {
         if (!worldIn.isRemote) {
             this.originalCactus = DamageSource.cactus;
@@ -66,7 +66,7 @@ public abstract class MixinBlockCactus extends MixinBlock {
         }
     }
 
-    @Inject(method = "onEntityCollidedWithBlock", at = @At(value = "FIELD", target = CACTUS_DAMAGE_FIELD, opcode = Opcodes.GETSTATIC, shift = At.Shift.AFTER))
+    @Inject(method = "onEntityCollidedWithBlock", at = @At(value = "FIELD", target = CACTUS_DAMAGE_FIELD, opcode = Opcodes.GETSTATIC, shift = At.Shift.AFTER), require = 1)
     public void postSetOnFire(net.minecraft.world.World worldIn, BlockPos pos, IBlockState state, Entity entityIn, CallbackInfo callbackInfo) {
         if (!worldIn.isRemote) {
             if (this.originalCactus == null) {

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockLeaves.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinBlockLeaves.java
@@ -57,7 +57,7 @@ import java.util.Optional;
 @Mixin(BlockLeaves.class)
 public abstract class MixinBlockLeaves extends MixinBlock {
 
-    @Redirect(method = "updateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;I)Z"))
+    @Redirect(method = "updateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;I)Z"), require = 1)
     public boolean onUpdateDecayState(net.minecraft.world.World worldIn, BlockPos pos, IBlockState state, int flags) {
         IMixinWorld spongeWorld = (IMixinWorld) worldIn;
         spongeWorld.setCapturingBlockDecay(true);
@@ -66,7 +66,7 @@ public abstract class MixinBlockLeaves extends MixinBlock {
         return result;
     }
 
-    @Redirect(method = "destroy", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockToAir(Lnet/minecraft/util/BlockPos;)Z") )
+    @Redirect(method = "destroy", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockToAir(Lnet/minecraft/util/BlockPos;)Z") , require = 1)
     private boolean onDestroyLeaves(net.minecraft.world.World worldIn, BlockPos pos) {
         IMixinWorld spongeWorld = (IMixinWorld) worldIn;
         spongeWorld.setCapturingBlockDecay(true);

--- a/src/main/java/org/spongepowered/common/mixin/core/block/properties/MixinPropertyBoolean.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/properties/MixinPropertyBoolean.java
@@ -38,10 +38,10 @@ import java.util.Collection;
 public abstract class MixinPropertyBoolean extends MixinPropertyHelper<Boolean> implements BooleanTrait {
 
     @SuppressWarnings("rawtypes")
-    @Shadow 
+    @Shadow
     public abstract Collection getAllowedValues();
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstructed(String name, CallbackInfo ci) {
         this.propertyName = name;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/block/properties/MixinPropertyEnum.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/properties/MixinPropertyEnum.java
@@ -38,11 +38,11 @@ import java.util.Collection;
 public abstract class MixinPropertyEnum<E extends Enum<E>> extends MixinPropertyHelper<E> implements EnumTrait<E> {
 
     @SuppressWarnings("rawtypes")
-    @Shadow 
+    @Shadow
     public abstract Collection getAllowedValues();
 
     @SuppressWarnings("rawtypes")
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstructed(String name, Class valueClass, Collection allowedValues, CallbackInfo ci) {
         this.propertyName = name;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntity.java
@@ -80,7 +80,7 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
     @Shadow public abstract void writeToNBT(NBTTagCompound compound);
     @Shadow public abstract void markDirty();
 
-    @Inject(method = "markDirty", at = @At(value = "HEAD"))
+    @Inject(method = "markDirty", at = @At(value = "HEAD"), require = 1)
     public void onMarkDirty(CallbackInfo ci) {
         if (this.worldObj != null && !this.worldObj.isRemote) {
             IMixinWorld world = (IMixinWorld) this.worldObj;
@@ -93,7 +93,7 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @Inject(method = "addMapping(Ljava/lang/Class;Ljava/lang/String;)V", at = @At(value = "RETURN"))
+    @Inject(method = "addMapping(Ljava/lang/Class;Ljava/lang/String;)V", at = @At(value = "RETURN"), require = 1)
     private static void onRegister(Class clazz, String name, CallbackInfo callbackInfo) {
         final String id = TileEntityTypeRegistryModule.getInstance().getIdForName(name);
         final TileEntityType tileEntityType = new SpongeTileEntityType((Class<? extends TileEntity>) clazz, name, id);
@@ -173,7 +173,7 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
      * @param compound The compound vanilla writes to (unused because we write to SpongeData)
      * @param ci (Unused) callback info
      */
-    @Inject(method = "Lnet/minecraft/tileentity/TileEntity;writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("HEAD"))
+    @Inject(method = "Lnet/minecraft/tileentity/TileEntity;writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("HEAD"), require = 1)
     public void onWriteToNBT(NBTTagCompound compound, CallbackInfo ci) {
         this.writeToNbt(this.getSpongeData());
     }
@@ -186,7 +186,7 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
      * @param compound The compound vanilla reads from (unused because we read from SpongeData)
      * @param ci (Unused) callback info
      */
-    @Inject(method = "Lnet/minecraft/tileentity/TileEntity;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"))
+    @Inject(method = "Lnet/minecraft/tileentity/TileEntity;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"), require = 1)
     public void onReadFromNBT(NBTTagCompound compound, CallbackInfo ci) {
         this.readFromNbt(this.getSpongeData());
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntityBanner.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/tiles/MixinTileEntityBanner.java
@@ -66,7 +66,7 @@ public abstract class MixinTileEntityBanner extends MixinTileEntity implements B
 
     private List<PatternLayer> patternLayers = Lists.newArrayList();
 
-    @Inject(method = "setItemValues(Lnet/minecraft/item/ItemStack;)V", at = @At("RETURN"))
+    @Inject(method = "setItemValues(Lnet/minecraft/item/ItemStack;)V", at = @At("RETURN"), require = 1)
     private void onSetItemValues(ItemStack stack, CallbackInfo ci) {
         updatePatterns();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandHandler.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandHandler.java
@@ -46,7 +46,7 @@ public abstract class MixinCommandHandler implements IMixinCommandHandler {
 
     private boolean expandedSelector;
 
-    @Inject(method = "tryExecute", at = @At(value = "HEAD"))
+    @Inject(method = "tryExecute", at = @At(value = "HEAD"), require = 1)
     public void onExecuteCommandHead(ICommandSender sender, String[] args, ICommand command, String input, CallbackInfoReturnable<Boolean> ci) {
         if (sender.getEntityWorld() != null) {
             IMixinWorld world = (IMixinWorld) sender.getEntityWorld();
@@ -55,7 +55,7 @@ public abstract class MixinCommandHandler implements IMixinCommandHandler {
         ((IMixinCommandBase) command).setExpandedSelector(this.isExpandedSelector());
     }
 
-    @Inject(method = "tryExecute", at = @At(value = "RETURN"))
+    @Inject(method = "tryExecute", at = @At(value = "RETURN"), require = 1)
     public void onExecuteCommandReturn(ICommandSender sender, String[] args, ICommand command, String input, CallbackInfoReturnable<Boolean> ci) {
         if (sender.getEntityWorld() != null) {
             IMixinWorld world = (IMixinWorld) sender.getEntityWorld();

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandScoreboard.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandScoreboard.java
@@ -58,22 +58,22 @@ public abstract class MixinCommandScoreboard extends CommandBase implements IMix
 
     private String realName;
 
-    @Inject(method = "joinTeam", at = @At(value = "INVOKE", target = GET_UNIQUE_ID), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "joinTeam", at = @At(value = "INVOKE", target = GET_UNIQUE_ID), locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void onGetUUIDJoin(ICommandSender p_147190_1_, String[] p_147190_2_, int p_147190_3_, CallbackInfo ci, Scoreboard scoreboard, String s, HashSet hashset, HashSet hashset1, String s1, List list, Iterator iterator, Entity entity) {
         this.onGetUUID(entity);
     }
 
-    @Redirect(method = "joinTeam", at = @At(value = "INVOKE", target = GET_ENTITY_NAME, ordinal = 0))
+    @Redirect(method = "joinTeam", at = @At(value = "INVOKE", target = GET_ENTITY_NAME, ordinal = 0), require = 1)
     public String onGetEntityNameJoin(ICommandSender sender, String string) throws EntityNotFoundException {
         return this.onGetEntityName(sender, string);
     }
 
-    @Inject(method = "leaveTeam", at = @At(value = "INVOKE", target = GET_UNIQUE_ID, ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "leaveTeam", at = @At(value = "INVOKE", target = GET_UNIQUE_ID, ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     private void onGetUUIDLeave(ICommandSender p_147199_1_, String[] p_147199_2_, int p_147199_3_, CallbackInfo ci, Scoreboard scoreboard, HashSet hashset, HashSet hashset1, String s, List list, Iterator iterator, Entity entity) {
         this.onGetUUID(entity);
     }
 
-    @Redirect(method = "leaveTeam", at = @At(value = "INVOKE", target = GET_ENTITY_NAME, ordinal = 0))
+    @Redirect(method = "leaveTeam", at = @At(value = "INVOKE", target = GET_ENTITY_NAME, ordinal = 0), require = 1)
     public String onGetEntityNameLeaveFirst(ICommandSender sender, String string) throws EntityNotFoundException {
         return this.onGetEntityName(sender, string);
     }
@@ -94,7 +94,7 @@ public abstract class MixinCommandScoreboard extends CommandBase implements IMix
         return CommandBase.getEntityName(sender, string);
     }
 
-    @Redirect(method = "leaveTeam", at = @At(value = "INVOKE", target = GET_ENTITY_NAME, ordinal = 0))
+    @Redirect(method = "leaveTeam", at = @At(value = "INVOKE", target = GET_ENTITY_NAME, ordinal = 0), require = 1)
     public String onGetEntityNameLeaveSecond(ICommandSender sender, String string) throws EntityNotFoundException {
         String entityName = CommandBase.getEntityName(sender, string);
         if (this.isExpandedSelector()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinPlayerSelectorScore.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinPlayerSelectorScore.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 @Mixin(targets = "net.minecraft.command.PlayerSelector$6")
 public class MixinPlayerSelectorScore {
 
-    @Redirect(method = "func_179603_a", at = @At(value = "INVOKE", target = "Ljava/util/UUID;toString()Ljava/lang/String;"))
+    @Redirect(method = "func_179603_a", at = @At(value = "INVOKE", target = "Ljava/util/UUID;toString()Ljava/lang/String;"), require = 1)
     public String onUUIDToString(UUID uuid, Entity entity) {
         if (entity instanceof EntityHuman) {
             return entity.getCustomNameTag();

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
@@ -67,7 +67,7 @@ public abstract class MixinSubject implements Subject, IMixinCommandSource, IMix
     @Nullable
     private Subject thisSubject;
 
-    @Inject(method = "<init>", at = @At("RETURN"), remap = false)
+    @Inject(method = "<init>", at = @At("RETURN"), remap = false, require = 1)
     public void subjectConstructor(CallbackInfo ci) {
         if (SpongeImpl.isInitialized()) {
             SpongeInternalListeners.getInstance().registerExpirableServiceCallback(PermissionService.class, new SubjectSettingCallback(this));

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -182,7 +182,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
 
     // @formatter:on
 
-    @Inject(method = "setSize", at = @At("RETURN"))
+    @Inject(method = "setSize", at = @At("RETURN"), require = 1)
     public void onSetSize(float width, float height, CallbackInfo ci) {
         if (this.origWidth == 0 || this.origHeight == 0) {
             this.origWidth = this.width;
@@ -190,14 +190,14 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         }
     }
 
-    @Inject(method = "moveEntity(DDD)V", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "moveEntity(DDD)V", at = @At("HEAD"), cancellable = true, require = 1)
     public void onMoveEntity(double x, double y, double z, CallbackInfo ci) {
         if (!this.worldObj.isRemote && !SpongeHooks.checkEntitySpeed(((net.minecraft.entity.Entity) (Object) this), x, y, z)) {
             ci.cancel();
         }
     }
 
-    @Inject(method = "setOnFireFromLava()V", at = @At(value = "FIELD", target = LAVA_DAMAGESOURCE_FIELD, opcode = Opcodes.GETSTATIC))
+    @Inject(method = "setOnFireFromLava()V", at = @At(value = "FIELD", target = LAVA_DAMAGESOURCE_FIELD, opcode = Opcodes.GETSTATIC), require = 1)
     public void preSetOnFire(CallbackInfo callbackInfo) {
         if (!this.worldObj.isRemote) {
             this.originalLava = DamageSource.lava;
@@ -208,7 +208,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         }
     }
 
-    @Inject(method = "setOnFireFromLava()V", at = @At(value = "INVOKE_ASSIGN", target = ATTACK_ENTITY_FROM_METHOD))
+    @Inject(method = "setOnFireFromLava()V", at = @At(value = "INVOKE_ASSIGN", target = ATTACK_ENTITY_FROM_METHOD), require = 1)
     public void postSetOnFire(CallbackInfo callbackInfo) {
         if (!this.worldObj.isRemote) {
             if (this.originalLava == null) {
@@ -221,7 +221,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
 
     private DamageSource originalInFire;
 
-    @Inject(method = "dealFireDamage", at = @At(value = "FIELD", target = FIRE_DAMAGESOURCE_FIELD, opcode = Opcodes.GETSTATIC))
+    @Inject(method = "dealFireDamage", at = @At(value = "FIELD", target = FIRE_DAMAGESOURCE_FIELD, opcode = Opcodes.GETSTATIC), require = 1)
     public void preFire(CallbackInfo callbackInfo) {
         // Sponge Start - Find the fire block!
         if (!this.worldObj.isRemote) {
@@ -233,7 +233,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         }
     }
 
-    @Inject(method = "dealFireDamage", at = @At(value = "INVOKE_ASSIGN", target = ATTACK_ENTITY_FROM_METHOD))
+    @Inject(method = "dealFireDamage", at = @At(value = "INVOKE_ASSIGN", target = ATTACK_ENTITY_FROM_METHOD), require = 1)
     public void postDealFireDamage(CallbackInfo callbackInfo) {
         if (!this.worldObj.isRemote) {
             if (this.originalInFire == null) {
@@ -722,7 +722,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
      *        to SpongeData)
      * @param ci (Unused) callback info
      */
-    @Inject(method = "Lnet/minecraft/entity/Entity;writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("HEAD"))
+    @Inject(method = "Lnet/minecraft/entity/Entity;writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("HEAD"), require = 1)
     public void onWriteToNBT(NBTTagCompound compound, CallbackInfo ci) {
         this.writeToNbt(this.getSpongeData());
     }
@@ -737,7 +737,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
      *        from SpongeData)
      * @param ci (Unused) callback info
      */
-    @Inject(method = "Lnet/minecraft/entity/Entity;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"))
+    @Inject(method = "Lnet/minecraft/entity/Entity;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"), require = 1)
     public void onReadFromNBT(NBTTagCompound compound, CallbackInfo ci) {
         this.readFromNbt(this.getSpongeData());
     }
@@ -917,7 +917,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         return new Vector3d(this.motionX, this.motionY, this.motionZ);
     }
 
-    @Redirect(method = "moveEntity", at = @At(value = "INVOKE", target="Lnet/minecraft/block/Block;onEntityCollidedWithBlock(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/entity/Entity;)V"))
+    @Redirect(method = "moveEntity", at = @At(value = "INVOKE", target="Lnet/minecraft/block/Block;onEntityCollidedWithBlock(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/entity/Entity;)V"), require = 1)
     public void onEntityCollideWithBlock(Block block, net.minecraft.world.World world, BlockPos pos, net.minecraft.entity.Entity entity) {
         if (block == Blocks.air) {
             return;
@@ -940,7 +940,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         StaticMixinHelper.collidePlayer = null;
     }
 
-    @Redirect(method = "doBlockCollisions", at = @At(value = "INVOKE", target="Lnet/minecraft/block/Block;onEntityCollidedWithBlock(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/entity/Entity;)V"))
+    @Redirect(method = "doBlockCollisions", at = @At(value = "INVOKE", target="Lnet/minecraft/block/Block;onEntityCollidedWithBlock(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/entity/Entity;)V"), require = 1)
     public void onEntityCollideWithBlockState(Block block, net.minecraft.world.World world, BlockPos pos, IBlockState state, net.minecraft.entity.Entity entity) {
         if (block == Blocks.air) {
             return;
@@ -964,7 +964,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         StaticMixinHelper.collidePlayer = null;
     }
 
-    @Redirect(method = "updateFallState", at = @At(value = "INVOKE", target="Lnet/minecraft/block/Block;onFallenUpon(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/entity/Entity;F)V"))
+    @Redirect(method = "updateFallState", at = @At(value = "INVOKE", target="Lnet/minecraft/block/Block;onFallenUpon(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/entity/Entity;F)V"), require = 1)
     public void onBlockFallenUpon(Block block, net.minecraft.world.World world, BlockPos pos, net.minecraft.entity.Entity entity, float fallDistance) {
         if (block == Blocks.air) {
             return;
@@ -1038,7 +1038,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         }
     }
 
-    @Redirect(method = "resetHeight", at = @At(value = "INVOKE", target = WORLD_SPAWN_PARTICLE))
+    @Redirect(method = "resetHeight", at = @At(value = "INVOKE", target = WORLD_SPAWN_PARTICLE), require = 1)
     public void spawnParticle(net.minecraft.world.World world, EnumParticleTypes particleTypes, double xCoord, double yCoord, double zCoord,
             double xOffset, double yOffset, double zOffset, int ... p_175688_14_) {
         if (!this.isReallyInvisible) {
@@ -1046,7 +1046,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
         }
     }
 
-    @Redirect(method = "createRunningParticles", at = @At(value = "INVOKE", target = WORLD_SPAWN_PARTICLE))
+    @Redirect(method = "createRunningParticles", at = @At(value = "INVOKE", target = WORLD_SPAWN_PARTICLE), require = 1)
     public void runningSpawnParticle(net.minecraft.world.World world, EnumParticleTypes particleTypes, double xCoord, double yCoord, double zCoord,
             double xOffset, double yOffset, double zOffset, int ... p_175688_14_) {
         if (!this.isReallyInvisible) {

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLiving.java
@@ -103,7 +103,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
         this.canPickUpLoot = canPickupItems;
     }
 
-    @Inject(method = "<init>", at = @At(value = "RETURN"))
+    @Inject(method = "<init>", at = @At(value = "RETURN"), require = 1)
     public void onConstruct(CallbackInfo ci) {
         ((IMixinEntityAITasks) this.tasks).setOwner((EntityLiving) (Object) this);
         ((IMixinEntityAITasks) this.tasks).setType(GoalTypes.NORMAL);
@@ -111,7 +111,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
         ((IMixinEntityAITasks) this.targetTasks).setType(GoalTypes.TARGET);
     }
 
-    @Inject(method = "interactFirst", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLiving;setLeashedToEntity(Lnet/minecraft/entity/Entity;Z)V"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
+    @Inject(method = "interactFirst", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLiving;setLeashedToEntity(Lnet/minecraft/entity/Entity;Z)V"), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true, require = 1)
     public void callLeashEvent(EntityPlayer playerIn, CallbackInfoReturnable<Boolean> ci, ItemStack itemstack) {
         if (!playerIn.worldObj.isRemote) {
             Entity leashedEntity = (Entity)(Object) this;
@@ -123,7 +123,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
         }
     }
 
-    @Inject(method = "clearLeashed", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/EntityLiving;isLeashed:Z", opcode = Opcodes.PUTFIELD), cancellable = true)
+    @Inject(method = "clearLeashed", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/EntityLiving;isLeashed:Z", opcode = Opcodes.PUTFIELD), cancellable = true, require = 1)
     public void callUnleashEvent(boolean sendPacket, boolean dropLead, CallbackInfo ci) {
         net.minecraft.entity.Entity entity = getLeashedToEntity();
         if (!this.worldObj.isRemote) {
@@ -148,7 +148,7 @@ public abstract class MixinEntityLiving extends MixinEntityLivingBase implements
         return Optional.empty();
     }
 
-    @Redirect(method = "despawnEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getClosestPlayerToEntity(Lnet/minecraft/entity/Entity;D)Lnet/minecraft/entity/player/EntityPlayer;"))
+    @Redirect(method = "despawnEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getClosestPlayerToEntity(Lnet/minecraft/entity/Entity;D)Lnet/minecraft/entity/player/EntityPlayer;"), require = 1)
     public EntityPlayer onDespawnEntity(World world, net.minecraft.entity.Entity entity, double distance) {
         return ((IMixinWorld) world).getClosestPlayerToEntityWhoAffectsSpawning(entity, distance);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
@@ -141,7 +141,7 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
     }
 
     @Redirect(method = "onDeath(Lnet/minecraft/util/DamageSource;)V", at = @At(value = "INVOKE", target =
-            "Lnet/minecraft/world/World;setEntityState(Lnet/minecraft/entity/Entity;B)V"))
+            "Lnet/minecraft/world/World;setEntityState(Lnet/minecraft/entity/Entity;B)V"), require = 1)
     public void onDeathSendEntityState(World world, net.minecraft.entity.Entity self, byte state) {
         // Don't send the state if this is a human. Fixes ghost items on client.
         if (!((net.minecraft.entity.Entity) (Object) this instanceof EntityHuman)) {
@@ -149,12 +149,12 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
         }
     }
 
-    @Redirect(method = "applyPotionDamageCalculations", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;isPotionActive(Lnet/minecraft/potion/Potion;)Z") )
+    @Redirect(method = "applyPotionDamageCalculations", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;isPotionActive(Lnet/minecraft/potion/Potion;)Z") , require = 1)
     public boolean onIsPotionActive(EntityLivingBase entityIn, Potion potion) {
         return false; // handled in our damageEntityHook
     }
 
-    @Redirect(method = "applyArmorCalculations", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;damageArmor(F)V") )
+    @Redirect(method = "applyArmorCalculations", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;damageArmor(F)V") , require = 1)
     protected void onDamageArmor(EntityLivingBase entityIn, float damage) {
         // do nothing as this is handled in our damageEntityHook
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityTracker.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityTracker.java
@@ -40,7 +40,7 @@ public abstract class MixinEntityTracker {
     @Shadow
     public abstract void trackEntity(Entity entityIn, int trackingRange, int updateFrequency);
 
-    @Inject(method = "trackEntity", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "trackEntity", at = @At("HEAD"), cancellable = true, require = 1)
     public void onTrackEntity(Entity entityIn, CallbackInfo ci) {
         if (entityIn instanceof EntityHuman) {
             this.trackEntity(entityIn, 512, 2);

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityTrackerEntry.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityTrackerEntry.java
@@ -74,14 +74,14 @@ public abstract class MixinEntityTrackerEntry {
     }
 
     // The spawn packet for a human is a player
-    @Inject(method = "func_151260_c", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "func_151260_c", at = @At("HEAD"), cancellable = true, require = 1)
     public void onGetSpawnPacket(CallbackInfoReturnable<Packet> cir) {
         if (this.trackedEntity instanceof EntityHuman) {
             cir.setReturnValue(((EntityHuman) this.trackedEntity).createSpawnPacket());
         }
     }
 
-    @Inject(method = "sendMetadataToAllAssociatedPlayers", at = @At("HEAD"))
+    @Inject(method = "sendMetadataToAllAssociatedPlayers", at = @At("HEAD"), require = 1)
     public void onSendMetadata(CallbackInfo ci) {
         if (!(this.trackedEntity instanceof EntityHuman)) {
             return;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/ai/MixinEntityAIBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/ai/MixinEntityAIBase.java
@@ -48,7 +48,7 @@ public abstract class MixinEntityAIBase implements IMixinEntityAIBase {
     private AITaskType type;
     private Optional<Goal<?>> owner = Optional.empty();
 
-    @Inject(method = "<init>", at = @At(value = "RETURN"))
+    @Inject(method = "<init>", at = @At(value = "RETURN"), require = 1)
     public void assignAITaskType(CallbackInfo ci) {
         final Optional<AITaskType> optAiTaskType = AITaskTypeModule.getInstance().getByAIClass(getClass());
         if (optAiTaskType.isPresent()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/ai/MixinEntityAIMate.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/ai/MixinEntityAIMate.java
@@ -52,7 +52,7 @@ public abstract class MixinEntityAIMate {
     @Shadow private EntityAnimal theAnimal;
     @Shadow private EntityAnimal targetMate;
 
-    @Inject(method = "spawnBaby()V", at = @At(value = "INVOKE_ASSIGN", target = METHOD_INVOKE_ASSIGN, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true)
+    @Inject(method = "spawnBaby()V", at = @At(value = "INVOKE_ASSIGN", target = METHOD_INVOKE_ASSIGN, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILEXCEPTION, cancellable = true, require = 1)
     public void callBreedEvent(CallbackInfo ci, EntityAgeable entityageable) {
         final BreedEntityEvent.Breed event = SpongeEventFactory.createBreedEntityEventBreed(Cause.of(NamedCause.source(this.theAnimal)),
             Optional.<Vector3d>empty(), (Ageable)entityageable, (Ageable)this.targetMate);

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/effect/MixinEntityLightningBolt.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/effect/MixinEntityLightningBolt.java
@@ -83,13 +83,13 @@ public abstract class MixinEntityLightningBolt extends MixinEntityWeatherEffect 
     }
 
     @Redirect(method = "<init>", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z"))
+            target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z"), require = 1)
     public boolean onStrikeBlockInit(net.minecraft.world.World world, BlockPos pos, IBlockState blockState) {
         return onStrikeBlock(world, pos, blockState);
     }
 
     @Redirect(method = "onUpdate()V", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z"))
+            target = "Lnet/minecraft/world/World;setBlockState(Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;)Z"), require = 1)
     public boolean onStrikeBlockUpdate(net.minecraft.world.World world, BlockPos pos, IBlockState blockState) {
         return onStrikeBlock(world, pos, blockState);
     }
@@ -109,7 +109,7 @@ public abstract class MixinEntityLightningBolt extends MixinEntityWeatherEffect 
     }
 
     @Redirect(method = "onUpdate()V", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/entity/Entity;onStruckByLightning(Lnet/minecraft/entity/effect/EntityLightningBolt;)V"))
+            target = "Lnet/minecraft/entity/Entity;onStruckByLightning(Lnet/minecraft/entity/effect/EntityLightningBolt;)V"), require = 1)
     public void onStrikeEntity(net.minecraft.entity.Entity mcEntity, EntityLightningBolt lightningBolt) {
         if (!this.effect) {
             Entity entity = (Entity) mcEntity;
@@ -120,7 +120,7 @@ public abstract class MixinEntityLightningBolt extends MixinEntityWeatherEffect 
         }
     }
 
-    @Inject(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/EntityLightningBolt;setDead()V"))
+    @Inject(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/effect/EntityLightningBolt;setDead()V"), require = 1)
     public void onSetDead(CallbackInfo ci) {
         if (this.isDead) {
             return;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityBoat.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityBoat.java
@@ -51,7 +51,7 @@ public abstract class MixinEntityBoat extends MixinEntity implements Boat {
     private double tempSpeedMultiplier;
     private double initialDisplacement;
 
-    @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityBoat;moveEntity(DDD)V"))
+    @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityBoat;moveEntity(DDD)V"), require = 1)
     public void implementLandBoats(CallbackInfo ci) {
         if (this.onGround && this.moveOnLand) {
             this.motionX /= 0.5;
@@ -60,19 +60,19 @@ public abstract class MixinEntityBoat extends MixinEntity implements Boat {
         }
     }
 
-    @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "java.lang.Math.sqrt(D)D", ordinal = 0))
+    @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "java.lang.Math.sqrt(D)D", ordinal = 0), require = 1)
     public void beforeModifyMotion(CallbackInfo ci) {
         this.initialDisplacement = Math.sqrt(this.motionX * this.motionX + this.motionZ * this.motionZ);
     }
 
-    @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "java.lang.Math.sqrt(D)D", ordinal = 1))
+    @Inject(method = "onUpdate()V", at = @At(value = "INVOKE", target = "java.lang.Math.sqrt(D)D", ordinal = 1), require = 1)
     public void beforeLimitSpeed(CallbackInfo ci) {
         this.tempMotionX = this.motionX;
         this.tempMotionZ = this.motionZ;
         this.tempSpeedMultiplier = this.speedMultiplier;
     }
 
-    @Inject(method = "onUpdate()V", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/item/EntityBoat;onGround:Z", ordinal = 1))
+    @Inject(method = "onUpdate()V", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/item/EntityBoat;onGround:Z", ordinal = 1), require = 1)
     public void afterLimitSpeed(CallbackInfo ci) {
         this.motionX = this.tempMotionX;
         this.motionZ = this.tempMotionZ;
@@ -96,7 +96,7 @@ public abstract class MixinEntityBoat extends MixinEntity implements Boat {
     }
 
     @Inject(method = "onUpdate()V",
-            at = @At(value = "FIELD", target = "Lnet/minecraft/entity/item/EntityBoat;riddenByEntity:Lnet/minecraft/entity/Entity;", ordinal = 0))
+            at = @At(value = "FIELD", target = "Lnet/minecraft/entity/item/EntityBoat;riddenByEntity:Lnet/minecraft/entity/Entity;", ordinal = 0), require = 1)
     public void implementCustomDeceleration(CallbackInfo ci) {
         if (!(this.riddenByEntity instanceof EntityLivingBase)) {
             double decel = this.riddenByEntity == null ? this.unoccupiedDecelerationSpeed : this.occupiedDecelerationSpeed;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderPearl.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderPearl.java
@@ -39,8 +39,8 @@ public abstract class MixinEntityEnderPearl extends MixinEntityThrowable impleme
     public double damageAmount;
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V", at =
-            @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z")
-        )
+            @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"),
+        require = 1)
     private float onAttackEntityFrom(float damage) {
         return (float) this.damageAmount;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityFallingBlock.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityFallingBlock.java
@@ -53,7 +53,7 @@ public abstract class MixinEntityFallingBlock extends MixinEntity implements Fal
     private DamageSource original;
     private boolean isAnvil;
 
-    @Inject(method = "fall(FF)V", at = @At(value = "JUMP", opcode = Opcodes.IFEQ, ordinal = 1))
+    @Inject(method = "fall(FF)V", at = @At(value = "JUMP", opcode = Opcodes.IFEQ, ordinal = 1), require = 1)
     public void beforeFall(float distance, float damageMultipleier, CallbackInfo callbackInfo) {
         this.isAnvil = this.fallTile.getBlock() == Blocks.anvil;
         this.original = this.isAnvil ? DamageSource.anvil : DamageSource.fallingBlock;
@@ -64,7 +64,7 @@ public abstract class MixinEntityFallingBlock extends MixinEntity implements Fal
         }
     }
 
-    @Inject(method = "fall(FF)V", at = @At("RETURN"))
+    @Inject(method = "fall(FF)V", at = @At("RETURN"), require = 1)
     public void afterFall(float distance, float damageMultiplier, CallbackInfo ci) {
         if (this.original == null) {
             return;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityItem.java
@@ -63,7 +63,7 @@ public abstract class MixinEntityItem extends MixinEntity implements Item {
     private boolean infiniteDespawnDelay;
 
     @Inject(method = "onUpdate()V", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/item/EntityItem;delayBeforeCanPickup:I",
-            opcode = Opcodes.PUTFIELD, shift = At.Shift.AFTER))
+            opcode = Opcodes.PUTFIELD, shift = At.Shift.AFTER), require = 1)
     private void onOnUpdate(CallbackInfo ci) {
         if (this.delayBeforeCanPickup == MAGIC_INFINITE_PICKUP_DELAY && !this.infinitePickupDelay && this.pluginPickupSet) {
             this.delayBeforeCanPickup--;
@@ -71,7 +71,7 @@ public abstract class MixinEntityItem extends MixinEntity implements Item {
     }
 
     @Inject(method = "onUpdate()V", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/item/EntityItem;age:I", opcode = Opcodes.PUTFIELD,
-            shift = At.Shift.AFTER))
+            shift = At.Shift.AFTER), require = 1)
     private void onOnUpdateAge(CallbackInfo ci) {
         if (this.delayBeforeCanPickup == MAGIC_INFINITE_DESPAWN_TIME && !this.infiniteDespawnDelay && this.pluginDespawnSet) {
             this.delayBeforeCanPickup--;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityMinecart.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityMinecart.java
@@ -46,7 +46,7 @@ public abstract class MixinEntityMinecart extends MixinEntity implements Minecar
     private Vector3d derailedMod = new Vector3d(0.5D, 0.5D, 0.5D);
 
     // this method overwrites vanilla behavior to allow for a custom deceleration rate when derailed
-    @Inject(method = "moveDerailedMinecart()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityMinecart;moveEntity(DDD)V"))
+    @Inject(method = "moveDerailedMinecart()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityMinecart;moveEntity(DDD)V"), require = 1)
     public void implementCustomDerailedDeceleration(CallbackInfo ci) {
         if (this.isOnGround()) {
             this.motionX /= 0.5D;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityOcelot.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityOcelot.java
@@ -53,7 +53,7 @@ public abstract class MixinEntityOcelot extends MixinEntityTameable implements O
 
     private ItemStack currentItemStack;
 
-    @Inject(method = "interact", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/EntityOcelot;isTamed()Z", shift = At.Shift.BEFORE, ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "interact", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/EntityOcelot;isTamed()Z", shift = At.Shift.BEFORE, ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void afterGetCurrentItem(EntityPlayer player, CallbackInfoReturnable<Boolean> cir, ItemStack currentItemStack) {
         if (currentItemStack != null) {
             this.currentItemStack = currentItemStack.copy();
@@ -67,7 +67,7 @@ public abstract class MixinEntityOcelot extends MixinEntityTameable implements O
         this.currentItemStack = player.inventory.getCurrentItem().copy();
     }
 
-    @Redirect(method = "interact", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0, remap = false))
+    @Redirect(method = "interact", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0, remap = false), require = 1)
     public int onTame(Random rand, int bound, EntityPlayer player) {
         int random = rand.nextInt(bound);
         if (random == 0 && !SpongeImpl

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityVillager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityVillager.java
@@ -68,7 +68,7 @@ public abstract class MixinEntityVillager extends MixinEntityAgeable implements 
     private Career spongeCareer;
 
     @SuppressWarnings("unchecked")
-    @Inject(method = "setProfession(I)V", at = @At("RETURN"))
+    @Inject(method = "setProfession(I)V", at = @At("RETURN"), require = 1)
     public void onSetProfession(int professionId, CallbackInfo ci) {
 //        this.profession = ((List<? extends Profession>) Sponge.getGame().getRegistry().getAllOf(Profession.class)).get(professionId);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityWolf.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/passive/MixinEntityWolf.java
@@ -72,14 +72,14 @@ public abstract class MixinEntityWolf extends MixinEntityAnimal implements Wolf 
         this.shadow$setAngry(angry);
     }
 
-    @Inject(method = "interact", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/EntityWolf;isTamed()Z", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "interact", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/EntityWolf;isTamed()Z", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void afterGetCurrentItem(EntityPlayer player, CallbackInfoReturnable<Boolean> cir, ItemStack currentItemStack) {
         if (currentItemStack != null) {
             this.currentItemStack = currentItemStack.copy();
         }
     }
 
-    @Redirect(method = "interact", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0, remap = false))
+    @Redirect(method = "interact", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 0, remap = false), require = 1)
     public int onTame(Random rand, int bound, EntityPlayer player) {
         int random = rand.nextInt(bound);
         if (random == 0 && !SpongeImpl

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
@@ -80,7 +80,7 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
     @Shadow protected FoodStats foodStats;
     private boolean affectsSpawning = true;
 
-    @Inject(method = "getDisplayName", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "getDisplayName", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void onGetDisplayName(CallbackInfoReturnable<IChatComponent> ci, ChatComponentText component) {
         ci.setReturnValue(LegacyTexts.parseComponent(component, SpongeTexts.COLOR_CHAR));
     }
@@ -133,7 +133,7 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
         this.capabilities.isFlying = flying;
     }
 
-    @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isPlayerSleeping()Z"))
+    @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isPlayerSleeping()Z"), require = 1)
     public boolean onIsPlayerSleeping(EntityPlayer self) {
         if (self.isPlayerSleeping()) {
             if (!this.worldObj.isRemote) {
@@ -150,7 +150,7 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
      * @author gabizou - January 4th, 2016
      * This is necessary for invisibility checks so that invisible players don't actually send the particle stuffs.
      */
-    @Redirect(method = "updateItemUse", at = @At(value = "INVOKE", target = WORLD_SPAWN_PARTICLE))
+    @Redirect(method = "updateItemUse", at = @At(value = "INVOKE", target = WORLD_SPAWN_PARTICLE), require = 1)
     public void spawnItemParticle(World world, EnumParticleTypes particleTypes, double xCoord, double yCoord, double zCoord, double xOffset,
             double yOffset, double zOffset, int ... p_175688_14_) {
         if (!this.isReallyREALLYInvisible()) {
@@ -163,7 +163,7 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
      *
      * This prevents sounds from being sent to the server by players who are invisible.
      */
-    @Redirect(method = "playSound", at = @At(value = "INVOKE", target = WORLD_PLAY_SOUND_AT))
+    @Redirect(method = "playSound", at = @At(value = "INVOKE", target = WORLD_PLAY_SOUND_AT), require = 1)
     public void playSound(World world, EntityPlayer player, String name, float volume, float pitch) {
         if (!this.isReallyREALLYInvisible()) {
             world.playSoundToNearExcept(player, name, volume, pitch);

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -135,13 +135,13 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     }
 
     @SuppressWarnings("rawtypes")
-    @Redirect(method = "onDeath", at = @At(value = "INVOKE", target = "Lnet/minecraft/scoreboard/Scoreboard;getObjectivesFromCriteria(Lnet/minecraft/scoreboard/IScoreObjectiveCriteria;)Ljava/util/Collection;"))
+    @Redirect(method = "onDeath", at = @At(value = "INVOKE", target = "Lnet/minecraft/scoreboard/Scoreboard;getObjectivesFromCriteria(Lnet/minecraft/scoreboard/IScoreObjectiveCriteria;)Ljava/util/Collection;"), require = 1)
     public Collection onGetObjectivesFromCriteria(net.minecraft.scoreboard.Scoreboard this$0, IScoreObjectiveCriteria criteria) {
         return this.getWorldScoreboard().getObjectivesFromCriteria(criteria);
     }
 
     @SuppressWarnings("unchecked")
-    @Inject(method = "onDeath", at = @At(value = "RETURN"))
+    @Inject(method = "onDeath", at = @At(value = "RETURN"), require = 1)
     public void onPlayerDeath(DamageSource damageSource, CallbackInfo ci) {
         IMixinWorld world = (IMixinWorld) this.worldObj;
         // Special case for players as sometimes tick capturing won't capture deaths

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinInventoryPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinInventoryPlayer.java
@@ -51,42 +51,42 @@ import java.util.Optional;
 
 @Mixin(InventoryPlayer.class)
 public abstract class MixinInventoryPlayer implements MinecraftInventoryAdapter, HumanInventory, IInventory {
-    
+
     protected SlotCollection slots;
     protected Fabric<IInventory> inventory;
     protected HumanInventoryLens lens;
-    
+
     private Humanoid carrier;
     private HotbarAdapter hotbar;
-    
-    @Inject(method = "<init>*", at = @At("RETURN"), remap = false)
+
+    @Inject(method = "<init>*", at = @At("RETURN"), remap = false, require = 1)
     private void onConstructed(EntityPlayer playerIn, CallbackInfo ci) {
         this.inventory = new DefaultInventoryFabric(this);
         this.slots = new SlotCollection.Builder().add(36).add(4, EquipmentSlotAdapter.class).build();
         this.lens = new HumanInventoryLens(this, this.slots);
         this.carrier = playerIn instanceof Humanoid ? (Humanoid) playerIn : null;
     }
-    
+
     @Override
     public Lens<IInventory, net.minecraft.item.ItemStack> getRootLens() {
         return this.lens;
     }
-    
+
     @Override
     public Fabric<IInventory> getInventory() {
         return this.inventory;
     }
-    
+
     @Override
     public Inventory getChild(Lens<IInventory, ItemStack> lens) {
         return null;
     }
-    
+
     @Override
     public Optional<Humanoid> getCarrier() {
         return Optional.ofNullable(this.carrier);
     }
-    
+
     @Override
     public Hotbar getHotbar() {
         if (this.hotbar == null) {
@@ -98,7 +98,7 @@ public abstract class MixinInventoryPlayer implements MinecraftInventoryAdapter,
     @Override
     public void notify(Object source, InventoryEventArgs eventArgs) {
     }
-    
+
     @Override
     public SlotProvider<IInventory, ItemStack> getSlotProvider() {
         return this.slots;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityEgg.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityEgg.java
@@ -38,8 +38,8 @@ public abstract class MixinEntityEgg extends MixinEntityThrowable implements Egg
     public double damageAmount;
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V", at =
-            @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z")
-        )
+            @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"),
+        require = 1)
     private float onAttackEntityFrom(float damage) {
         return (float) this.damageAmount;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityFishHook.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityFishHook.java
@@ -105,8 +105,8 @@ public abstract class MixinEntityFishHook extends MixinEntity implements FishHoo
     }
 
     @Redirect(method = "onUpdate()V", at =
-            @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z")
-        )
+            @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"),
+        require = 1)
     public boolean onAttackEntityFrom(net.minecraft.entity.Entity entity, DamageSource damageSource, float damage) {
         EntitySnapshot fishHookSnapshot = this.createSnapshot();
         FishingEvent.HookEntity event = SpongeEventFactory.createFishingEventHookEntity(

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityLargeFireball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityLargeFireball.java
@@ -44,13 +44,13 @@ public abstract class MixinEntityLargeFireball extends MixinEntityFireball imple
     private float damage = 6.0f;
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"), require = 1)
     protected float onAttackEntityFrom(float amount) {
         return this.damage;
     }
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V",
-        at = @At(value = "INVOKE", target = NEW_EXPLOSION_METHOD))
+        at = @At(value = "INVOKE", target = NEW_EXPLOSION_METHOD), require = 1)
     protected Entity newExplosion(Entity entityIn) {
         return (Entity) (Object) this;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySmallFireball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySmallFireball.java
@@ -38,7 +38,7 @@ public abstract class MixinEntitySmallFireball extends MixinEntityFireball imple
     private float damage = 5.0f;
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"), require = 1)
     protected float onAttackEntityFrom(float amount) {
         return this.damage;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySnowball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySnowball.java
@@ -39,7 +39,7 @@ public abstract class MixinEntitySnowball extends MixinEntityThrowable implement
     private boolean damageSet = false;
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
+            target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"), require = 1)
     private float onAttackEntityFrom(float damage) {
         return this.damageSet ? (float) this.damageAmount : damage;
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityWitherSkull.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityWitherSkull.java
@@ -39,7 +39,7 @@ public abstract class MixinEntityWitherSkull extends MixinEntityFireball impleme
     private boolean damageSet = false;
 
     @ModifyArg(method = "onImpact(Lnet/minecraft/util/MovingObjectPosition;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;attackEntityFrom(Lnet/minecraft/util/DamageSource;F)Z"), require = 1)
     protected float onAttackEntityFrom(float amount) {
         return (float) getDamage();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/event/cause/entity/damage/MixinDamageSource.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/event/cause/entity/damage/MixinDamageSource.java
@@ -56,7 +56,7 @@ public abstract class MixinDamageSource implements DamageSource {
 
     private DamageType apiDamageType;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstructed(String damageTypeIn, CallbackInfo ci) {
         final Optional<DamageType> damageType = DamageSourceToTypeProvider.getInstance().get(damageTypeIn);
         if (!damageType.isPresent()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/event/cause/entity/damage/MixinIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/event/cause/entity/damage/MixinIndirectEntityDamageSource.java
@@ -48,7 +48,7 @@ public abstract class MixinIndirectEntityDamageSource extends MixinEntityDamageS
 
     private Optional<User> owner;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     private void onConstruct(CallbackInfo callbackInfo) {
         this.owner = ((IMixinEntity) super.getSource()).getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinEnchantment.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinEnchantment.java
@@ -56,7 +56,7 @@ public abstract class MixinEnchantment implements Enchantment {
 
     private String id = "";
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstructed(int id, ResourceLocation resLoc, int weight, EnumEnchantmentType type, CallbackInfo ci) {
         this.id = resLoc.toString();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItem.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItem.java
@@ -59,7 +59,7 @@ public abstract class MixinItem implements ItemType, IMixinItem, SpongeGameDicti
     @Shadow
     public abstract String getUnlocalizedName();
 
-    @Inject(method = "registerItem(ILnet/minecraft/util/ResourceLocation;Lnet/minecraft/item/Item;)V", at = @At("RETURN"))
+    @Inject(method = "registerItem(ILnet/minecraft/util/ResourceLocation;Lnet/minecraft/item/Item;)V", at = @At("RETURN"), require = 1)
     private static void registerMinecraftItem(int id, ResourceLocation name, Item item, CallbackInfo ci) {
         ItemTypeRegistryModule.getInstance().registerAdditionalCatalog((ItemType) item);
     }
@@ -119,7 +119,7 @@ public abstract class MixinItem implements ItemType, IMixinItem, SpongeGameDicti
     protected final <T extends DataManipulator<T, ?>> T getData(ItemStack itemStack, Class<T> manipulatorClass) {
         return ((org.spongepowered.api.item.inventory.ItemStack) itemStack).get(manipulatorClass).get();
     }
-    
+
     @Override
     public ItemStack createDictionaryStack(int wildcardValue) {
         return new ItemStack((Item) (Object) this, 1, wildcardValue);

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemArmorMaterial.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemArmorMaterial.java
@@ -43,7 +43,7 @@ public abstract class MixinItemArmorMaterial implements ArmorType {
     // the texture, as the resource location is wrong.
     private String capitalizedName;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstruct(CallbackInfo ci) {
         this.capitalizedName = StringUtils.capitalize(this.name);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemBlock.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemBlock.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 @Mixin(net.minecraft.item.ItemBlock.class)
 public abstract class MixinItemBlock extends MixinItem {
 
-    @Inject(method = "<init>", at = @At(value = "RETURN"))
+    @Inject(method = "<init>", at = @At(value = "RETURN"), require = 1)
     public void onConstructed(Block block, CallbackInfo ci) {
         this.blockType = Optional.of((BlockType) block);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemEmptyMap.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemEmptyMap.java
@@ -36,7 +36,7 @@ import org.spongepowered.common.world.DimensionManager;
 @Mixin(ItemEmptyMap.class)
 public class MixinItemEmptyMap extends ItemMapBase {
 
-    @Redirect(method = "onItemRightClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getUniqueDataId(Ljava/lang/String;)I"))
+    @Redirect(method = "onItemRightClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getUniqueDataId(Ljava/lang/String;)I"), require = 1)
     private int getOverworldUniqueDataId(World worldIn, String key) {
         return DimensionManager.getWorldFromDimId(0).getUniqueDataId(key);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemMap.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemMap.java
@@ -42,7 +42,7 @@ public class MixinItemMap extends ItemMapBase {
         return DimensionManager.getWorldFromDimId(0).loadItemData(clazz, dataId);
     }
 
-    @Redirect(method = "getMapData", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getUniqueDataId(Ljava/lang/String;)I"))
+    @Redirect(method = "getMapData", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getUniqueDataId(Ljava/lang/String;)I"), require = 1)
     private int getOverworldUniqueDataId(World worldIn, String key) {
         return DimensionManager.getWorldFromDimId(0).getUniqueDataId(key);
     }
@@ -53,7 +53,7 @@ public class MixinItemMap extends ItemMapBase {
         DimensionManager.getWorldFromDimId(0).setItemData(dataId, data);
     }
 
-    @Redirect(method = "onCreated", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getUniqueDataId(Ljava/lang/String;)I"))
+    @Redirect(method = "onCreated", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getUniqueDataId(Ljava/lang/String;)I"), require = 1)
     private int onCreatedGetOverworldUniqueDataId(World worldIn, String key) {
         return DimensionManager.getWorldFromDimId(0).getUniqueDataId(key);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
@@ -87,21 +87,21 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
     @Shadow public abstract net.minecraft.item.ItemStack shadow$copy();
     @Shadow public abstract Item shadow$getItem();
 
-    @Inject(method = "writeToNBT", at = @At(value = "HEAD"))
+    @Inject(method = "writeToNBT", at = @At(value = "HEAD"), require = 1)
     private void onWrite(NBTTagCompound incoming, CallbackInfoReturnable<NBTTagCompound> info) {
         if (this.hasManipulators()) {
             writeToNbt(incoming);
         }
     }
 
-    @Inject(method = "readFromNBT", at = @At("RETURN"))
+    @Inject(method = "readFromNBT", at = @At("RETURN"), require = 1)
     private void onRead(NBTTagCompound compound, CallbackInfo info) {
         if (hasTagCompound() && getTagCompound().hasKey(NbtDataUtil.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
             readFromNbt(getTagCompound().getCompoundTag(NbtDataUtil.SPONGE_DATA));
         }
     }
 
-    @Inject(method = "copy", at = @At("RETURN"))
+    @Inject(method = "copy", at = @At("RETURN"), require = 1)
     private void onCopy(CallbackInfoReturnable<net.minecraft.item.ItemStack> info) {
         final net.minecraft.item.ItemStack itemStack = info.getReturnValue();
         if (hasManipulators()) { // no manipulators? no problem.
@@ -111,7 +111,7 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
         }
     }
 
-    @Inject(method = "splitStack", at = @At("RETURN"))
+    @Inject(method = "splitStack", at = @At("RETURN"), require = 1)
     private void onSplit(int amount, CallbackInfoReturnable<net.minecraft.item.ItemStack> info) {
         final net.minecraft.item.ItemStack itemStack = info.getReturnValue();
         if (hasManipulators()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemToolMaterial.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemToolMaterial.java
@@ -39,7 +39,7 @@ public abstract class MixinItemToolMaterial implements ToolType {
     private String name;
     private String capitalizedName;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onConstruct(CallbackInfo ci) {
         // This is a giant workaround due to being unable to refer to synthetic
         // methods provided by Enum and the base enum itself does not

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
@@ -91,7 +91,7 @@ public abstract class MixinContainer implements org.spongepowered.api.item.inven
      * Purpose: All player inventory changes that need to be synced to
      * client flow through this method. Overwrite is used as no mod
      * should be touching this method.
-     * 
+     *
      */
     @Overwrite
     public void detectAndSendChanges() {
@@ -120,7 +120,7 @@ public abstract class MixinContainer implements org.spongepowered.api.item.inven
         }
     }
 
-    @Inject(method = "putStackInSlot", at = @At(value = "HEAD") )
+    @Inject(method = "putStackInSlot", at = @At(value = "HEAD") , require = 1)
     public void onPutStackInSlot(int slotId, ItemStack itemstack, CallbackInfo ci) {
         if (this.captureInventory) {
             Slot slot = getSlot(slotId);

--- a/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
@@ -158,7 +158,7 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
      * @param tileentity Injected tilentity param
      * @param tileentitysign Injected tileentitysign param
      */
-    @Inject(method = "processUpdateSign", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/client/C12PacketUpdateSign;getLines()[Lnet/minecraft/util/IChatComponent;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT)
+    @Inject(method = "processUpdateSign", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/client/C12PacketUpdateSign;getLines()[Lnet/minecraft/util/IChatComponent;"), cancellable = true, locals = LocalCapture.CAPTURE_FAILSOFT, require = 1)
     public void callSignChangeEvent(C12PacketUpdateSign packetIn, CallbackInfo ci, WorldServer worldserver, BlockPos blockpos, TileEntity tileentity, TileEntitySign tileentitysign) {
         ci.cancel();
 
@@ -295,12 +295,12 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
         return input;
     }
 
-    @Inject(method = "setPlayerLocation(DDDFFLjava/util/Set;)V", at = @At(value = "RETURN"))
+    @Inject(method = "setPlayerLocation(DDDFFLjava/util/Set;)V", at = @At(value = "RETURN"), require = 1)
     public void setPlayerLocation(double x, double y, double z, float yaw, float pitch, Set<?> relativeSet, CallbackInfo ci) {
         this.justTeleported = true;
     }
 
-    @Inject(method = "processPlayer", at = @At(value = "FIELD", target = "net.minecraft.network.NetHandlerPlayServer.hasMoved:Z", ordinal = 2), cancellable = true)
+    @Inject(method = "processPlayer", at = @At(value = "FIELD", target = "net.minecraft.network.NetHandlerPlayServer.hasMoved:Z", ordinal = 2), cancellable = true, require = 1)
     public void proccesPlayerMoved(C03PacketPlayer packetIn, CallbackInfo ci){
         if (packetIn.isMoving() || packetIn.getRotating() && !this.playerEntity.isDead) {
             Player player = (Player) this.playerEntity;
@@ -379,7 +379,7 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
         event.getMessage().ifPresent(text -> event.getChannel().ifPresent(channel -> channel.send(text)));
     }
 
-    @Inject(method = "handleResourcePackStatus", at = @At("HEAD"))
+    @Inject(method = "handleResourcePackStatus", at = @At("HEAD"), require = 1)
     public void onResourcePackStatus(C19PacketResourcePackStatus packet, CallbackInfo ci) {
         String hash = packet.hash;
         ResourcePackStatusEvent.ResourcePackStatus status;
@@ -407,7 +407,7 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
             (Player)this.playerEntity, status));
     }
 
-    @Inject(method = "sendPacket", at = @At("HEAD"))
+    @Inject(method = "sendPacket", at = @At("HEAD"), require = 1)
     public void onResourcePackSend(Packet packet, CallbackInfo ci) {
         if (packet instanceof IMixinPacketResourcePackSend) {
             IMixinPacketResourcePackSend p = (IMixinPacketResourcePackSend) packet;
@@ -415,7 +415,7 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
         }
     }
 
-    @Inject(method = "processPlayerBlockPlacement", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "processPlayerBlockPlacement", at = @At("HEAD"), cancellable = true, require = 1)
     public void injectBlockPlacement(C08PacketPlayerBlockPlacement packetIn, CallbackInfo ci) {
         // This is a horrible hack needed because the client sends 2 packets on 'right mouse click'
         // aimed at a block. We shouldn't need to get the second packet if the data is handled
@@ -437,7 +437,7 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
         }
     }
 
-    @Redirect(method = "processPlayerBlockPlacement", at = @At(value = "INVOKE", target="Lnet/minecraft/server/management/ItemInWorldManager;activateBlockOrUseItem(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/BlockPos;Lnet/minecraft/util/EnumFacing;FFF)Z"))
+    @Redirect(method = "processPlayerBlockPlacement", at = @At(value = "INVOKE", target="Lnet/minecraft/server/management/ItemInWorldManager;activateBlockOrUseItem(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/BlockPos;Lnet/minecraft/util/EnumFacing;FFF)Z"), require = 1)
     public boolean onActivateBlockOrUseItem(ItemInWorldManager itemManager, EntityPlayer player, net.minecraft.world.World worldIn, ItemStack stack, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ) {
         boolean result = itemManager.activateBlockOrUseItem(player, worldIn, stack, pos, side, hitX, hitY, hitZ);
         if (stack != null && !result) {
@@ -451,38 +451,38 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
         return result;
     }
 
-    @Inject(method = "processClickWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;slotClick(IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;", ordinal = 0))
+    @Inject(method = "processClickWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/inventory/Container;slotClick(IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;", ordinal = 0), require = 1)
     public void onBeforeSlotClick(C0EPacketClickWindow packetIn, CallbackInfo ci) {
         ((IMixinContainer) this.playerEntity.openContainer).setCaptureInventory(true);
     }
 
-    @Inject(method = "processClickWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;updateCraftingInventory(Lnet/minecraft/inventory/Container;Ljava/util/List;)V", shift = At.Shift.AFTER))
+    @Inject(method = "processClickWindow", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;updateCraftingInventory(Lnet/minecraft/inventory/Container;Ljava/util/List;)V", shift = At.Shift.AFTER), require = 1)
     public void onAfterSecondUpdateCraftingInventory(C0EPacketClickWindow packetIn, CallbackInfo ci) {
         ((IMixinContainer) this.playerEntity.openContainer).setCaptureInventory(false);
     }
 
-    @Inject(method = "processClickWindow", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayerMP;isChangingQuantityOnly:Z", shift = At.Shift.AFTER, ordinal = 1))
+    @Inject(method = "processClickWindow", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayerMP;isChangingQuantityOnly:Z", shift = At.Shift.AFTER, ordinal = 1), require = 1)
     public void onThirdUpdateCraftingInventory(C0EPacketClickWindow packetIn, CallbackInfo ci) {
         ((IMixinContainer) this.playerEntity.openContainer).setCaptureInventory(false);
     }
 
-    @Inject(method = "processCreativeInventoryAction", at = @At(value = "HEAD"))
+    @Inject(method = "processCreativeInventoryAction", at = @At(value = "HEAD"), require = 1)
     public void onProcessCreativeInventoryActionHead(C10PacketCreativeInventoryAction packetIn, CallbackInfo ci) {
         ((IMixinContainer) this.playerEntity.inventoryContainer).setCaptureInventory(true);
     }
 
-    @Inject(method = "processCreativeInventoryAction", at = @At(value = "RETURN"))
+    @Inject(method = "processCreativeInventoryAction", at = @At(value = "RETURN"), require = 1)
     public void onProcessCreativeInventoryActionReturn(C10PacketCreativeInventoryAction packetIn, CallbackInfo ci) {
         ((IMixinContainer) this.playerEntity.inventoryContainer).setCaptureInventory(false);
     }
 
-    @Inject(method = "processHeldItemChange", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/client/C09PacketHeldItemChange;getSlotId()I", ordinal = 2), cancellable = true)
+    @Inject(method = "processHeldItemChange", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/play/client/C09PacketHeldItemChange;getSlotId()I", ordinal = 2), cancellable = true, require = 1)
     public void onGetSlotId(C09PacketHeldItemChange packetIn, CallbackInfo ci) {
         SpongeCommonEventFactory.callChangeInventoryHeldEvent(this.playerEntity, packetIn);
         ci.cancel();
     }
 
-    @Redirect(method = "processUseEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;attackTargetEntityWithCurrentItem(Lnet/minecraft/entity/Entity;)V"))
+    @Redirect(method = "processUseEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;attackTargetEntityWithCurrentItem(Lnet/minecraft/entity/Entity;)V"), require = 1)
     public void onAttackTargetEntity(EntityPlayerMP player, net.minecraft.entity.Entity entityIn) {
         if (entityIn instanceof Player && !((World) player.worldObj).getProperties().isPVPEnabled()) {
             return; // PVP is disabled, ignore

--- a/src/main/java/org/spongepowered/common/mixin/core/network/packet/MixinS3BPacketScoreboardObjective.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/packet/MixinS3BPacketScoreboardObjective.java
@@ -38,7 +38,7 @@ public class MixinS3BPacketScoreboardObjective {
 
     @Shadow public IScoreObjectiveCriteria.EnumRenderType type;
 
-    @Inject(method = "<init>(Lnet/minecraft/scoreboard/ScoreObjective;I)V", at = @At("RETURN"), remap = false)
+    @Inject(method = "<init>(Lnet/minecraft/scoreboard/ScoreObjective;I)V", at = @At("RETURN"), remap = false, require = 1)
     public void onInit(ScoreObjective objective, int i, CallbackInfo ci) {
         this.type = objective.getRenderType();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/network/packet/MixinS48PacketResourcePackSend.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/packet/MixinS48PacketResourcePackSend.java
@@ -43,7 +43,7 @@ public abstract class MixinS48PacketResourcePackSend implements IMixinPacketReso
     @Shadow private String hash;
     private ResourcePack pack;
 
-    @Inject(method = "<init>(Ljava/lang/String;Ljava/lang/String;)V", at = @At("RETURN") , remap = false)
+    @Inject(method = "<init>(Ljava/lang/String;Ljava/lang/String;)V", at = @At("RETURN") , remap = false, require = 1)
     public void setResourcePack(String url, String hash, CallbackInfo ci) {
         try {
             this.pack = SpongeResourcePack.create(url, hash);

--- a/src/main/java/org/spongepowered/common/mixin/core/network/rcon/MixinRConConsoleSource.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/rcon/MixinRConConsoleSource.java
@@ -74,7 +74,7 @@ public abstract class MixinRConConsoleSource implements ICommandSender, IMixinCo
      * Add newlines between output lines for a command
      * @param component
      */
-    @Inject(method = "addChatMessage", at = @At("RETURN"))
+    @Inject(method = "addChatMessage", at = @At("RETURN"), require = 1)
     public void addNewlines(IChatComponent component, CallbackInfo ci) {
         this.buffer.append('\n');
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/network/rcon/MixinRConThreadClient.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/rcon/MixinRConThreadClient.java
@@ -83,7 +83,7 @@ public abstract class MixinRConThreadClient extends RConThreadBase implements Re
     }
 
     @Redirect(method = "run", at = @At(value = "INVOKE", target = "net.minecraft.network.rcon.IServer.handleRConCommand(Ljava/lang/String;)"
-            + "Ljava/lang/String;"))
+            + "Ljava/lang/String;"), require = 1)
     public String commandExecutionHook(IServer server, String commandStr) {
         try {
             synchronized (this.clientSocket) {
@@ -99,7 +99,7 @@ public abstract class MixinRConThreadClient extends RConThreadBase implements Re
     }
 
     @Inject(method = "run", at = @At(value = "INVOKE", target = "net.minecraft.network.rcon.RConThreadClient.sendResponse(IILjava/lang/String;)V",
-            shift = At.Shift.BEFORE))
+            shift = At.Shift.BEFORE), require = 1)
     public void rconLoginCallback(CallbackInfo ci) throws IOException {
         if (this.source == null) {
             initSource();
@@ -113,7 +113,7 @@ public abstract class MixinRConThreadClient extends RConThreadBase implements Re
         }
     }
 
-    @Inject(method = "closeSocket", at = @At("HEAD"))
+    @Inject(method = "closeSocket", at = @At("HEAD"), require = 1)
     public void rconLogoutCallback(CallbackInfo ci){
         if (this.source == null) {
             initSource();

--- a/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScore.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScore.java
@@ -55,7 +55,7 @@ public abstract class MixinScore implements IMixinScore {
         this.spongeScore = score;
     }
 
-    @Inject(method = "setScorePoints", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "setScorePoints", at = @At("HEAD"), cancellable = true, require = 1)
     public void onSetScorePoints(int points, CallbackInfo ci) {
         if (this.theScoreboard != null && ((IMixinScoreboard) this.theScoreboard).isClient()) {
             return; // Let the normal logic take over.

--- a/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreObjective.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreObjective.java
@@ -58,7 +58,7 @@ public abstract class MixinScoreObjective implements IMixinScoreObjective {
         this.spongeObjective = spongeObjective;
     }
 
-    @Inject(method = "setDisplayName", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "setDisplayName", at = @At("HEAD"), cancellable = true, require = 1)
     public void onSetDisplayName(String name, CallbackInfo ci) {
         if (this.theScoreboard != null && ((IMixinScoreboard) this.theScoreboard).isClient()) {
             return; // Let the normal logic take over.
@@ -73,7 +73,7 @@ public abstract class MixinScoreObjective implements IMixinScoreObjective {
         ci.cancel();
     }
 
-    @Inject(method = "setRenderType", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "setRenderType", at = @At("HEAD"), cancellable = true, require = 1)
     public void onSetRenderType(IScoreObjectiveCriteria.EnumRenderType type, CallbackInfo ci) {
         if (this.theScoreboard != null && ((IMixinScoreboard) this.theScoreboard).isClient()) {
             return; // Let the normal logic take over.

--- a/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScorePlayerTeam.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScorePlayerTeam.java
@@ -87,7 +87,7 @@ public abstract class MixinScorePlayerTeam extends net.minecraft.scoreboard.Team
         }
     }
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onInit(CallbackInfo ci) {
         // Initialize cached values
         this.displayName = SpongeTexts.fromLegacy(this.teamNameSPT);
@@ -226,63 +226,63 @@ public abstract class MixinScorePlayerTeam extends net.minecraft.scoreboard.Team
         return true;
     }
 
-    @Redirect(method = "setTeamName", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE))
+    @Redirect(method = "setTeamName", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE), require = 1)
     private void onSetTeamName(Scoreboard scoreboard, ScorePlayerTeam team) {
         this.doTeamUpdate();
     }
 
-    @Inject(method = "setTeamName", at = @At("HEAD"))
+    @Inject(method = "setTeamName", at = @At("HEAD"), require = 1)
     public void onSetTeamName(String name, CallbackInfo ci) {
         if (name != null) {
             this.displayName = SpongeTexts.fromLegacy(name);
         }
     }
 
-    @Redirect(method = "setNamePrefix", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE))
+    @Redirect(method = "setNamePrefix", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE), require = 1)
     private void onSetNamePrefix(Scoreboard scoreboard, ScorePlayerTeam team) {
         this.doTeamUpdate();
     }
 
-    @Inject(method = "setNamePrefix", at = @At("HEAD"))
+    @Inject(method = "setNamePrefix", at = @At("HEAD"), require = 1)
     public void onSetNamePrefix(String prefix, CallbackInfo ci) {
         if (prefix != null) {
             this.prefix = SpongeTexts.fromLegacy(prefix);
         }
     }
 
-    @Redirect(method = "setNameSuffix", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE))
+    @Redirect(method = "setNameSuffix", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE), require = 1)
     private void onSetNameSuffix(Scoreboard scoreboard, ScorePlayerTeam team) {
         this.doTeamUpdate();
     }
 
-    @Inject(method = "setNameSuffix", at = @At("HEAD"))
+    @Inject(method = "setNameSuffix", at = @At("HEAD"), require = 1)
     public void onSetNameSuffix(String suffix, CallbackInfo ci) {
         if (suffix != null) {
             this.suffix = SpongeTexts.fromLegacy(suffix);
         }
     }
 
-    @Redirect(method = "setAllowFriendlyFire", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE))
+    @Redirect(method = "setAllowFriendlyFire", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE), require = 1)
     private void onSetAllowFriendlyFire(Scoreboard scoreboard, ScorePlayerTeam team) {
         this.doTeamUpdate();
     }
 
-    @Redirect(method = "setSeeFriendlyInvisiblesEnabled", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE))
+    @Redirect(method = "setSeeFriendlyInvisiblesEnabled", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE), require = 1)
     private void onSetSeeFriendlyInvisiblesEnabled(Scoreboard scoreboard, ScorePlayerTeam team) {
         this.doTeamUpdate();
     }
 
-    @Redirect(method = "setNameTagVisibility", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE))
+    @Redirect(method = "setNameTagVisibility", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE), require = 1)
     private void onSetNameTagVisibility(Scoreboard scoreboard, ScorePlayerTeam team) {
         this.doTeamUpdate();
     }
 
-    @Redirect(method = "setDeathMessageVisibility", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE))
+    @Redirect(method = "setDeathMessageVisibility", at = @At(value = "INVOKE", target = TEAM_UPDATE_SIGNATURE), require = 1)
     private void onSetDeathMessageVisibility(Scoreboard scoreboard, ScorePlayerTeam team) {
         this.doTeamUpdate();
     }
 
-    @Inject(method = "setChatFormat", at = @At("RETURN"))
+    @Inject(method = "setChatFormat", at = @At("RETURN"), require = 1)
     private void onSetChatFormat(EnumChatFormatting format, CallbackInfo ci) {
         this.color = TextColorRegistryModule.enumChatColor.get(format);
         // This isn't called by Vanilla, so we inject the call ourselves.

--- a/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreboardClientCheck.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreboardClientCheck.java
@@ -37,7 +37,7 @@ public abstract class MixinScoreboardClientCheck implements IMixinScoreboard {
 
     private boolean isClient;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onInit(CallbackInfo ci) {
         this.isClient = !(((Object) this) instanceof ServerScoreboard);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreboardLogic.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreboardLogic.java
@@ -112,7 +112,7 @@ public abstract class MixinScoreboardLogic extends Scoreboard implements IMixinS
         ((SpongeObjective) objective).updateScores(this);
     }
 
-    @Inject(method = "onScoreObjectiveAdded", at = @At("RETURN"))
+    @Inject(method = "onScoreObjectiveAdded", at = @At("RETURN"), require = 1)
     public void onOnScoreObjectiveAdded(ScoreObjective objective, CallbackInfo ci) {
         this.sendToPlayers(new S3BPacketScoreboardObjective(objective, SpongeScoreboardConstants.OBJECTIVE_PACKET_ADD));
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinServerScoreboardPacketSending.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinServerScoreboardPacketSending.java
@@ -115,22 +115,22 @@ public abstract class MixinServerScoreboardPacketSending extends Scoreboard impl
         }
     }
 
-    @Redirect(method = "func_96536_a", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "func_96536_a", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onUpdateScoreValue(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
-    @Redirect(method = "func_96536_a", at = @At(value = "INVOKE", target = SET_CONTAINS))
+    @Redirect(method = "func_96536_a", at = @At(value = "INVOKE", target = SET_CONTAINS), require = 1)
     public boolean onUpdateScoreValue(Set set, Object object) {
         return true;
     }
 
-    @Redirect(method = "func_96516_a", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "func_96516_a", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onRemoveScore(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
-    @Redirect(method = "func_178820_a", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "func_178820_a", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onRemoveScoreForObjective(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
@@ -140,56 +140,56 @@ public abstract class MixinServerScoreboardPacketSending extends Scoreboard impl
         this.sendToPlayers(packet);
     }*/
 
-    @Redirect(method = "addPlayerToTeam", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "addPlayerToTeam", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onAddPlayerToTeam(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
-    @Redirect(method = "removePlayerFromTeam", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "removePlayerFromTeam", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onRemovePlayerFromTeam(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
-    @Redirect(method = "func_96532_b", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "func_96532_b", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onUpdateObjective(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
-    @Redirect(method = "func_96532_b", at = @At(value = "INVOKE", target = SET_CONTAINS))
+    @Redirect(method = "func_96532_b", at = @At(value = "INVOKE", target = SET_CONTAINS), require = 1)
     public boolean onUpdateObjective(Set set, Object object) {
         return true;
     }
 
-    @Redirect(method = "func_96533_c", at = @At(value = "INVOKE", target = SET_CONTAINS))
+    @Redirect(method = "func_96533_c", at = @At(value = "INVOKE", target = SET_CONTAINS), require = 1)
     public boolean onSendDisplayPackets(Set set, Object object) {
         return true;
     }
 
-    @Redirect(method = "broadcastTeamCreated", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "broadcastTeamCreated", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onBroadcastTeamCreated(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
-    @Redirect(method = "sendTeamUpdate", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "sendTeamUpdate", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onSendTeamUpdate(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
-    @Redirect(method = "func_96513_c", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD))
+    @Redirect(method = "func_96513_c", at = @At(value = "INVOKE", target = SEND_PACKET_METHOD), require = 1)
     public void onRemoveTeam(ServerConfigurationManager manager, Packet packet) {
         this.sendToPlayers(packet);
     }
 
     @SuppressWarnings("rawtypes")
     @Redirect(method = "func_96549_e", at = @At(value = "INVOKE", target = "Ljava/util/List;iterator()Ljava/util/Iterator;", ordinal = 0, remap =
-            false))
+            false), require = 1)
     public Iterator onGetPlayerIteratorForObjectives(List list) {
         return this.players.iterator();
     }
 
     @SuppressWarnings("rawtypes")
     @Redirect(method = "getPlayerIterator", at = @At(value = "INVOKE", target = "Ljava/util/List;iterator()Ljava/util/Iterator;", ordinal = 0, remap =
-            false))
+            false), require = 1)
     public Iterator onGetPlayerIterator(List list) {
         return this.players.iterator();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinDedicatedServer.java
@@ -63,7 +63,7 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
         this.guiIsEnabled = false;
     }
 
-    @Inject(method = "systemExitNow", at = @At("HEAD"))
+    @Inject(method = "systemExitNow", at = @At("HEAD"), require = 1)
     public void postGameStoppingEvent(CallbackInfo ci) {
         SpongeImpl.postShutdownEvents();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
@@ -308,7 +308,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
         initiateShutdown();
     }
 
-    @Inject(method = "stopServer()V", at = @At("HEAD"))
+    @Inject(method = "stopServer()V", at = @At("HEAD"), require = 1)
     public void onServerStopping(CallbackInfo ci) {
         ((MinecraftServer) (Object) this).getPlayerProfileCache().save();
     }
@@ -913,7 +913,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
         return Optional.ofNullable(this.resourcePack);
     }
 
-    @Inject(method = "setResourcePack(Ljava/lang/String;Ljava/lang/String;)V", at = @At("HEAD") )
+    @Inject(method = "setResourcePack(Ljava/lang/String;Ljava/lang/String;)V", at = @At("HEAD") , require = 1)
     public void onSetResourcePack(String url, String hash, CallbackInfo ci) {
         if (url.length() == 0) {
             this.resourcePack = null;
@@ -931,7 +931,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
         this.enableSaving = enabled;
     }
 
-    @Inject(method = "saveAllWorlds(Z)V", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "saveAllWorlds(Z)V", at = @At("HEAD"), cancellable = true, require = 1)
     private void onSaveWorlds(boolean dontLog, CallbackInfo ci) {
         if (!this.enableSaving) {
             ci.cancel();
@@ -948,7 +948,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
         return Optional.empty();
     }
 
-    @Inject(method = "getTabCompletions", at = @At(value = "RETURN", ordinal = 1), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "getTabCompletions", at = @At(value = "RETURN", ordinal = 1), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void onTabCompleteChat(ICommandSender sender, String input, BlockPos pos, CallbackInfoReturnable<List> cir, ArrayList arraylist, String astring[], String s1, String astring1[], int i) {
         TabCompleteEvent.Chat event = SpongeEventFactory.createTabCompleteEventChat(Cause.of(sender), ImmutableList.copyOf(arraylist), arraylist, input);
         Sponge.getEventManager().post(event);

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinNetHandlerHandshakeTCP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinNetHandlerHandshakeTCP.java
@@ -39,7 +39,7 @@ public abstract class MixinNetHandlerHandshakeTCP {
 
     @Shadow private NetworkManager networkManager;
 
-    @Inject(method = "processHandshake", at = @At("HEAD"))
+    @Inject(method = "processHandshake", at = @At("HEAD"), require = 1)
     public void onProcessHandshake(C00Handshake packetIn, CallbackInfo ci) {
         IMixinNetworkManager info = (IMixinNetworkManager) this.networkManager;
         info.setVersion(packetIn.getProtocolVersion());

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
@@ -490,7 +490,7 @@ public abstract class MixinServerConfigurationManager {
         }
     }
 
-    @Inject(method = "playerLoggedOut(Lnet/minecraft/entity/player/EntityPlayerMP;)V", at = @At("HEAD"))
+    @Inject(method = "playerLoggedOut(Lnet/minecraft/entity/player/EntityPlayerMP;)V", at = @At("HEAD"), require = 1)
     private void onPlayerLogOut(EntityPlayerMP player, CallbackInfo ci) {
         // Synchronise with user object
         NBTTagCompound nbt = new NBTTagCompound();
@@ -498,7 +498,7 @@ public abstract class MixinServerConfigurationManager {
         ((SpongeUser) ((IMixinEntityPlayerMP) player).getUserObject()).readFromNbt(nbt);
     }
 
-    @Inject(method = "saveAllPlayerData()V", at = @At("RETURN"))
+    @Inject(method = "saveAllPlayerData()V", at = @At("RETURN"), require = 1)
     private void onSaveAllPlayerData(CallbackInfo ci) {
         for (SpongeUser user : SpongeUser.dirtyUsers) {
             user.save();

--- a/src/main/java/org/spongepowered/common/mixin/core/server/network/MixinNetHandlerLoginServerAnonThread.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/network/MixinNetHandlerLoginServerAnonThread.java
@@ -42,7 +42,7 @@ public class MixinNetHandlerLoginServerAnonThread extends Thread {
     private IMixinNetHandlerLoginServer outerRef = (IMixinNetHandlerLoginServer) this.field_180221_a;
 
     @Inject(method = "run()V", at = @At(value = "JUMP", opcode = Opcodes.IFNULL, ordinal = 0, shift = At.Shift.AFTER),
-            remap = false, cancellable = true)
+            remap = false, cancellable = true, require = 1)
     public void fireAuthEvent(CallbackInfo ci) {
         if (this.outerRef.fireAuthEvent()) {
             ci.cancel();

--- a/src/main/java/org/spongepowered/common/mixin/core/status/MixinServerStatusResponse.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/status/MixinServerStatusResponse.java
@@ -60,7 +60,7 @@ public abstract class MixinServerStatusResponse implements ClientPingServerEvent
     private ServerStatusResponse.PlayerCountData playerBackup;
     private Favicon faviconHandle;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     public void onInit(CallbackInfo ci) {
         setServerDescription(null);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/util/MixinPacketThreadUtil.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/util/MixinPacketThreadUtil.java
@@ -45,7 +45,7 @@ import org.spongepowered.common.util.StaticMixinHelper;
 @Mixin(targets = "net/minecraft/network/PacketThreadUtil$1")
 public class MixinPacketThreadUtil {
 
-    @Redirect(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/Packet;processPacket(Lnet/minecraft/network/INetHandler;)V") )
+    @Redirect(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/Packet;processPacket(Lnet/minecraft/network/INetHandler;)V") , require = 1)
     public void onProcessPacket(Packet packetIn, INetHandler netHandler) {
         if (netHandler instanceof NetHandlerPlayServer) {
             StaticMixinHelper.processingPacket = packetIn;
@@ -71,7 +71,7 @@ public class MixinPacketThreadUtil {
                     resetStaticData();
                     return;
                 }
-                
+
                 long packetDiff = System.currentTimeMillis() - StaticMixinHelper.lastInventoryOpenPacketTimeStamp;
                 // If the time between packets is small enough, mark the current packet to be ignored for our event handler.
                 if (packetDiff < 100) {
@@ -91,7 +91,7 @@ public class MixinPacketThreadUtil {
                         return;
                     }
                 }
-                
+
             }*/
 
             //System.out.println("RECEIVED PACKET " + packetIn);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinChunk.java
@@ -146,7 +146,7 @@ public abstract class MixinChunk implements Chunk, IMixinChunk {
     @Shadow(prefix = "shadow$")
     public abstract Block shadow$getBlock(int x, int y, int z);
 
-    @Inject(method = "<init>(Lnet/minecraft/world/World;II)V", at = @At("RETURN"), remap = false)
+    @Inject(method = "<init>(Lnet/minecraft/world/World;II)V", at = @At("RETURN"), remap = false, require = 1)
     public void onConstructed(World world, int x, int z, CallbackInfo ci) {
         this.chunkPos = new Vector3i(x, 0, z);
         this.blockMin = SpongeChunkLayout.instance.toWorld(this.chunkPos).get();
@@ -160,14 +160,14 @@ public abstract class MixinChunk implements Chunk, IMixinChunk {
         }
     }
 
-    @Inject(method = "onChunkLoad()V", at = @At("RETURN"))
+    @Inject(method = "onChunkLoad()V", at = @At("RETURN"), require = 1)
     public void onChunkLoadInject(CallbackInfo ci) {
         if (!this.worldObj.isRemote) {
             SpongeHooks.logChunkLoad(this.worldObj, this.chunkPos);
         }
     }
 
-    @Inject(method = "onChunkUnload()V", at = @At("RETURN"))
+    @Inject(method = "onChunkUnload()V", at = @At("RETURN"), require = 1)
     public void onChunkUnloadInject(CallbackInfo ci) {
         if (!this.worldObj.isRemote) {
             SpongeHooks.logChunkUnload(this.worldObj, this.chunkPos);
@@ -364,7 +364,7 @@ public abstract class MixinChunk implements Chunk, IMixinChunk {
     }
 
     @SuppressWarnings({"unchecked"})
-    @Inject(method = "getEntitiesWithinAABBForEntity", at = @At(value = "RETURN"))
+    @Inject(method = "getEntitiesWithinAABBForEntity", at = @At(value = "RETURN"), require = 1)
     public void onGetEntitiesWithinAABBForEntity(Entity entityIn, AxisAlignedBB aabb, List<Entity> listToFill, Predicate<Entity> p_177414_4_, CallbackInfo ci) {
         if (this.worldObj.isRemote) {
             return;
@@ -385,7 +385,7 @@ public abstract class MixinChunk implements Chunk, IMixinChunk {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @Inject(method = "getEntitiesOfTypeWithinAAAB", at = @At(value = "RETURN"))
+    @Inject(method = "getEntitiesOfTypeWithinAAAB", at = @At(value = "RETURN"), require = 1)
     public void onGetEntitiesOfTypeWithinAAAB(Class<? extends Entity> entityClass, AxisAlignedBB aabb, List listToFill, Predicate<Entity> p_177430_4_, CallbackInfo ci) {
         if (this.worldObj.isRemote) {
             return;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinExplosion.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinExplosion.java
@@ -58,7 +58,7 @@ public abstract class MixinExplosion implements Explosion, IMixinExplosion {
     @SuppressWarnings("rawtypes")
     @Shadow public List affectedBlockPositions;
 
-    @Inject(method = "<init>*", at = @At("RETURN"))
+    @Inject(method = "<init>*", at = @At("RETURN"), require = 1)
     public void onConstructed(net.minecraft.world.World world, Entity entity, double originX, double originY,
             double originZ, float radius, boolean isFlaming, boolean isSmoking,
             CallbackInfo ci) {
@@ -66,7 +66,7 @@ public abstract class MixinExplosion implements Explosion, IMixinExplosion {
         this.shouldBreakBlocks = true; // by default, all explosions do this can be changed by the explosion builder
     }
 
-    @Inject(method = "doExplosionA", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "doExplosionA", at = @At("HEAD"), cancellable = true, require = 1)
     public void onDoExplosionA(CallbackInfo ci) {
         if (!this.shouldBreakBlocks) {
             ci.cancel();

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinSpawnerAnimals.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinSpawnerAnimals.java
@@ -73,14 +73,14 @@ public abstract class MixinSpawnerAnimals {
     private static EntityType spawnerEntityType;
     private static Class<? extends Entity> spawnerEntityClass;
 
-    @Inject(method = "findChunksForSpawning", at = @At(value = "HEAD"))
+    @Inject(method = "findChunksForSpawning", at = @At(value = "HEAD"), require = 1)
     public void onFindChunksForSpawningHead(WorldServer worldServer, boolean spawnHostileMobs, boolean spawnPeacefulMobs, boolean spawnedOnSetTickRate, CallbackInfoReturnable<Integer> ci) {
         ((IMixinWorld) worldServer).setWorldSpawnerRunning(true);
         ((IMixinWorld) worldServer).setProcessingCaptureCause(true);
         spawnerStart = true;
     }
 
-    @Inject(method = "findChunksForSpawning", at = @At(value = "RETURN"))
+    @Inject(method = "findChunksForSpawning", at = @At(value = "RETURN"), require = 1)
     public void onFindChunksForSpawningReturn(WorldServer worldServer, boolean spawnHostileMobs, boolean spawnPeacefulMobs, boolean spawnedOnSetTickRate, CallbackInfoReturnable<Integer> ci) {
         ((IMixinWorld) worldServer).handlePostTickCaptures(Cause.of(NamedCause.source(worldServer)));
         ((IMixinWorld) worldServer).setWorldSpawnerRunning(false);
@@ -92,14 +92,14 @@ public abstract class MixinSpawnerAnimals {
         }
     }
 
-    @Inject(method = "performWorldGenSpawning", at = @At(value = "HEAD"))
+    @Inject(method = "performWorldGenSpawning", at = @At(value = "HEAD"), require = 1)
     private static void onPerformWorldGenSpawningHead(World worldServer, BiomeGenBase biome, int j, int k, int l, int m, Random rand, CallbackInfo ci) {
         ((IMixinWorld) worldServer).setChunkSpawnerRunning(true);
         ((IMixinWorld) worldServer).setProcessingCaptureCause(true);
         spawnerStart = true;
     }
 
-    @Inject(method = "performWorldGenSpawning", at = @At(value = "RETURN"))
+    @Inject(method = "performWorldGenSpawning", at = @At(value = "RETURN"), require = 1)
     private static void onPerformWorldGenSpawningReturn(World worldServer, BiomeGenBase biome, int j, int k, int l, int m, Random rand, CallbackInfo ci) {
         ((IMixinWorld) worldServer).handlePostTickCaptures(Cause.of(NamedCause.source(worldServer), NamedCause.of("Biome", biome)));
         ((IMixinWorld) worldServer).setChunkSpawnerRunning(false);
@@ -111,7 +111,7 @@ public abstract class MixinSpawnerAnimals {
         }
     }
 
-    @Redirect(method = "findChunksForSpawning", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isSpectator()Z"))
+    @Redirect(method = "findChunksForSpawning", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;isSpectator()Z"), require = 1)
     public boolean onFindChunksForSpawningEligiblePlayer(EntityPlayer player) {
         // We treat players who do not affect spawning as "spectators"
         return !((IMixinEntityPlayer) player).affectsSpawning() || player.isSpectator();
@@ -131,7 +131,7 @@ public abstract class MixinSpawnerAnimals {
      * @return True if the worldserver check was valid and if our event wasn't cancelled
      */
     @SuppressWarnings("unchecked")
-    @Redirect(method = "findChunksForSpawning", at = @At(value = "INVOKE", target = WORLD_CAN_SPAWN_CREATURE))
+    @Redirect(method = "findChunksForSpawning", at = @At(value = "INVOKE", target = WORLD_CAN_SPAWN_CREATURE), require = 1)
     public boolean onCanSpawn(WorldServer worldServer, EnumCreatureType creatureType, BiomeGenBase.SpawnListEntry spawnListEntry, BlockPos pos) {
         setEntityType(spawnListEntry.entityClass);
         return worldServer.canCreatureTypeSpawnHere(creatureType, spawnListEntry, pos) && check(pos, worldServer);
@@ -145,7 +145,7 @@ public abstract class MixinSpawnerAnimals {
      * @param pos
      * @return
      */
-    @Redirect(method = "performWorldGenSpawning", at = @At(value = "INVOKE", target = BIOME_CAN_SPAWN_ANIMAL))
+    @Redirect(method = "performWorldGenSpawning", at = @At(value = "INVOKE", target = BIOME_CAN_SPAWN_ANIMAL), require = 1)
     private static boolean onCanGenerate(EntityLiving.SpawnPlacementType type, World worldIn, BlockPos pos) {
         return SpawnerAnimals.canCreatureTypeSpawnAtLocation(type, worldIn, pos) && check(pos, worldIn);
     }
@@ -159,7 +159,7 @@ public abstract class MixinSpawnerAnimals {
      * @return
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @Redirect(method = "performWorldGenSpawning", at = @At(value = "INVOKE", target = WEIGHTED_RANDOM_GET))
+    @Redirect(method = "performWorldGenSpawning", at = @At(value = "INVOKE", target = WEIGHTED_RANDOM_GET), require = 1)
     private static WeightedRandom.Item onGetRandom(Random random, Collection collection) {
         BiomeGenBase.SpawnListEntry entry = (BiomeGenBase.SpawnListEntry) WeightedRandom.getRandomItem(random, collection);
         setEntityType(entry.entityClass);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -311,7 +311,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
 
     // @formatter:on
 
-    @Inject(method = "<init>", at = @At("RETURN") )
+    @Inject(method = "<init>", at = @At("RETURN") , require = 1)
     public void onConstructed(ISaveHandler saveHandlerIn, WorldInfo info, WorldProvider providerIn, Profiler profilerIn, boolean client,
             CallbackInfo ci) {
         if (SpongeImpl.getGame().getPlatform().getType() == Platform.Type.SERVER) {
@@ -424,7 +424,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         }
     }
 
-    @Redirect(method = "forceBlockUpdateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;updateTick(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;Ljava/util/Random;)V") )
+    @Redirect(method = "forceBlockUpdateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;updateTick(Lnet/minecraft/world/World;Lnet/minecraft/util/BlockPos;Lnet/minecraft/block/state/IBlockState;Ljava/util/Random;)V") , require = 1)
     public void onForceBlockUpdateTick(Block block, net.minecraft.world.World worldIn, BlockPos pos, IBlockState state, Random rand) {
         if (this.isRemote || this.currentTickBlock != null || ((IMixinWorld) worldIn).capturingTerrainGen()) {
             block.updateTick(worldIn, pos, state, rand);
@@ -439,7 +439,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         this.processingCaptureCause = false;
     }
 
-    @Redirect(method = "updateEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onUpdate()V") )
+    @Redirect(method = "updateEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onUpdate()V") , require = 1)
     public void onUpdateEntities(net.minecraft.entity.Entity entityIn) {
         if (this.isRemote || this.currentTickEntity != null) {
             entityIn.onUpdate();
@@ -454,7 +454,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         this.processingCaptureCause = false;
     }
 
-    @Redirect(method = "updateEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/gui/IUpdatePlayerListBox;update()V") )
+    @Redirect(method = "updateEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/gui/IUpdatePlayerListBox;update()V") , require = 1)
     public void onUpdateTileEntities(IUpdatePlayerListBox tile) {
         if (this.isRemote || this.currentTickTileEntity != null) {
             tile.update();
@@ -469,7 +469,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         this.processingCaptureCause = false;
     }
 
-    @Redirect(method = "updateEntityWithOptionalForce", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onUpdate()V") )
+    @Redirect(method = "updateEntityWithOptionalForce", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onUpdate()V") , require = 1)
     public void onCallEntityUpdate(net.minecraft.entity.Entity entity) {
         if (this.isRemote || this.currentTickEntity != null || StaticMixinHelper.packetPlayer != null) {
             entity.onUpdate();
@@ -484,7 +484,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         this.processingCaptureCause = false;
     }
 
-    @Inject(method = "onEntityRemoved", at = @At(value = "HEAD"))
+    @Inject(method = "onEntityRemoved", at = @At(value = "HEAD"), require = 1)
     public void onEntityRemoval(net.minecraft.entity.Entity entityIn, CallbackInfo ci) {
         if (entityIn.isDead && entityIn.getEntityId() != StaticMixinHelper.lastDestroyedEntityId && !(entityIn instanceof EntityLivingBase)) {
             MessageChannel originalChannel = MessageChannel.TO_NONE;
@@ -1517,7 +1517,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
     public abstract int getLightFor(EnumSkyBlock type, BlockPos pos);
 
     @SuppressWarnings("rawtypes")
-    @Inject(method = "getCollidingBoundingBoxes(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/AxisAlignedBB;)Ljava/util/List;", at = @At("HEAD") , cancellable = true)
+    @Inject(method = "getCollidingBoundingBoxes(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/AxisAlignedBB;)Ljava/util/List;", at = @At("HEAD") , cancellable = true, require = 1)
     public
             void onGetCollidingBoundingBoxes(net.minecraft.entity.Entity entity, AxisAlignedBB axis,
                     CallbackInfoReturnable<List> cir) {
@@ -1823,7 +1823,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         }
     }
 
-    @Inject(method = "updateWeather", at = @At(value = "RETURN"))
+    @Inject(method = "updateWeather", at = @At(value = "RETURN"), require = 1)
     public void onUpdateWeatherReturn(CallbackInfo ci) {
         Weather weather = getWeather();
         int duration = (int) getRemainingDuration();
@@ -2536,7 +2536,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
         return result;
     }
 
-    @Redirect(method = "isAnyPlayerWithinRangeAt", at = @At(value = "INVOKE", target="Lcom/google/common/base/Predicate;apply(Ljava/lang/Object;)Z"))
+    @Redirect(method = "isAnyPlayerWithinRangeAt", at = @At(value = "INVOKE", target="Lcom/google/common/base/Predicate;apply(Ljava/lang/Object;)Z"), require = 1)
     public boolean onIsAnyPlayerWithinRangePredicate(com.google.common.base.Predicate<EntityPlayer> predicate, Object object) {
         EntityPlayer player = (EntityPlayer) object;
         if (player.isDead || !((IMixinEntityPlayer) player).affectsSpawning()) {
@@ -2552,7 +2552,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
     }
 
     // For invisibility
-    @Redirect(method = CHECK_NO_ENTITY_COLLISION, at = @At(value = "INVOKE", target = GET_ENTITIES_WITHIN_AABB))
+    @Redirect(method = CHECK_NO_ENTITY_COLLISION, at = @At(value = "INVOKE", target = GET_ENTITIES_WITHIN_AABB), require = 1)
     public List<net.minecraft.entity.Entity> filterInvisibile(net.minecraft.world.World world, net.minecraft.entity.Entity entityIn,
             AxisAlignedBB axisAlignedBB) {
         List<net.minecraft.entity.Entity> entities = world.getEntitiesWithinAABBExcludingEntity(entityIn, axisAlignedBB);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldSettings.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldSettings.java
@@ -75,13 +75,13 @@ public abstract class MixinWorldSettings implements WorldCreationSettings, IMixi
     @Shadow private boolean commandsAllowed;
     @Shadow private boolean bonusChestEnabled;
 
-    @Inject(method = "<init>*", at = @At("RETURN"))
+    @Inject(method = "<init>*", at = @At("RETURN"), require = 1)
     private void onConstructed(long seedIn, WorldSettings.GameType gameType, boolean enableMapFeatures, boolean hardcoreMode, WorldType worldTypeIn,
             CallbackInfo ci) {
         this.actualWorldName = "";
     }
 
-    @Inject(method = "<init>*", at = @At("RETURN"))
+    @Inject(method = "<init>*", at = @At("RETURN"), require = 1)
     private void onConstructed(WorldInfo info, CallbackInfo ci) {
         this.actualWorldName = info.getWorldName();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiomeDecorator.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiomeDecorator.java
@@ -36,7 +36,7 @@ public class MixinBiomeDecorator {
 
     // Cancel genDecorations just in case this does get called as all of these
     // are handled already by populators.
-    @Inject(method = "genDecorations(Lnet/minecraft/world/biome/BiomeGenBase;)V", at = @At("HEAD") , cancellable = true)
+    @Inject(method = "genDecorations(Lnet/minecraft/world/biome/BiomeGenBase;)V", at = @At("HEAD") , cancellable = true, require = 1)
     protected void genDecorations(BiomeGenBase biomeGenBaseIn, CallbackInfo ci) {
         ci.cancel();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiomeGenMesa.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/biome/MixinBiomeGenMesa.java
@@ -75,7 +75,7 @@ public abstract class MixinBiomeGenMesa extends MixinBiomeGenBase {
      * Cancel the call to place the terrain blocks as this is instead handled
      * through our custom genpop.
      */
-    @Inject(method = "genTerrainBlocks(Lnet/minecraft/world/World;Ljava/util/Random;Lnet/minecraft/world/chunk/ChunkPrimer;IID)V", at = @At("HEAD") , cancellable = true)
+    @Inject(method = "genTerrainBlocks(Lnet/minecraft/world/World;Ljava/util/Random;Lnet/minecraft/world/chunk/ChunkPrimer;IID)V", at = @At("HEAD") , cancellable = true, require = 1)
     public void genTerrainBlocks(World world, Random rand, ChunkPrimer chunk, int x, int z, double stoneNoise, CallbackInfo ci) {
         ci.cancel();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/chunk/storage/MixinAnvilChunkLoader.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/chunk/storage/MixinAnvilChunkLoader.java
@@ -44,7 +44,7 @@ import java.util.Map;
 @Mixin(AnvilChunkLoader.class)
 public class MixinAnvilChunkLoader {
 
-    @Inject(method = "writeChunkToNBT", at = @At(value = "RETURN"))
+    @Inject(method = "writeChunkToNBT", at = @At(value = "RETURN"), require = 1)
     public void onWriteChunkToNBT(net.minecraft.world.chunk.Chunk chunkIn, World worldIn, NBTTagCompound compound, CallbackInfo ci) {
         IMixinChunk chunk = (IMixinChunk) chunkIn;
 
@@ -87,7 +87,7 @@ public class MixinAnvilChunkLoader {
         }
     }
 
-    @Inject(method = "readChunkFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;getIntArray(Ljava/lang/String;)[I", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "readChunkFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;getIntArray(Ljava/lang/String;)[I", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void onReadChunkFromNBT(World worldIn, NBTTagCompound compound, CallbackInfoReturnable<net.minecraft.world.chunk.Chunk> ci, int chunkX, int chunkZ, net.minecraft.world.chunk.Chunk chunkIn) {
         if (compound.hasKey(NbtDataUtil.SPONGE_DATA)) {
             Map<Integer, PlayerTracker> trackedIntPlayerPositions = Maps.newHashMap();

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderGenerate.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderGenerate.java
@@ -99,7 +99,7 @@ public abstract class MixinChunkProviderGenerate implements IChunkProvider, Gene
     @Shadow private BiomeGenBase[] biomesForGeneration;
     private BiomeGenerator biomegen;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>", at = @At("RETURN"), require = 1)
     private void onConstruct(net.minecraft.world.World worldIn, long p_i45636_2_, boolean p_i45636_4_, String p_i45636_5_, CallbackInfo ci) {
         if (this.settings == null) {
             this.settings = new ChunkProviderSettings.Factory().func_177864_b();

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinGeneratorBushFeature.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinGeneratorBushFeature.java
@@ -66,7 +66,7 @@ public abstract class MixinGeneratorBushFeature implements Mushroom {
     private Function<Location<Chunk>, MushroomType> override = null;
     private VariableAmount mushroomsPerChunk;
 
-    @Inject(method = "<init>", at = @At("RETURN") )
+    @Inject(method = "<init>", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.types = new ChanceTable<>();
         this.mushroomsPerChunk = VariableAmount.fixed(1);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenBigMushroom.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenBigMushroom.java
@@ -67,7 +67,7 @@ public abstract class MixinWorldGenBigMushroom extends MixinWorldGenerator imple
     private Function<Location<Chunk>, PopulatorObject> override = null;
     private VariableAmount mushroomsPerChunk;
 
-    @Inject(method = "<init>", at = @At("RETURN") )
+    @Inject(method = "<init>", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.types = new WeightedTable<>();
         this.mushroomsPerChunk = VariableAmount.fixed(1);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenBlockBlob.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenBlockBlob.java
@@ -54,7 +54,7 @@ public abstract class MixinWorldGenBlockBlob implements BlockBlob {
     private VariableAmount radius;
     private VariableAmount count;
 
-    @Inject(method = "<init>(Lnet/minecraft/block/Block;I)V", at = @At("RETURN") )
+    @Inject(method = "<init>(Lnet/minecraft/block/Block;I)V", at = @At("RETURN") , require = 1)
     public void onConstructed(Block block, int radius, CallbackInfo ci) {
         this.block = (BlockState) block.getDefaultState();
         this.radius = VariableAmount.fixed(radius);
@@ -83,7 +83,7 @@ public abstract class MixinWorldGenBlockBlob implements BlockBlob {
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: This overwrite is to replace the usages of Block with BlockState as well
      * as to modify the radii calculations to use our VariableAmount.
      */

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenCactus.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenCactus.java
@@ -49,7 +49,7 @@ public abstract class MixinWorldGenCactus implements Cactus {
     private VariableAmount cactiPerChunk;
     private VariableAmount height;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.cactiPerChunk = VariableAmount.fixed(10);
         this.height = VariableAmount.baseWithRandomAddition(1, VariableAmount.baseWithRandomAddition(1, 3));
@@ -77,7 +77,7 @@ public abstract class MixinWorldGenCactus implements Cactus {
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: Overwritten to be less random. This method was completely rewritten.
      */
     @Overwrite

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDeadBush.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDeadBush.java
@@ -47,7 +47,7 @@ public abstract class MixinWorldGenDeadBush extends WorldGenerator implements De
 
     private VariableAmount count;
 
-    @Inject(method = "<init>", at = @At("RETURN") )
+    @Inject(method = "<init>", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.fixed(128);
     }
@@ -69,7 +69,7 @@ public abstract class MixinWorldGenDeadBush extends WorldGenerator implements De
             generate(world, random, pos);
         }
     }
-    
+
     @Override
     public VariableAmount getShrubsPerChunk() {
         return this.count;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDesertWells.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDesertWells.java
@@ -52,7 +52,7 @@ public abstract class MixinWorldGenDesertWells extends WorldGenerator implements
     private double spawnProbability;
     private PopulatorObject obj;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.spawnProbability = 0.001;
         this.obj = this;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDoublePlant.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDoublePlant.java
@@ -65,7 +65,7 @@ public class MixinWorldGenDoublePlant implements DoublePlant {
 
     @Shadow private BlockDoublePlant.EnumPlantType field_150549_a;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.types = new WeightedTable<>();
         this.count = VariableAmount.fixed(1);
@@ -100,7 +100,7 @@ public class MixinWorldGenDoublePlant implements DoublePlant {
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: Completely changes the method to leverage the WeightedTable
      * types. This method was almost completely rewritten.
      */

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDungeons.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenDungeons.java
@@ -67,7 +67,7 @@ public abstract class MixinWorldGenDungeons implements Dungeon, IWorldGenDungeon
     @Shadow
     public abstract String pickMobSpawner(Random p_76543_1_);
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.attempts = VariableAmount.fixed(8);
         // TODO data impl of MobSpawnerData
@@ -108,10 +108,10 @@ public abstract class MixinWorldGenDungeons implements Dungeon, IWorldGenDungeon
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: Overwritten to leverage the data manipulator while creating the
      * tile entity and the weighted table while filling chests.
-     * 
+     *
      * TODO can possibly be changed to a pair of injections
      * TODO could we represent this with a populator object to allow plguin
      * modification of the structure
@@ -285,7 +285,7 @@ public abstract class MixinWorldGenDungeons implements Dungeon, IWorldGenDungeon
     public MobSpawnerData getSpawnerData() {
         return this.data;
     }
-    
+
     @Override
     public void setSpawnerData(MobSpawnerData data) {
         this.data = data;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenFire.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenFire.java
@@ -50,7 +50,7 @@ public class MixinWorldGenFire implements NetherFire {
     private VariableAmount count;
     private VariableAmount cluster;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.fixed(10);
     }
@@ -74,7 +74,7 @@ public class MixinWorldGenFire implements NetherFire {
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: Overwritten to use our custom cluster size.
      */
     @Overwrite
@@ -112,7 +112,7 @@ public class MixinWorldGenFire implements NetherFire {
     public void setClustersPerChunk(VariableAmount count) {
         this.count = checkNotNull(count);
     }
-    
+
     @Override
     public String toString() {
     	return Objects.toStringHelper(this)

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenFlowers.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenFlowers.java
@@ -65,7 +65,7 @@ public abstract class MixinWorldGenFlowers extends WorldGenerator implements Flo
     @Shadow
     public abstract void setGeneratedBlock(BlockFlower p_175914_1_, BlockFlower.EnumFlowerType p_175914_2_);
 
-    @Inject(method = "<init>(Lnet/minecraft/block/BlockFlower;Lnet/minecraft/block/BlockFlower$EnumFlowerType;)V", at = @At("RETURN") )
+    @Inject(method = "<init>(Lnet/minecraft/block/BlockFlower;Lnet/minecraft/block/BlockFlower$EnumFlowerType;)V", at = @At("RETURN") , require = 1)
     public void onConstructed(BlockFlower block, BlockFlower.EnumFlowerType type, CallbackInfo ci) {
         this.flowers = new WeightedTable<PlantType>();
         this.count = VariableAmount.fixed(2);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenGlowstone.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenGlowstone.java
@@ -53,7 +53,7 @@ public abstract class MixinWorldGenGlowstone extends MixinWorldGenerator impleme
     private VariableAmount count;
     private VariableAmount attempts;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.baseWithRandomAddition(1, 10);
         this.attempts = VariableAmount.fixed(1500);
@@ -83,7 +83,7 @@ public abstract class MixinWorldGenGlowstone extends MixinWorldGenerator impleme
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: Change the number of iterations and the height of the cluster
      * depending on the respective variable amounts.
      */

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenIcePath.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenIcePath.java
@@ -52,7 +52,7 @@ public abstract class MixinWorldGenIcePath implements IcePath {
 
     @Shadow private Block block;
 
-    @Inject(method = "<init>(I)V", at = @At("RETURN") )
+    @Inject(method = "<init>(I)V", at = @At("RETURN") , require = 1)
     public void onConstructed(int radius, CallbackInfo ci) {
         this.radius = VariableAmount.baseWithRandomAddition(2, radius > 2 ? radius - 2 : 1);
         this.sections = VariableAmount.fixed(2);
@@ -79,7 +79,7 @@ public abstract class MixinWorldGenIcePath implements IcePath {
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: Overwritten to replace the path radius with one dependent on
      * our variable amount.
      */

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenIceSpike.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenIceSpike.java
@@ -55,7 +55,7 @@ public abstract class MixinWorldGenIceSpike extends WorldGenerator implements Ic
     private VariableAmount count;
     private double prob;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.height = VariableAmount.baseWithRandomAddition(7, 4);
         this.increase = VariableAmount.baseWithRandomAddition(10, 30);
@@ -84,7 +84,7 @@ public abstract class MixinWorldGenIceSpike extends WorldGenerator implements Ic
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: overwritten to make use of populator parameters
      */
     @Override
@@ -102,9 +102,9 @@ public abstract class MixinWorldGenIceSpike extends WorldGenerator implements Ic
             // rand.nextInt(4) + 7;
             int height = this.height.getFlooredAmount(rand);
             int width = height / 4 + rand.nextInt(2);
-         
+
             // rand.nextInt(60) == 0)
-            if (width > 1 && rand.nextDouble() < this.prob) 
+            if (width > 1 && rand.nextDouble() < this.prob)
             {
                 // position.up(10 + rand.nextInt(30));
                 position = position.up(this.increase.getFlooredAmount(rand));

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenLake.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenLake.java
@@ -59,7 +59,7 @@ public abstract class MixinWorldGenLake implements Lake {
     @Shadow
     public abstract boolean generate(World worldIn, Random rand, BlockPos position);
 
-    @Inject(method = "<init>(Lnet/minecraft/block/Block;)V", at = @At("RETURN") )
+    @Inject(method = "<init>(Lnet/minecraft/block/Block;)V", at = @At("RETURN") , require = 1)
     public void onConstructed(Block block, CallbackInfo ci) {
         this.prob = 0.25D;
         this.height = VariableAmount.baseWithRandomAddition(0, 256);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenMelon.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenMelon.java
@@ -46,7 +46,7 @@ public class MixinWorldGenMelon implements Melon {
 
     private VariableAmount count;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.fixed(10);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenMinable.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenMinable.java
@@ -56,7 +56,7 @@ public abstract class MixinWorldGenMinable extends WorldGenerator implements Ore
     private VariableAmount count;
     private VariableAmount height;
 
-    @Inject(method = "<init>(Lnet/minecraft/block/state/IBlockState;ILcom/google/common/base/Predicate;)V", at = @At("RETURN") )
+    @Inject(method = "<init>(Lnet/minecraft/block/state/IBlockState;ILcom/google/common/base/Predicate;)V", at = @At("RETURN") , require = 1)
     public void onConstructed(IBlockState ore, int count, Predicate condition, CallbackInfo ci) {
         this.size = VariableAmount.fixed(count);
         this.count = VariableAmount.fixed(16);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenPumpkin.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenPumpkin.java
@@ -50,7 +50,7 @@ public class MixinWorldGenPumpkin implements Pumpkin {
     private VariableAmount count;
     private double chance;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.fixed(10);
         this.chance = 0.1;
@@ -75,7 +75,7 @@ public class MixinWorldGenPumpkin implements Pumpkin {
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: This is overwritten in order to use our custom patch size.
      */
     @Overwrite

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenReed.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenReed.java
@@ -49,7 +49,7 @@ public class MixinWorldGenReed implements Reed {
     private VariableAmount count;
     private VariableAmount height;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.fixed(10);
         this.height = VariableAmount.baseWithRandomAddition(2, 2);
@@ -73,7 +73,7 @@ public class MixinWorldGenReed implements Reed {
 
     /*
      * Author: Deamon - December 12th, 2015
-     * 
+     *
      * Purpose: This is overwritten to use our custom attempt counts and reed
      * heights.
      */

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenSpikes.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenSpikes.java
@@ -55,7 +55,7 @@ public class MixinWorldGenSpikes implements EnderCrystalPlatform {
     private VariableAmount height;
     private VariableAmount radius;
 
-    @Inject(method = "<init>(Lnet/minecraft/block/Block;)V", at = @At("RETURN") )
+    @Inject(method = "<init>(Lnet/minecraft/block/Block;)V", at = @At("RETURN") , require = 1)
     public void onConstructed(Block block, CallbackInfo ci) {
         this.probability = 0.2;
         this.radius = VariableAmount.baseWithRandomAddition(1, 4);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenTallGrass.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenTallGrass.java
@@ -66,7 +66,7 @@ public abstract class MixinWorldGenTallGrass extends WorldGenerator implements S
     private Function<Location<Chunk>, ShrubType> override = null;
     private VariableAmount count;
 
-    @Inject(method = "<init>(Lnet/minecraft/block/BlockTallGrass$EnumType;)V", at = @At("RETURN") )
+    @Inject(method = "<init>(Lnet/minecraft/block/BlockTallGrass$EnumType;)V", at = @At("RETURN") , require = 1)
     public void onConstructed(BlockTallGrass.EnumType type, CallbackInfo ci) {
         this.types = new WeightedTable<ShrubType>();
         this.types.add(new WeightedObject<ShrubType>((ShrubType) (Object) type, 1));

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenVines.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenVines.java
@@ -48,7 +48,7 @@ public abstract class MixinWorldGenVines extends WorldGenerator implements Vine 
 
     private VariableAmount count;
 
-    @Inject(method = "<init>", at = @At("RETURN") )
+    @Inject(method = "<init>", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.fixed(50);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenWaterLily.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/populators/MixinWorldGenWaterLily.java
@@ -46,7 +46,7 @@ public abstract class MixinWorldGenWaterLily extends WorldGenerator implements W
 
     private VariableAmount count;
 
-    @Inject(method = "<init>()V", at = @At("RETURN") )
+    @Inject(method = "<init>()V", at = @At("RETURN") , require = 1)
     public void onConstructed(CallbackInfo ci) {
         this.count = VariableAmount.fixed(4);
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
@@ -56,35 +56,35 @@ public abstract class MixinSaveHandler implements IMixinSaveHandler {
     @Shadow private long initializationTime;
 
     @ModifyArg(method = "checkSessionLock", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/MinecraftException;<init>(Ljava/lang/String;)V"
-            , ordinal = 0, remap = false))
+            , ordinal = 0, remap = false), require = 1)
     public String modifyMinecraftExceptionOutputIfNotInitializationTime(String message) {
         return "The save folder for world " + this.worldDirectory + " is being accessed from another location, aborting";
     }
 
     @ModifyArg(method = "checkSessionLock", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/MinecraftException;<init>(Ljava/lang/String;)V"
-            , ordinal = 1, remap = false))
+            , ordinal = 1, remap = false), require = 1)
     public String modifyMinecraftExceptionOutputIfIOException(String message) {
         return "Failed to check session lock for world " + this.worldDirectory + ", aborting";
     }
 
     @Inject(method = "saveWorldInfoWithPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;setTag(Ljava/lang/String;"
-            + "Lnet/minecraft/nbt/NBTBase;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+            + "Lnet/minecraft/nbt/NBTBase;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void onSaveWorldInfoWithPlayerAfterTagSet(WorldInfo worldInformation, NBTTagCompound tagCompound, CallbackInfo ci, NBTTagCompound nbttagcompound1, NBTTagCompound nbttagcompound2) {
         saveDimensionAndOtherData((SaveHandler) (Object) this, worldInformation, nbttagcompound2);
     }
 
-    @Inject(method = "saveWorldInfoWithPlayer", at = @At("RETURN"))
+    @Inject(method = "saveWorldInfoWithPlayer", at = @At("RETURN"), require = 1)
     public void onSaveWorldInfoWithPlayerEnd(WorldInfo worldInformation, NBTTagCompound tagCompound, CallbackInfo ci) {
         saveSpongeDatData(worldInformation);
     }
 
     @Inject(method = "saveWorldInfo", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;setTag(Ljava/lang/String;"
-            + "Lnet/minecraft/nbt/NBTBase;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+            + "Lnet/minecraft/nbt/NBTBase;)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void onSaveWorldInfoAfterTagSet(WorldInfo worldInformation, CallbackInfo ci, NBTTagCompound nbttagcompound, NBTTagCompound nbttagcompound1) {
         saveDimensionAndOtherData((SaveHandler) (Object) this, worldInformation, nbttagcompound1);
     }
 
-    @Inject(method = "saveWorldInfo", at = @At("RETURN"))
+    @Inject(method = "saveWorldInfo", at = @At("RETURN"), require = 1)
     public void onSaveWorldInfoEnd(WorldInfo worldInformation, CallbackInfo ci) {
         if (!StaticMixinHelper.convertingMapFormat) {
             saveSpongeDatData(worldInformation);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
@@ -140,7 +140,7 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
     @Shadow
     public abstract NBTTagCompound getNBTTagCompound();
 
-    @Inject(method = "<init>", at = @At("RETURN") )
+    @Inject(method = "<init>", at = @At("RETURN") , require = 1)
     public void onConstruction(CallbackInfo ci) {
         this.spongeRootLevelNbt = new NBTTagCompound();
         this.spongeNbt = new NBTTagCompound();
@@ -153,7 +153,7 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
         }
     }
 
-    @Inject(method = "<init>*", at = @At("RETURN") )
+    @Inject(method = "<init>*", at = @At("RETURN") , require = 1)
     public void onConstruction(WorldSettings settings, String name, CallbackInfo ci) {
         if (name.equals("MpServer")) {
             return;
@@ -179,14 +179,14 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
         this.worldConfig.save();
     }
 
-    @Inject(method = "<init>*", at = @At("RETURN") )
+    @Inject(method = "<init>*", at = @At("RETURN") , require = 1)
     public void onConstruction(NBTTagCompound nbt, CallbackInfo ci) {
         if (!StaticMixinHelper.convertingMapFormat) {
             onConstruction(ci);
         }
     }
 
-    @Inject(method = "<init>*", at = @At("RETURN") )
+    @Inject(method = "<init>*", at = @At("RETURN") , require = 1)
     public void onConstruction(WorldInfo worldInformation, CallbackInfo ci) {
         onConstruction(ci);
 

--- a/src/main/java/org/spongepowered/common/mixin/eulashutdown/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/eulashutdown/MixinDedicatedServer.java
@@ -42,7 +42,7 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
         super(workDir, proxy, profileCacheDir);
     }
 
-    @Redirect(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerEula;hasAcceptedEULA()Z"))
+    @Redirect(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/ServerEula;hasAcceptedEULA()Z"), require = 1)
     public boolean onHasAcceptedEULA(ServerEula eula) {
         boolean hasAcceptedEULA = eula.hasAcceptedEULA();
         if (!hasAcceptedEULA && SpongeImpl.getGlobalConfig().getConfig().getEulaShutdown().shouldShutdownServer()) {

--- a/src/main/java/org/spongepowered/common/mixin/timings/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/timings/MixinMinecraftServer.java
@@ -34,12 +34,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 
-    @Inject(method = "tick()V", at = @At("HEAD") )
+    @Inject(method = "tick()V", at = @At("HEAD") , require = 1)
     private void onTickBegin(CallbackInfo ci) {
         TimingsManager.FULL_SERVER_TICK.startTiming();
     }
 
-    @Inject(method = "tick()V", at = @At("RETURN") )
+    @Inject(method = "tick()V", at = @At("RETURN") , require = 1)
     private void onTickEnd(CallbackInfo ci) {
         TimingsManager.FULL_SERVER_TICK.stopTiming();
     }

--- a/src/main/java/org/spongepowered/common/mixin/timings/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/timings/MixinWorld.java
@@ -51,19 +51,19 @@ public class MixinWorld {
 
     protected WorldTimingsHandler timings;
 
-    @Inject(method = "<init>", at = @At("RETURN") )
+    @Inject(method = "<init>", at = @At("RETURN") , require = 1)
     private void onInit(CallbackInfo ci) {
         this.timings = new WorldTimingsHandler((World) (Object) this);
     }
 
-    @Inject(method = "updateEntities", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=remove", shift = At.Shift.AFTER) )
+    @Inject(method = "updateEntities", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=remove", shift = At.Shift.AFTER) , require = 1)
     private void onEntityRemovalBegin(CallbackInfo ci) {
         if (!this.isRemote) {
             this.timings.entityRemoval.startTiming();
         }
     }
 
-    @Inject(method = "updateEntities", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=regular", shift = At.Shift.AFTER) )
+    @Inject(method = "updateEntities", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=regular", shift = At.Shift.AFTER) , require = 1)
     private void onEntityRemovalEnd(CallbackInfo ci) {
         if (!this.isRemote) {
             this.timings.entityRemoval.stopTiming();
@@ -72,7 +72,7 @@ public class MixinWorld {
         }
     }
 
-    @Inject(method = "updateEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;updateEntity(Lnet/minecraft/entity/Entity;)V") )
+    @Inject(method = "updateEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;updateEntity(Lnet/minecraft/entity/Entity;)V") , require = 1)
     private void onBeginEntityTick(CallbackInfo ci) {
         if (!this.isRemote) {
             SpongeTimings.tickEntityTimer.startTiming();
@@ -90,7 +90,7 @@ public class MixinWorld {
         }
     }
 
-    @Inject(method = "updateEntities", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=blockEntities", shift = At.Shift.AFTER) )
+    @Inject(method = "updateEntities", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=blockEntities", shift = At.Shift.AFTER) , require = 1)
     private void onTileEntityTickBegin(CallbackInfo ci) {
         if (!this.isRemote) {
             this.timings.entityTick.stopTiming();
@@ -98,14 +98,14 @@ public class MixinWorld {
         }
     }
 
-    @Inject(method = "updateEntities", at = @At("RETURN") )
+    @Inject(method = "updateEntities", at = @At("RETURN") , require = 1)
     private void addTileEntityTicks(CallbackInfo ci) {
         if (!this.isRemote) {
             TimingHistory.tileEntityTicks += this.loadedTileEntityList.size();
         }
     }
 
-    @Inject(method = "updateEntityWithOptionalForce", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/Entity;ticksExisted:I", opcode = Opcodes.GETFIELD) )
+    @Inject(method = "updateEntityWithOptionalForce", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/Entity;ticksExisted:I", opcode = Opcodes.GETFIELD) , require = 1)
     private void incrementActivatedEntityTicks(CallbackInfo ci) {
         if (!this.isRemote) {
             TimingHistory.activatedEntityTicks++;

--- a/src/main/java/org/spongepowered/common/mixin/timings/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/timings/MixinWorldServer.java
@@ -36,14 +36,14 @@ public abstract class MixinWorldServer extends MixinWorld {
     // ESS - endStartSection
     private static final String ESS = "Lnet/minecraft/profiler/Profiler;endStartSection(Ljava/lang/String;)V";
 
-    @Inject(method = "tick()V", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=tickPending") )
+    @Inject(method = "tick()V", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=tickPending") , require = 1)
     private void onBeginTickBlockUpdate(CallbackInfo ci) {
         if (!this.isRemote) {
             this.timings.scheduledBlocks.startTiming();
         }
     }
 
-    @Inject(method = "tick()V", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=tickBlocks") )
+    @Inject(method = "tick()V", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=tickBlocks") , require = 1)
     private void onAfterTickBlockUpdate(CallbackInfo ci) {
         if (!this.isRemote) {
             this.timings.scheduledBlocks.stopTiming();
@@ -51,7 +51,7 @@ public abstract class MixinWorldServer extends MixinWorld {
         }
     }
 
-    @Inject(method = "tick()V", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=chunkMap") )
+    @Inject(method = "tick()V", at = @At(value = "INVOKE_STRING", target = ESS, args = "ldc=chunkMap") , require = 1)
     private void onBeginUpdateBlocks(CallbackInfo ci) {
         if (!this.isRemote) {
             this.timings.chunkTicks.stopTiming();


### PR DESCRIPTION
SpongeCommon | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/491) | [SpongeVanilla](https://github.com/SpongePowered/SpongeVanilla/pull/203)

Now that we're using Mixin 0.4.10, a new parameter `require` is available in the various injectors (`@Inject`, `@Redirect`, `@ModifyArg`). This requires the injector to find at least as many targets as are specified by `require`.

By enabling this, we get an error when an injection fails, instead of it silently failing. While the `require` parameter can be leveraged to provide soft-failure (like `@Surrogate` for local var capture), all of our current injectors are required. This allows us to easily discover if a coremod is preventing an injection from working, and add another injection point to fix it.