### PR TITLE
Added the ability to override the java version for Sponge

### DIFF
--- a/src/java6/java/org/spongepowered/launch/JavaVersionCheckUtils.java
+++ b/src/java6/java/org/spongepowered/launch/JavaVersionCheckUtils.java
@@ -50,6 +50,6 @@ public class JavaVersionCheckUtils {
     }
 
     private static String getCurrentVersion() {
-        return System.getProperty("java.version");
+        return System.getProperty("sponge.override.java.version", System.getProperty("java.version"));
     }
 }


### PR DESCRIPTION
java -jar -Dsponge.override.java.version=1.8.0_40 -jar ...

Can now be used to override the java version in the version
check. This is done to allow users who have invalidly versioned
versions of Java to still run the server.

Fixes  #660