### PR TITLE
Add mixin to use wall time instead of ticks for several things.

### DIFF
--- a/src/main/java/org/spongepowered/common/config/SpongeConfig.java
+++ b/src/main/java/org/spongepowered/common/config/SpongeConfig.java
@@ -126,6 +126,7 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
     // MODULES
     public static final String MODULE_ENTITY_ACTIVATION_RANGE = "entity-activation-range";
     public static final String MODULE_BUNGEECORD = "bungeecord";
+    public static final String MODULE_REALTIME = "realtime";
 
     // WORLD
     public static final String WORLD_PVP_ENABLED = "pvp-enabled";
@@ -777,6 +778,9 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
         @Setting("exploits")
         private boolean enableExploitPatches = true;
 
+        @Setting(value = MODULE_REALTIME, comment = "Use real (wall) time instead of ticks as much as possible")
+        private boolean pluginRealTime = false;
+
         public boolean usePluginBungeeCord() {
             return this.pluginBungeeCord;
         }
@@ -807,6 +811,14 @@ public class SpongeConfig<T extends SpongeConfig.ConfigBase> {
 
         public void setExploitPatches(boolean enableExploitPatches) {
             this.enableExploitPatches = enableExploitPatches;
+        }
+
+        public boolean usePluginRealTime() {
+            return this.pluginRealTime;
+        }
+
+        public void setPluginRealTime(boolean state) {
+            this.pluginRealTime = state;
         }
     }
 

