### PR TITLE
Do not use the works of PermissionService

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinSubject.java
@@ -138,7 +138,8 @@ public abstract class MixinSubject implements Subject, IMixinCommandSource, IMix
 
     @Override
     public boolean hasPermission(String permission) {
-        return hasPermission(getActiveContexts(), permission);
+        Subject subj = internalSubject();
+        return subj == null ? this.permDefault(permission).asBoolean() : subj.hasPermission(permission);
     }
 
     @Override


### PR DESCRIPTION
My function "hasPermission(String permission)" doesn't use "getActiveContexts()"