### PR TITLE
Check getSlot bounds during interact capture, fixes #602

### DIFF
--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -259,7 +259,8 @@ public class SpongeCommonEventFactory {
                     entitySnapshotBuilder.build(), (org.spongepowered.api.item.inventory.Container) player.openContainer, (World) player.worldObj,
                     ((IMixinContainer) player.openContainer).getCapturedTransactions());
         } else {
-            if (((IMixinContainer) player.openContainer).getCapturedTransactions().size() == 0 && packetIn.getSlotId() >= 0) {
+            if (((IMixinContainer) player.openContainer).getCapturedTransactions().size() == 0 && packetIn.getSlotId() >= 0
+                    && packetIn.getSlotId() < player.openContainer.inventorySlots.size()) {
                 Slot slot = player.openContainer.getSlot(packetIn.getSlotId());
                 if (slot != null) {
                     SlotTransaction slotTransaction =
@@ -302,7 +303,8 @@ public class SpongeCommonEventFactory {
         Transaction<ItemStackSnapshot> cursorTransaction = new Transaction<>(StaticMixinHelper.lastCursor, newCursor);
         ClickInventoryEvent clickEvent = null;
         // Handle empty slot clicks
-        if (((IMixinContainer) player.openContainer).getCapturedTransactions().size() == 0 && packetIn.getSlotId() >= 0) {
+        if (((IMixinContainer) player.openContainer).getCapturedTransactions().size() == 0 && packetIn.getSlotId() >= 0
+                && packetIn.getSlotId() < player.openContainer.inventorySlots.size()) {
             Slot slot = player.openContainer.getSlot(packetIn.getSlotId());
             if (slot != null && !slot.getHasStack()) {
                 SlotTransaction slotTransaction =


### PR DESCRIPTION
This is a proper fix at the source of the problem, this overrides https://github.com/SpongePowered/SpongeCommon/pull/610.