### PR TITLE
Update HealthValueProcessor to fire DestructEntityEvent.Death

### DIFF
--- a/src/main/java/org/spongepowered/common/data/processor/value/entity/HealthValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/entity/HealthValueProcessor.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.data.processor.value.entity;
 import static org.spongepowered.common.data.util.ComparatorUtil.doubleComparator;
 
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.DamageSource;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.ValueContainer;
@@ -110,6 +111,9 @@ public class HealthValueProcessor extends AbstractSpongeValueProcessor<EntityLiv
                 ((EntityLivingBase) container).setHealth(value.floatValue());
             } catch (Exception e) {
                 return DataTransactionResult.errorResult(newHealthValue);
+            }
+            if (value.floatValue() <= 0.0F) {
+                ((EntityLivingBase) container).onDeath(DamageSource.generic);
             }
             return builder.success(newHealthValue).replace(oldHealthValue).result(DataTransactionResult.Type.SUCCESS).build();
         }


### PR DESCRIPTION
Currently, offering zero health to an entity does not fire the `DestructEntityEvent.Death`. This PR fixes that, and is based on the [HealthDataProcessor](https://github.com/SpongePowered/SpongeCommon/blob/master/src/main/java/org/spongepowered/common/data/processor/multi/entity/HealthDataProcessor.java#L67-L69), which manually calls EntityLivingBase#onDeath() if the health is set to zero. This was not getting called when going through the `ValueProcesor`, even though the client was correctly registering the death. Nor was the server printing a death message.

I would expect that a death due to a plugin setting an entities' health to zero would still fire the event in question.

I wrote a test plugin to check the behaviour of Sponge, to verify that setting health to zero wasn't firing the event. Running `/die` will set health to zero via offering `Keys.HEALTH`, `/die2` via `HeathData`, `/heal` to check it doesn't fire when setting the health to 20, and running `/creeper` spawns 20 creepers to ensure death occurs naturally.

Test code and relevant logs: https://gist.github.com/dualspiral/9072da43f6211ed09890ad0c1611c4eb