### PR TITLE
Flip accidentally inverted cancellation check, fixes SpongeForge/586

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -129,7 +129,7 @@ public abstract class MixinWorldServer extends MixinWorld {
             ConstructEntityEvent.Pre event = SpongeEventFactory.createConstructEntityEventPre(Cause.of(NamedCause.source(cause)),
                     EntityTypes.LIGHTNING, transform);
             SpongeImpl.postEvent(event);
-            return event.isCancelled();
+            return !event.isCancelled();
         }
         return false;
     }


### PR DESCRIPTION
This is a clear case of a oversight, this method needs to be true (isRainingCheck succeeds) if the event isn't canceled (which means the lightning is still spawned). Through testing this is verified to solve
the referenced issue with respect to storms.