### PR TITLE
Implement 'Allow SendCommandEvent to set the command and arguments.'

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
@@ -247,6 +247,13 @@ public class SpongeCommandManager implements CommandManager {
             return event.getResult();
         }
 
+        //Only the first part of argSplit is used at the moment, do the other in the future if needed.
+        argSplit[0] = event.getCommand();
+
+        commandLine = event.getCommand();
+        if(!event.getArguments().isEmpty())
+            commandLine += ' ' + event.getArguments();
+
         try {
             try {
                 return this.dispatcher.process(source, commandLine);


### PR DESCRIPTION
This allows for SendCommandEvent to set the command and arguments.

The use case is to replace 'variables' in the text with other text, such as CraftBook's variables feature.

[API](https://github.com/SpongePowered/SpongeAPI/pull/1129)