### PR TITLE
Fix per-world world borders

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandWorldBorder.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandWorldBorder.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.core.command;
+
+import net.minecraft.command.CommandWorldBorder;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.world.border.WorldBorder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
+
+@Mixin(CommandWorldBorder.class)
+public abstract class MixinCommandWorldBorder {
+
+    @Nullable private ICommandSender sender;
+
+    @Inject(method = "processCommand(Lnet/minecraft/command/ICommandSender;[Ljava/lang/String;)V", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/command/CommandWorldBorder;getWorldBorder()Lnet/minecraft/world/border/WorldBorder;"))
+    private void beforeGetWorldBorder(ICommandSender sender, String[] args, CallbackInfo ci) {
+        this.sender = sender;
+    }
+
+    /**
+     * @author Minecrell
+     * @reason Returns the correct worldborder for the current world of the command sender
+     */
+    @Overwrite
+    protected WorldBorder getWorldBorder() {
+        ICommandSender sender = this.sender;
+        this.sender = null;
+        return sender.getEntityWorld().getWorldBorder();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
@@ -38,7 +38,6 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.S01PacketJoinGame;
-import net.minecraft.network.play.server.S03PacketTimeUpdate;
 import net.minecraft.network.play.server.S05PacketSpawnPosition;
 import net.minecraft.network.play.server.S06PacketUpdateHealth;
 import net.minecraft.network.play.server.S07PacketRespawn;
@@ -51,7 +50,6 @@ import net.minecraft.network.play.server.S39PacketPlayerAbilities;
 import net.minecraft.network.play.server.S3FPacketCustomPayload;
 import net.minecraft.network.play.server.S40PacketDisconnect;
 import net.minecraft.network.play.server.S41PacketServerDifficulty;
-import net.minecraft.network.play.server.S44PacketWorldBorder;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.PlayerProfileCache;
@@ -489,7 +487,7 @@ public abstract class MixinServerConfigurationManager {
     private void onSetPlayerManager(WorldServer[] worldServers, CallbackInfo callbackInfo) {
         if (this.playerNBTManagerObj == null) {
             this.playerNBTManagerObj = worldServers[0].getSaveHandler().getPlayerNBTManager();
-            worldServers[0].getWorldBorder().addListener(new PlayerBorderListener());
+            worldServers[0].getWorldBorder().addListener(new PlayerBorderListener(0));
         }
         callbackInfo.cancel();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinServerConfigurationManager.java
@@ -487,7 +487,8 @@ public abstract class MixinServerConfigurationManager {
     private void onSetPlayerManager(WorldServer[] worldServers, CallbackInfo callbackInfo) {
         if (this.playerNBTManagerObj == null) {
             this.playerNBTManagerObj = worldServers[0].getSaveHandler().getPlayerNBTManager();
-            worldServers[0].getWorldBorder().addListener(new PlayerBorderListener(0));
+            // This is already added in our world constructor
+            //worldServers[0].getWorldBorder().addListener(new PlayerBorderListener(0));
         }
         callbackInfo.cancel();
     }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -79,7 +79,6 @@ import net.minecraft.server.management.ServerConfigurationManager;
 import net.minecraft.stats.StatList;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.BlockPos;
-import net.minecraft.util.EntitySelectors;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.MathHelper;
@@ -190,7 +189,6 @@ import org.spongepowered.common.entity.PlayerTracker;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.interfaces.IMixinChunk;
 import org.spongepowered.common.interfaces.IMixinMinecraftServer;
-import org.spongepowered.common.interfaces.block.IMixinBlock;
 import org.spongepowered.common.interfaces.entity.IMixinEntity;
 import org.spongepowered.common.interfaces.entity.IMixinEntityLightningBolt;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayer;
@@ -350,7 +348,7 @@ public abstract class MixinWorld implements World, IMixinWorld {
     public void onConstructed(ISaveHandler saveHandlerIn, WorldInfo info, WorldProvider providerIn, Profiler profilerIn, boolean client,
             CallbackInfo ci) {
         if (SpongeImpl.getGame().getPlatform().getType() == Platform.Type.SERVER) {
-            this.worldBorder.addListener(new PlayerBorderListener());
+            this.worldBorder.addListener(new PlayerBorderListener(providerIn.getDimensionId()));
         }
 
         // Turn on capturing

--- a/src/main/java/org/spongepowered/common/world/border/PlayerBorderListener.java
+++ b/src/main/java/org/spongepowered/common/world/border/PlayerBorderListener.java
@@ -29,36 +29,43 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.border.IBorderListener;
 import net.minecraft.world.border.WorldBorder;
 
-public class PlayerBorderListener implements IBorderListener {
+public final class PlayerBorderListener implements IBorderListener {
+
+    private final int dimensionId;
+
+    public PlayerBorderListener(int dimensionId) {
+        this.dimensionId = dimensionId;
+    }
 
     @Override
     public void onSizeChanged(WorldBorder border, double newSize) {
         MinecraftServer.getServer().getConfigurationManager()
-                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_SIZE));
+                .sendPacketToAllPlayersInDimension(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_SIZE), this.dimensionId);
     }
 
     @Override
     public void onTransitionStarted(WorldBorder border, double oldSize, double newSize, long time) {
         MinecraftServer.getServer().getConfigurationManager()
-                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.LERP_SIZE));
+                .sendPacketToAllPlayersInDimension(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.LERP_SIZE), this.dimensionId);
     }
 
     @Override
     public void onCenterChanged(WorldBorder border, double x, double z) {
         MinecraftServer.getServer().getConfigurationManager()
-                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_CENTER));
+                .sendPacketToAllPlayersInDimension(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_CENTER), this.dimensionId);
     }
 
     @Override
     public void onWarningTimeChanged(WorldBorder border, int newTime) {
         MinecraftServer.getServer().getConfigurationManager()
-                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_WARNING_TIME));
+                .sendPacketToAllPlayersInDimension(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_WARNING_TIME), this.dimensionId);
     }
 
     @Override
     public void onWarningDistanceChanged(WorldBorder border, int newDistance) {
         MinecraftServer.getServer().getConfigurationManager()
-                .sendPacketToAllPlayers(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_WARNING_BLOCKS));
+                .sendPacketToAllPlayersInDimension(new S44PacketWorldBorder(border, S44PacketWorldBorder.Action.SET_WARNING_BLOCKS),
+                        this.dimensionId);
     }
 
     @Override
@@ -68,4 +75,5 @@ public class PlayerBorderListener implements IBorderListener {
     @Override
     public void onDamageBufferChanged(WorldBorder border, double newSize) {
     }
+
 }

--- a/src/main/resources/mixins.common.core.json
+++ b/src/main/resources/mixins.common.core.json
@@ -166,6 +166,7 @@
         "command.MixinCommandHandler",
         "command.MixinCommandScoreboard",
         "command.MixinCommandSource",
+        "command.MixinCommandWorldBorder",
         "command.MixinICommandSender",
         "command.MixinLocatedSource",
         "command.MixinMinecartCommandBlockSender",


### PR DESCRIPTION
Currently, world border changes are always send to all players, even though they affect only players in certain dimensions. This causes wrong world borders to be displayed on the client. Also, while Vanilla supports only one world border directly (the one of the main world), Sponge supports per-world world borders, therefore I've also modified the `/worldborder` command to use the appropriate world for the sender.

- Send world border changes only to players in the affected dimension
- Modify /worldborder command to use the current world of the sender