### PR TITLE
Fixes ItemStackUtil#fromNative

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/util/ItemStackUtil.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/util/ItemStackUtil.java
@@ -51,7 +51,7 @@ public abstract class ItemStackUtil {
     }
     
     public static ItemStack fromNative(net.minecraft.item.ItemStack stack) {
-        if (stack instanceof ItemStack) {
+        if (stack == null || stack instanceof ItemStack) {
             return (ItemStack) stack;
         }
         throw new NativeStackException("The supplied native item stack was not compatible with the target environment");


### PR DESCRIPTION
Do not throw NativeStackException when the native ItemStack is null because of an empty slot.
Usages of ItemStackUtil#fromNative:
Adapter.Logic#insertStack
SlotAdapter#poll
SlotAdapter#set

Fixes #488