### PR TITLE
Add null check to DyeableDataProcessor#isDyeable

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/data/DyeableDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/DyeableDataProcessor.java
@@ -59,11 +59,16 @@ public class DyeableDataProcessor extends AbstractSingleDataProcessor<DyeColor, 
     }
 
     public static boolean isDyeable(Item item) {
-        return item.equals(Items.dye)
-                || Block.getBlockFromItem(item).equals(Blocks.wool)
-                || Block.getBlockFromItem(item).equals(Blocks.stained_glass)
-                || Block.getBlockFromItem(item).equals(Blocks.stained_glass_pane)
-                || Block.getBlockFromItem(item).equals(Blocks.stained_hardened_clay);
+        if (item.equals(Items.dye)) {
+            return true;
+        }
+
+        Block block = Block.getBlockFromItem(item);
+        return block != null
+            && (block.equals(Blocks.wool)
+                || block.equals(Blocks.stained_glass)
+                || block.equals(Blocks.stained_glass_pane)
+                || block.equals(Blocks.stained_hardened_clay));
     }
 
     @Override


### PR DESCRIPTION
When running `ItemStack.supports(Keys.DYE_COLOR)` on an item that is not destined to become a block (or is not a dye), an NPE is thrown because `Block.getBlockFromItem(item)` returns `null`. This PR adds a null check to the method so that if the item is not a block, the method correctly returns `false`.