### PR TITLE
Resolved an issue with polling inventory queries

### DIFF
--- a/src/main/java/org/spongepowered/common/item/inventory/query/result/QueryResult.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/query/result/QueryResult.java
@@ -54,7 +54,7 @@ public interface QueryResult<TInventory, TStack> extends Result<TInventory, TSta
         protected void init(SlotProvider<TInventory, TStack> slots) {
             for (Lens<TInventory, TStack> result : this.resultSet) {
                 Collection<InventoryProperty<?, ?>> properties = this.resultSet.getProperties(result);
-                this.addChild(result, properties.toArray(new InventoryProperty[0]));
+                this.addSpanningChild(result, properties.toArray(new InventoryProperty[0]));
             }
         }
 


### PR DESCRIPTION
The function, getLensForOrdinal(int ordinal) was always returning null on any queries which returned multiple results, resulting in no operation. This change adds the child as a spanning child, which allows getLensForOrdinal to return the correct result, and thus operations such as poll(20) work with any amount of item stacks returned from the query.

Reference #560 for an example of a situation which this fixes.