### PR TITLE
Add ItemStacks to cause for Interact Event

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/network/MixinNetHandlerPlayServer.java
@@ -92,6 +92,7 @@ import org.spongepowered.common.interfaces.IMixinPacketResourcePackSend;
 import org.spongepowered.common.interfaces.network.IMixinC08PacketPlayerBlockPlacement;
 import org.spongepowered.common.network.PacketUtil;
 import org.spongepowered.common.text.SpongeTexts;
+import org.spongepowered.common.util.StaticMixinHelper;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
@@ -450,8 +451,12 @@ public abstract class MixinNetHandlerPlayServer implements PlayerConnection {
             return; // PVP is disabled, ignore
         }
 
-        InteractEntityEvent.Primary event = SpongeEventFactory.createInteractEntityEventPrimary(
-            Cause.of(NamedCause.source(this.playerEntity)), Optional.empty(), (org.spongepowered.api.entity.Entity) entityIn);
+        Cause cause = Cause.of(NamedCause.source(this.playerEntity));
+        if(StaticMixinHelper.prePacketProcessItem != null){
+            cause = cause.with(StaticMixinHelper.prePacketProcessItem);
+        }
+
+        InteractEntityEvent.Primary event = SpongeEventFactory.createInteractEntityEventPrimary(cause, Optional.empty(), (org.spongepowered.api.entity.Entity) entityIn);
         SpongeImpl.postEvent(event);
         if (!event.isCancelled()) {
             player.attackTargetEntityWithCurrentItem(entityIn);


### PR DESCRIPTION
This adds ItemStacks to causes for interact events, the reasoning behind this is for modded / 1.9 item interactions where the itemslot that is currently active is unknown.

This currently works for vanilla but likely needs to be thought carefully about in order to make this work nicely with mods.