### PR TITLE
[WIP] Check slot bounds. Fixes #409

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -268,11 +268,18 @@ public class SpongeCommonEventFactory {
         ClickInventoryEvent clickEvent = null;
         // Handle empty slot clicks
         if (((IMixinContainer) player.openContainer).getCapturedTransactions().size() == 0 && packetIn.getSlotId() >= 0) {
-            Slot slot = player.openContainer.getSlot(packetIn.getSlotId());
-            if (slot != null) {
-                SlotTransaction slotTransaction =
-                        new SlotTransaction(new SlotAdapter(slot), ItemStackSnapshot.NONE, ItemStackSnapshot.NONE);
-                ((IMixinContainer) player.openContainer).getCapturedTransactions().add(slotTransaction);
+            // Handle out of bounds slot locations
+            if (packetIn.getSlotId() >= player.openContainer.inventorySlots.size()) {
+                // Kick the player who's sending an invalid slot index
+                player.playerNetServerHandler.kickPlayerFromServer(
+                        "You have been kicked for attempting to click an out of bounds slot.");
+            } else {
+                Slot slot = player.openContainer.getSlot(packetIn.getSlotId());
+                if (slot != null) {
+                    SlotTransaction slotTransaction =
+                            new SlotTransaction(new SlotAdapter(slot), ItemStackSnapshot.NONE, ItemStackSnapshot.NONE);
+                    ((IMixinContainer) player.openContainer).getCapturedTransactions().add(slotTransaction);
+                }
             }
         }
         if (packetIn.getMode() == MODE_CLICK || packetIn.getMode() == MODE_PICKBLOCK) {

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
@@ -146,7 +146,6 @@ public abstract class MixinContainer implements org.spongepowered.api.item.inven
                 ((EntityPlayerMP) player).playerNetServerHandler
                         .kickPlayerFromServer("You have been kicked for attempting to click an out of bounds slot.");
                 ci.setReturnValue(null);
-                ci.cancel();
             }
         }
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/inventory/MixinContainer.java
@@ -24,6 +24,8 @@
  */
 package org.spongepowered.common.mixin.core.item.inventory;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -37,6 +39,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.interfaces.IMixinContainer;
 import org.spongepowered.common.item.inventory.adapter.impl.slots.SlotAdapter;
 
@@ -120,7 +123,7 @@ public abstract class MixinContainer implements org.spongepowered.api.item.inven
         }
     }
 
-    @Inject(method = "putStackInSlot", at = @At(value = "HEAD") )
+    @Inject(method = "putStackInSlot", at = @At(value = "HEAD"))
     public void onPutStackInSlot(int slotId, ItemStack itemstack, CallbackInfo ci) {
         if (this.captureInventory) {
             Slot slot = getSlot(slotId);
@@ -131,6 +134,19 @@ public abstract class MixinContainer implements org.spongepowered.api.item.inven
                         itemstack == null ? ItemStackSnapshot.NONE : ((org.spongepowered.api.item.inventory.ItemStack) itemstack).createSnapshot();
                 SlotTransaction slotTransaction = new SlotTransaction(new SlotAdapter(slot), originalItem, newItem);
                 this.capturedSlotTransactions.add(slotTransaction);
+            }
+        }
+    }
+
+    @Inject(method = "slotClick", at = @At(value = "HEAD"), cancellable = true)
+    public void onSlotClick(int slotId, int clickedButton, int mode, EntityPlayer player, CallbackInfoReturnable<net.minecraft.item.ItemStack> ci) {
+        if (slotId >= inventorySlots.size()) {
+            // Kick the player who's sending invalid packets and cancel the click
+            if (player instanceof EntityPlayerMP) {
+                ((EntityPlayerMP) player).playerNetServerHandler
+                        .kickPlayerFromServer("You have been kicked for attempting to click an out of bounds slot.");
+                ci.setReturnValue(null);
+                ci.cancel();
             }
         }
     }


### PR DESCRIPTION
Although I failed to reproduce the error as the mod in the issue doesn't seem to activate on a server without the serverside component. I do however believe this safety check will solve the issue of invalid clicked slots being sent to the server. The player will be kicked as @Mumfrey indicated this is to be treated as an exploit.