### PR TITLE
Pad out each page with empty lines, end pages with next page with ... fixes #638

### DIFF
--- a/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
@@ -30,8 +30,8 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.PeekingIterator;
-import org.spongepowered.api.text.Text;
 import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageReceiver;
 
 import java.util.ArrayList;
@@ -82,9 +82,11 @@ class IterablePagination extends ActivePagination {
         int addedLines = 0;
         while (addedLines <= getMaxContentLinesPerPage()) {
             if (!this.countIterator.hasNext()) {
+                padPage(ret,addedLines, Text.EMPTY);
                 break;
             }
             if (addedLines + this.countIterator.peek().getValue() > getMaxContentLinesPerPage()) {
+                padPage(ret,addedLines, t("..."));
                 break;
             }
             Map.Entry<Text, Integer> ent = this.countIterator.next();
@@ -92,6 +94,17 @@ class IterablePagination extends ActivePagination {
             addedLines += ent.getValue();
         }
         return ret;
+    }
+
+    private void padPage(final List<Text> currentPage, final int currentPageLines, final Text continuation) {
+        final int maxContentLinesPerPage = getMaxContentLinesPerPage();
+        for (int i = currentPageLines; i< maxContentLinesPerPage; i++){
+            if (i == (maxContentLinesPerPage - 1)) {
+                currentPage.add(continuation);
+            } else {
+                currentPage.add(Text.EMPTY);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
@@ -49,6 +49,7 @@ class ListPagination extends ActivePagination {
 
         for (Map.Entry<Text, Integer> ent : lines) {
             if (getMaxContentLinesPerPage() > 0 && ent.getValue() + currentPageLines > getMaxContentLinesPerPage() && currentPageLines != 0) {
+                padPage(currentPage, currentPageLines, t("..."));
                 currentPageLines = 0;
                 pages.add(currentPage);
                 currentPage = new ArrayList<>();
@@ -57,9 +58,21 @@ class ListPagination extends ActivePagination {
             currentPage.add(ent.getKey());
         }
         if (currentPageLines > 0) {
+            padPage(currentPage, currentPageLines, Text.EMPTY);
             pages.add(currentPage);
         }
         this.pages = pages;
+    }
+
+    private void padPage(final List<Text> currentPage, final int currentPageLines, final Text continuation) {
+        final int maxContentLinesPerPage = getMaxContentLinesPerPage();
+        for (int i = currentPageLines; i< maxContentLinesPerPage; i++){
+            if (i == maxContentLinesPerPage - 1) {
+                currentPage.add(continuation);
+            } else {
+                currentPage.add(Text.EMPTY);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Expands out the pagination pages with empty lines, Reduces the jitter when changing pages.

Also the last padded empty line when a next page exists is replaced with "..." to show that there are additional pages.

Fixes #638 

Edit: @Zidane You asked for more justification, if you havn't already read the issue. 

![image](https://cloud.githubusercontent.com/assets/141554/15266769/9d83c0e2-19ee-11e6-8054-5a258a8cfdaf.png)

Is how it looks without these changes, Notice that it can and will show the previous set of navigation links.

This PR adds whitespace so that this doesn't happen on the default chat width/height.


![image](https://cloud.githubusercontent.com/assets/141554/14319511/a36c3cfc-fc50-11e5-9b89-8b2b5d7b7db5.png)