--- a/src/main/java/org/spongepowered/common/launch/SpongeLaunch.java
+++ b/src/main/java/org/spongepowered/common/launch/SpongeLaunch.java
@@ -72,6 +72,7 @@ public class SpongeLaunch {
                 .addConfiguration("mixins.common.core.json")
                 .addConfiguration("mixins.common.bungeecord.json")
                 .addConfiguration("mixins.common.exploit.json")
+                .addConfiguration("mixins.common.realtime.json")
                 .addConfiguration("mixins.common.timings.json");
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/plugin/RealTimePlugin.java
+++ b/src/main/java/org/spongepowered/common/mixin/plugin/RealTimePlugin.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.plugin;
+
+import org.spongepowered.asm.lib.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.List;
+import java.util.Set;
+
+public class RealTimePlugin implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return SpongeImpl.getGlobalConfig().getConfig().getModules().usePluginRealTime();
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/IMixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/IMixinMinecraftServer.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime;
+
+public interface IMixinMinecraftServer {
+
+    long getRealTimeTicks();
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntity.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+// TODO(amaranth): Should this handle fire ticks too? Mobs can't move fast enough
+@Mixin(Entity.class)
+public abstract class MixinEntity {
+
+    private static final String ENTITY_RIDABLE_COOLDOWN_FIELD = "Lnet/minecraft/entity/Entity;field_184245_j:I";
+    private static final String ENTITY_PORTAL_COUNTER_FIELD = "Lnet/minecraft/entity/Entity;portalCounter:I";
+    @Shadow protected int field_184245_j;
+    @Shadow public World worldObj;
+    @Shadow protected int portalCounter;
+
+    @Redirect(method = "onEntityUpdate", at = @At(value = "FIELD", target = ENTITY_RIDABLE_COOLDOWN_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupEntityCooldown(Entity self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) this.worldObj.getMinecraftServer()).getRealTimeTicks();
+        this.field_184245_j = Math.max(0, this.field_184245_j - ticks);
+    }
+
+    @Redirect(method = "onEntityUpdate", at = @At(value = "FIELD", target = ENTITY_PORTAL_COUNTER_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupPortalCounter(Entity self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) this.worldObj.getMinecraftServer()).getRealTimeTicks();
+        this.portalCounter += ticks;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityAgeable.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityAgeable.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.EntityAgeable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityAgeable.class)
+public abstract class MixinEntityAgeable {
+
+    private static final String ENTITY_AGEABLE_SET_GROWING_AGE_METHOD = "Lnet/minecraft/entity/EntityAgeable;setGrowingAge(I)V";
+
+    @Redirect(method = "onLivingUpdate", at = @At(value = "INVOKE", target = ENTITY_AGEABLE_SET_GROWING_AGE_METHOD, ordinal = 0))
+    public void fixupGrowingUp(EntityAgeable self, int age) {
+        // Subtract the one the original update method added
+        int diff = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks() - 1;
+        self.setGrowingAge(Math.min(0, age + diff));
+    }
+
+    @Redirect(method = "onLivingUpdate", at = @At(value = "INVOKE", target = ENTITY_AGEABLE_SET_GROWING_AGE_METHOD, ordinal = 1))
+    public void fixupBreedingCooldown(EntityAgeable self, int age) {
+        // Subtract the one the original update method added
+        int diff = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks() - 1;
+        self.setGrowingAge(Math.max(0, age - diff));
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityItem.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityItem.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.item.EntityItem;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityItem.class)
+public abstract class MixinEntityItem {
+
+    private static final String ENTITY_ITEM_DELAY_PICKUP_FIELD = "Lnet/minecraft/entity/item/EntityItem;delayBeforeCanPickup:I";
+    private static final String ENTITY_ITEM_AGE_FIELD = "Lnet/minecraft/entity/item/EntityItem;age:I";
+    @Shadow private int delayBeforeCanPickup;
+    @Shadow public int age;
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = ENTITY_ITEM_DELAY_PICKUP_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupPickupDelay(EntityItem self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.delayBeforeCanPickup = Math.max(0, this.delayBeforeCanPickup - ticks);
+    }
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = ENTITY_ITEM_AGE_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupAge(EntityItem self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.age += ticks;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityLiving.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityLiving.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.world.World;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityLiving.class)
+public abstract class MixinEntityLiving extends EntityLivingBase {
+
+    private static final String ENTITY_LIVING_AGE_FIELD = "Lnet/minecraft/entity/EntityLiving;entityAge:I";
+
+    public MixinEntityLiving(World worldIn) {
+        super(worldIn);
+    }
+
+    @Redirect(method = "updateEntityActionState", at = @At(value = "FIELD", target = ENTITY_LIVING_AGE_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupEntityDespawnAge(EntityLiving self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.entityAge += ticks;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityLivingBase.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.EntityLivingBase;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityLivingBase.class)
+public abstract class MixinEntityLivingBase {
+
+    private static final String ENTITY_LIVING_BASE_DEATH_TIME_FIELD = "Lnet/minecraft/entity/EntityLivingBase;deathTime:I";
+    @Shadow public int deathTime;
+
+    @Redirect(method = "onDeathUpdate", at = @At(value = "FIELD", target = ENTITY_LIVING_BASE_DEATH_TIME_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupDeathTime(EntityLivingBase self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.deathTime = Math.min(20, this.deathTime + ticks);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityPlayer.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityPlayer.class)
+public abstract class MixinEntityPlayer {
+
+    private static final String ENTITY_PLAYER_XP_COOLDOWN_FIELD = "Lnet/minecraft/entity/player/EntityPlayer;xpCooldown:I";
+    private static final String ENTITY_PLAYER_SLEEP_TIMER_FIELD = "Lnet/minecraft/entity/player/EntityPlayer;sleepTimer:I";
+    @Shadow public int xpCooldown;
+    @Shadow private int sleepTimer;
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = ENTITY_PLAYER_XP_COOLDOWN_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupXpCooldown(EntityPlayer self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.xpCooldown = Math.max(0, this.xpCooldown - ticks);
+    }
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = ENTITY_PLAYER_SLEEP_TIMER_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupSleepTimer(EntityPlayer self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.sleepTimer += ticks;
+    }
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = ENTITY_PLAYER_SLEEP_TIMER_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 2))
+    public void fixupWakeTimer(EntityPlayer self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.sleepTimer += ticks;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityPlayerMP.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.world.World;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityPlayerMP.class)
+public abstract class MixinEntityPlayerMP extends Entity {
+
+    private static final String ENTITY_PLAYER_MP_PORTAL_COOLDOWN_FIELD = "Lnet/minecraft/entity/player/EntityPlayerMP;timeUntilPortal:I";
+
+    public MixinEntityPlayerMP(World worldIn) {
+        super(worldIn);
+    }
+
+    @Redirect(method = "func_184173_H", at = @At(value = "FIELD", target = ENTITY_PLAYER_MP_PORTAL_COOLDOWN_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupPortalCooldown(EntityPlayerMP self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.timeUntilPortal = Math.max(0, this.timeUntilPortal - ticks);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityXPOrb.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityXPOrb.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.item.EntityXPOrb;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityXPOrb.class)
+public abstract class MixinEntityXPOrb {
+
+    private static final String ENTITY_XP_DELAY_PICKUP_FIELD = "Lnet/minecraft/entity/item/EntityXPOrb;delayBeforeCanPickup:I";
+    private static final String ENTITY_XP_AGE_FIELD = "Lnet/minecraft/entity/item/EntityXPOrb;xpOrbAge:I";
+    @Shadow public int delayBeforeCanPickup;
+    @Shadow public int xpOrbAge;
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = ENTITY_XP_DELAY_PICKUP_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupPickupDelay(EntityXPOrb self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.delayBeforeCanPickup = Math.max(0, this.delayBeforeCanPickup - ticks);
+    }
+
+    @Redirect(method = "onUpdate", at = @At(value = "FIELD", target = ENTITY_XP_AGE_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupAge(EntityXPOrb self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        this.xpOrbAge += ticks;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityZombie.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityZombie.java
@@ -35,6 +35,7 @@ import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
 public abstract class MixinEntityZombie {
 
     private static final String ENTITY_ZOMBIE_GET_CONVERSION_BOOST_METHOD = "Lnet/minecraft/entity/monster/EntityZombie;getConversionTimeBoost()I";
+
     @Shadow protected abstract int getConversionTimeBoost();
 
     @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = ENTITY_ZOMBIE_GET_CONVERSION_BOOST_METHOD, ordinal = 0))

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityZombie.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinEntityZombie.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.entity.monster.EntityZombie;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(EntityZombie.class)
+public abstract class MixinEntityZombie {
+
+    private static final String ENTITY_ZOMBIE_GET_CONVERSION_BOOST_METHOD = "Lnet/minecraft/entity/monster/EntityZombie;getConversionTimeBoost()I";
+    @Shadow protected abstract int getConversionTimeBoost();
+
+    @Redirect(method = "onUpdate", at = @At(value = "INVOKE", target = ENTITY_ZOMBIE_GET_CONVERSION_BOOST_METHOD, ordinal = 0))
+    public int fixupConversionTimeBoost(EntityZombie self) {
+        int ticks = (int) ((IMixinMinecraftServer) self.getEntityWorld().getMinecraftServer()).getRealTimeTicks();
+        return this.getConversionTimeBoost() * ticks;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinMinecraftServer.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(MinecraftServer.class)
+public abstract class MixinMinecraftServer implements IMixinMinecraftServer {
+
+    private static long lastTickMillis = System.currentTimeMillis();
+    private static long realTimeTicks = 1;
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    public void tick(CallbackInfo ci) {
+        long currentMillis = System.currentTimeMillis();
+        realTimeTicks = (currentMillis - lastTickMillis) / 50;
+        if (realTimeTicks < 1) {
+            realTimeTicks = 1;
+        }
+        lastTickMillis = currentMillis;
+    }
+
+    @Override
+    public long getRealTimeTicks() {
+        return realTimeTicks;
+    }
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinMinecraftServer.java
@@ -34,17 +34,17 @@ import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
 @Mixin(MinecraftServer.class)
 public abstract class MixinMinecraftServer implements IMixinMinecraftServer {
 
-    private static long lastTickMillis = System.currentTimeMillis();
+    private static long lastTickNanos = System.nanoTime();
     private static long realTimeTicks = 1;
 
     @Inject(method = "tick", at = @At("HEAD"))
     public void tick(CallbackInfo ci) {
-        long currentMillis = System.currentTimeMillis();
-        realTimeTicks = (currentMillis - lastTickMillis) / 50;
+        long currentNanos = System.nanoTime();
+        realTimeTicks = (currentNanos - lastTickNanos) / 50000000;
         if (realTimeTicks < 1) {
             realTimeTicks = 1;
         }
-        lastTickMillis = currentMillis;
+        lastTickNanos = currentNanos;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinNetHandlerPlayServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinNetHandlerPlayServer.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(NetHandlerPlayServer.class)
+public abstract class MixinNetHandlerPlayServer {
+
+    private static final String NET_HANDLER_PLAY_CHAT_SPAM_FIELD = "Lnet/minecraft/network/NetHandlerPlayServer;chatSpamThresholdCount:I";
+    private static final String NET_HANDLER_PLAY_DROP_SPAM_FIELD = "Lnet/minecraft/network/NetHandlerPlayServer;itemDropThreshold:I";
+    @Shadow private int chatSpamThresholdCount;
+    @Shadow private int itemDropThreshold;
+    @Shadow @Final private MinecraftServer serverController;
+
+    @Redirect(method = "update", at = @At(value = "FIELD", target = NET_HANDLER_PLAY_CHAT_SPAM_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupChatSpamCheck(NetHandlerPlayServer self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) serverController).getRealTimeTicks();
+        this.chatSpamThresholdCount = Math.max(0, this.chatSpamThresholdCount - ticks);
+    }
+
+    @Redirect(method = "update", at = @At(value = "FIELD", target = NET_HANDLER_PLAY_DROP_SPAM_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupDropSpamCheck(NetHandlerPlayServer self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) serverController).getRealTimeTicks();
+        this.itemDropThreshold = Math.max(0, this.itemDropThreshold - ticks);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinPlayerInteractionManager.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinPlayerInteractionManager.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.server.management.PlayerInteractionManager;
+import net.minecraft.world.World;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(PlayerInteractionManager.class)
+public abstract class MixinPlayerInteractionManager {
+
+    private static final String PLAYER_INTERACTION_BLOCK_DAMAGE_FIELD = "Lnet/minecraft/server/management/PlayerInteractionManager;curblockDamage:I";
+    @Shadow public World theWorld;
+    @Shadow private int curblockDamage;
+
+    @Redirect(method = "updateBlockRemoving", at = @At(value = "FIELD", target = PLAYER_INTERACTION_BLOCK_DAMAGE_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupDiggingTime(PlayerInteractionManager self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) this.theWorld.getMinecraftServer()).getRealTimeTicks();
+        this.curblockDamage += ticks;
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinTileEntityBrewingStand.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinTileEntityBrewingStand.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityBrewingStand;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(TileEntityBrewingStand.class)
+public abstract class MixinTileEntityBrewingStand extends TileEntity {
+
+    private static final String BREWING_STAND_BREW_TIME_FIELD = "Lnet/minecraft/tileentity/TileEntityBrewingStand;brewTime:I";
+    @Shadow private int brewTime;
+
+    @Redirect(method = "update", at = @At(value = "FIELD", target = BREWING_STAND_BREW_TIME_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupBrewTime(TileEntityBrewingStand self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) this.getWorld().getMinecraftServer()).getRealTimeTicks();
+        this.brewTime = Math.max(0, this.brewTime - ticks);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinTileEntityFurnace.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinTileEntityFurnace.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityFurnace;
+import net.minecraft.util.math.MathHelper;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(TileEntityFurnace.class)
+public abstract class MixinTileEntityFurnace extends TileEntity {
+
+    private static final String FURNACE_BURN_TIME_FIELD = "Lnet/minecraft/tileentity/TileEntityFurnace;furnaceBurnTime:I";
+    private static final String FURNACE_COOK_TIME_FIELD = "Lnet/minecraft/tileentity/TileEntityFurnace;cookTime:I";
+    @Shadow private int furnaceBurnTime;
+    @Shadow private int cookTime;
+    @Shadow private int totalCookTime;
+
+    @Redirect(method = "update", at = @At(value = "FIELD", target = FURNACE_BURN_TIME_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupBurnTime(TileEntityFurnace self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) this.getWorld().getMinecraftServer()).getRealTimeTicks();
+        this.furnaceBurnTime = Math.max(0, this.furnaceBurnTime - ticks);
+    }
+
+    @Redirect(method = "update", at = @At(value = "FIELD", target = FURNACE_COOK_TIME_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 0))
+    public void fixupCookTime(TileEntityFurnace self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) this.getWorld().getMinecraftServer()).getRealTimeTicks();
+        this.cookTime = Math.min(this.totalCookTime, this.cookTime + ticks);
+    }
+
+    @Redirect(method = "update", at = @At(value = "FIELD", target = FURNACE_COOK_TIME_FIELD, opcode = Opcodes.PUTFIELD, ordinal = 3))
+    public void fixupCookTimeCooldown(TileEntityFurnace self, int modifier) {
+        int ticks = (int) ((IMixinMinecraftServer) this.getWorld().getMinecraftServer()).getRealTimeTicks();
+        this.cookTime = MathHelper.clamp_int(this.cookTime - (2 * ticks), 0, this.totalCookTime);
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/realtime/mixin/MixinWorldServer.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.mixin.realtime.mixin;
+
+import net.minecraft.profiler.Profiler;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.storage.ISaveHandler;
+import net.minecraft.world.storage.WorldInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.mixin.realtime.IMixinMinecraftServer;
+
+@Mixin(WorldServer.class)
+public abstract class MixinWorldServer extends World {
+
+    @Shadow public abstract MinecraftServer getMinecraftServer();
+
+    protected MixinWorldServer(ISaveHandler saveHandlerIn, WorldInfo info, WorldProvider providerIn,
+            Profiler profilerIn, boolean client) {
+        super(saveHandlerIn, info, providerIn, profilerIn, client);
+    }
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    public void fixTimeOfDay(CallbackInfo ci) {
+        if (this.worldInfo.getGameRulesInstance().getBoolean("doDaylightCycle")) {
+            // Subtract the one the original tick method is going to add
+            long diff = ((IMixinMinecraftServer) this.getMinecraftServer()).getRealTimeTicks() - 1;
+            // Don't set if we're not changing it as other mods might be listening for changes
+            if (diff > 0) {
+                this.worldInfo.setWorldTime(this.worldInfo.getWorldTime() + diff);
+            }
+        }
+    }
+
+}

--- a/src/main/resources/mixins.common.realtime.json
+++ b/src/main/resources/mixins.common.realtime.json
@@ -1,0 +1,28 @@
+{
+  "minVersion": "0.5.1",
+  "package": "org.spongepowered.common.mixin.realtime.mixin",
+  "refmap": "mixins.common.refmap.json",
+  "plugin": "org.spongepowered.common.mixin.plugin.RealTimePlugin",
+  "mixins": [
+    "MixinEntity",
+    "MixinEntityAgeable",
+    "MixinEntityItem",
+    "MixinEntityLiving",
+    "MixinEntityLivingBase",
+    "MixinEntityPlayer",
+    "MixinEntityPlayerMP",
+    "MixinEntityXPOrb",
+    "MixinEntityZombie",
+    "MixinMinecraftServer",
+    "MixinNetHandlerPlayServer",
+    "MixinPlayerInteractionManager",
+    "MixinTileEntityBrewingStand",
+    "MixinTileEntityFurnace",
+    "MixinWorldServer"
+  ],
+  "server": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/mixins.common.realtime.json
+++ b/src/main/resources/mixins.common.realtime.json
@@ -1,28 +1,28 @@
 {
-  "minVersion": "0.5.1",
-  "package": "org.spongepowered.common.mixin.realtime.mixin",
-  "refmap": "mixins.common.refmap.json",
-  "plugin": "org.spongepowered.common.mixin.plugin.RealTimePlugin",
-  "mixins": [
-    "MixinEntity",
-    "MixinEntityAgeable",
-    "MixinEntityItem",
-    "MixinEntityLiving",
-    "MixinEntityLivingBase",
-    "MixinEntityPlayer",
-    "MixinEntityPlayerMP",
-    "MixinEntityXPOrb",
-    "MixinEntityZombie",
-    "MixinMinecraftServer",
-    "MixinNetHandlerPlayServer",
-    "MixinPlayerInteractionManager",
-    "MixinTileEntityBrewingStand",
-    "MixinTileEntityFurnace",
-    "MixinWorldServer"
-  ],
-  "server": [
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+    "minVersion": "0.5.1",
+    "package": "org.spongepowered.common.mixin.realtime.mixin",
+    "refmap": "mixins.common.refmap.json",
+    "plugin": "org.spongepowered.common.mixin.plugin.RealTimePlugin",
+    "mixins": [
+        "MixinEntity",
+        "MixinEntityAgeable",
+        "MixinEntityItem",
+        "MixinEntityLiving",
+        "MixinEntityLivingBase",
+        "MixinEntityPlayer",
+        "MixinEntityPlayerMP",
+        "MixinEntityXPOrb",
+        "MixinEntityZombie",
+        "MixinMinecraftServer",
+        "MixinNetHandlerPlayServer",
+        "MixinPlayerInteractionManager",
+        "MixinTileEntityBrewingStand",
+        "MixinTileEntityFurnace",
+        "MixinWorldServer"
+    ],
+    "server": [
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    }
 }


### PR DESCRIPTION
Use actual time passed to emulate a constant tick rate in places that are unlikely to break things and easily noticed by players. Should reduce "block lag" while digging on a server with a low tick rate, among other things.