### PR TITLE
Changed HashSet<> to HashSet<Team> due to Eclipse (4.6.0M5) complaint

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreboardLogic.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/scoreboard/MixinScoreboardLogic.java
@@ -213,9 +213,8 @@ public abstract class MixinScoreboardLogic extends Scoreboard implements IMixinS
         return Optional.empty();
     }
 
-    @SuppressWarnings("unchecked")
     public Set<Team> scoreboard$getTeams() {
-        return new HashSet<>((Set) this.teams.values());
+        return this.teams.values().stream().map(team -> (Team) team).collect(Collectors.toSet());
     }
 
     public Optional<Team> scoreboard$getMemberTeam(Text member) {


### PR DESCRIPTION
Says "Type mismatch: cannot convert from HashSet to Set<Team>" without
this.