### PR TITLE
NBT Data Cleanup

### DIFF
--- a/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshotBuilder.java
+++ b/src/main/java/org/spongepowered/common/block/SpongeBlockSnapshotBuilder.java
@@ -102,9 +102,9 @@ public class SpongeBlockSnapshotBuilder extends AbstractDataBuilder<BlockSnapsho
     public SpongeBlockSnapshotBuilder position(Vector3i position) {
         this.coords = checkNotNull(position);
         if (this.compound != null) {
-            this.compound.setInteger(NbtDataUtil.TILE_ENTITY_POSITION_X, position.getX());
-            this.compound.setInteger(NbtDataUtil.TILE_ENTITY_POSITION_Y, position.getY());
-            this.compound.setInteger(NbtDataUtil.TILE_ENTITY_POSITION_Z, position.getZ());
+            this.compound.setInteger(NbtDataUtil.TileEntity.POS_X, position.getX());
+            this.compound.setInteger(NbtDataUtil.TileEntity.POS_Y, position.getY());
+            this.compound.setInteger(NbtDataUtil.TileEntity.POS_Z, position.getZ());
         }
         return this;
     }

--- a/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
+++ b/src/main/java/org/spongepowered/common/data/processor/common/SkullUtils.java
@@ -97,7 +97,7 @@ public class SkullUtils {
 
     public static Optional<GameProfile> getProfile(ItemStack skull) {
         if (isValidItemStack(skull) && getSkullType(skull).equals(SkullTypes.PLAYER)) {
-            final NBTTagCompound nbt = skull.getSubCompound(NbtDataUtil.ITEM_SKULL_OWNER, false);
+            final NBTTagCompound nbt = skull.getSubCompound(NbtDataUtil.Item.SKULL_OWNER, false);
             final com.mojang.authlib.GameProfile mcProfile = nbt == null ? null : NBTUtil.readGameProfileFromNBT(nbt);
             return Optional.ofNullable((GameProfile) mcProfile);
         }
@@ -108,12 +108,12 @@ public class SkullUtils {
         if (isValidItemStack(skull) && getSkullType(skull).equals(SkullTypes.PLAYER)) {
             if (profile == null || profile.equals(SpongeRepresentedPlayerData.NULL_PROFILE)) {
                 if (skull.getTagCompound() != null) {
-                    skull.getTagCompound().removeTag(NbtDataUtil.ITEM_SKULL_OWNER);
+                    skull.getTagCompound().removeTag(NbtDataUtil.Item.SKULL_OWNER);
                 }
             } else {
                 final NBTTagCompound nbt = new NBTTagCompound();
                 NBTUtil.writeGameProfile(nbt, (com.mojang.authlib.GameProfile) resolveProfileIfNecessary(profile));
-                skull.setTagInfo(NbtDataUtil.ITEM_SKULL_OWNER, nbt);
+                skull.setTagInfo(NbtDataUtil.Item.SKULL_OWNER, nbt);
             }
             return true;
         }

--- a/src/main/java/org/spongepowered/common/data/processor/data/DisplayNameDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/DisplayNameDataProcessor.java
@@ -97,12 +97,12 @@ public class DisplayNameDataProcessor extends AbstractSingleDataProcessor<Text, 
                     return Optional.empty(); // The book wasn't initialized.
                 }
 
-                return Optional.of(new SpongeDisplayNameData(SpongeTexts.fromLegacy(compound.getString(NbtDataUtil.ITEM_BOOK_TITLE))));
+                return Optional.of(new SpongeDisplayNameData(SpongeTexts.fromLegacy(compound.getString(NbtDataUtil.Item.Book.TITLE))));
             }
 
-            final NBTTagCompound compound = ((ItemStack) holder).getSubCompound(NbtDataUtil.ITEM_DISPLAY, false);
-            if (compound != null && compound.hasKey(NbtDataUtil.ITEM_DISPLAY_NAME, 8)) {
-                return Optional.of(new SpongeDisplayNameData(SpongeTexts.fromLegacy(compound.getString(NbtDataUtil.ITEM_DISPLAY_NAME))));
+            final NBTTagCompound compound = ((ItemStack) holder).getSubCompound(NbtDataUtil.Item.DISPLAY_TAG, false);
+            if (compound != null && compound.hasKey(NbtDataUtil.Item.DISPLAY_NAME, 8)) {
+                return Optional.of(new SpongeDisplayNameData(SpongeTexts.fromLegacy(compound.getString(NbtDataUtil.Item.DISPLAY_NAME))));
             } else {
                 return Optional.empty();
             }

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/BreakableDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/BreakableDataProcessor.java
@@ -58,12 +58,12 @@ public class BreakableDataProcessor
 
     @Override
     protected Optional<Set<BlockType>> getVal(ItemStack itemStack) {
-        return BreakablePlaceableUtils.get(itemStack, NbtDataUtil.ITEM_BREAKABLE_BLOCKS);
+        return BreakablePlaceableUtils.get(itemStack, NbtDataUtil.Item.CAN_DESTROY);
     }
 
     @Override
     protected boolean set(ItemStack itemStack, Set<BlockType> value) {
-        return BreakablePlaceableUtils.set(itemStack, NbtDataUtil.ITEM_BREAKABLE_BLOCKS, value);
+        return BreakablePlaceableUtils.set(itemStack, NbtDataUtil.Item.CAN_DESTROY, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/GenerationDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/GenerationDataProcessor.java
@@ -66,13 +66,13 @@ public final class GenerationDataProcessor
 
     @Override
     protected boolean set(ItemStack stack, Integer value) {
-        NbtDataUtil.getOrCreateCompound(stack).setInteger(NbtDataUtil.ITEM_BOOK_GENERATION, value);
+        NbtDataUtil.getOrCreateCompound(stack).setInteger(NbtDataUtil.Item.Book.GENERATION, value);
         return true;
     }
 
     @Override
     protected Optional<Integer> getVal(ItemStack stack) {
-        return Optional.of(NbtDataUtil.getItemCompound(stack).map(tag -> tag.getInteger(NbtDataUtil.ITEM_BOOK_GENERATION)).orElse(0));
+        return Optional.of(NbtDataUtil.getItemCompound(stack).map(tag -> tag.getInteger(NbtDataUtil.Item.Book.GENERATION)).orElse(0));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemAuthorDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemAuthorDataProcessor.java
@@ -66,16 +66,16 @@ public class ItemAuthorDataProcessor extends AbstractItemSingleDataProcessor<Tex
         if (!itemStack.hasTagCompound()) {
             itemStack.setTagCompound(new NBTTagCompound());
         }
-        itemStack.getTagCompound().setString(NbtDataUtil.ITEM_BOOK_AUTHOR, SpongeTexts.toLegacy(value));
+        itemStack.getTagCompound().setString(NbtDataUtil.Item.Book.AUTHOR, SpongeTexts.toLegacy(value));
         return true;
     }
 
     @Override
     protected Optional<Text> getVal(ItemStack itemStack) {
-        if (!itemStack.hasTagCompound() || !itemStack.getTagCompound().hasKey(NbtDataUtil.ITEM_BOOK_AUTHOR)) {
+        if (!itemStack.hasTagCompound() || !itemStack.getTagCompound().hasKey(NbtDataUtil.Item.Book.AUTHOR)) {
             return Optional.empty();
         }
-        final String json = itemStack.getTagCompound().getString(NbtDataUtil.ITEM_BOOK_AUTHOR);
+        final String json = itemStack.getTagCompound().getString(NbtDataUtil.Item.Book.AUTHOR);
         final Text author = TextSerializers.JSON.deserializeUnchecked(json);
         return Optional.of(author);
     }

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemEnchantmentDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemEnchantmentDataProcessor.java
@@ -101,7 +101,7 @@ public class ItemEnchantmentDataProcessor
             if (!old.isPresent()) {
                 return DataTransactionResult.successNoData();
             }
-            stack.getTagCompound().removeTag(NbtDataUtil.ITEM_ENCHANTMENT_LIST);
+            stack.getTagCompound().removeTag(NbtDataUtil.Item.ENCHANTMENT_LIST);
             return DataTransactionResult.successRemove(constructImmutableValue(old.get()));
         }
         return DataTransactionResult.failNoData();

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemLockableDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemLockableDataProcessor.java
@@ -77,7 +77,7 @@ public final class ItemLockableDataProcessor extends AbstractItemSingleDataProce
     @Override
     protected boolean set(ItemStack stack, String value) {
         NBTTagCompound mainCompound = NbtDataUtil.getOrCreateCompound(stack);
-        NBTTagCompound tileCompound = NbtDataUtil.getOrCreateSubCompound(mainCompound, NbtDataUtil.BLOCK_ENTITY_TAG);
+        NBTTagCompound tileCompound = NbtDataUtil.getOrCreateSubCompound(mainCompound, NbtDataUtil.TileEntity.TILE_ENTITY_ROOT);
         LockCode code = new LockCode(value);
         if (code.isEmpty()) {
             tileCompound.removeTag("Lock");
@@ -92,7 +92,7 @@ public final class ItemLockableDataProcessor extends AbstractItemSingleDataProce
         if (container.getTagCompound() == null) {
             return Optional.of("");
         }
-        NBTTagCompound tileCompound = container.getTagCompound().getCompoundTag(NbtDataUtil.BLOCK_ENTITY_TAG);
+        NBTTagCompound tileCompound = container.getTagCompound().getCompoundTag(NbtDataUtil.TileEntity.TILE_ENTITY_ROOT);
         LockCode code = LockCode.fromNBT(tileCompound);
         if (code.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemLoreDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemLoreDataProcessor.java
@@ -87,11 +87,11 @@ public class ItemLoreDataProcessor extends AbstractItemSingleDataProcessor<List<
 
     @Override
     protected Optional<List<Text>> getVal(ItemStack itemStack) {
-        final NBTTagCompound subCompound = itemStack.getSubCompound(NbtDataUtil.ITEM_DISPLAY, false);
+        final NBTTagCompound subCompound = itemStack.getSubCompound(NbtDataUtil.Item.DISPLAY_TAG, false);
         if (subCompound == null) {
             return Optional.empty();
         }
-        if (!subCompound.hasKey(NbtDataUtil.ITEM_LORE, NbtDataUtil.TAG_LIST)) {
+        if (!subCompound.hasKey(NbtDataUtil.Item.LORE, NbtDataUtil.TAG_LIST)) {
             return Optional.empty();
         }
         return Optional.of(NbtDataUtil.getLoreFromNBT(subCompound));

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemPagedDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemPagedDataProcessor.java
@@ -89,7 +89,7 @@ public class ItemPagedDataProcessor extends AbstractItemSingleDataProcessor<List
 
     @Override
     protected Optional<List<Text>> getVal(ItemStack itemStack) {
-        if (!itemStack.hasTagCompound() || !itemStack.getTagCompound().hasKey(NbtDataUtil.ITEM_BOOK_PAGES)) {
+        if (!itemStack.hasTagCompound() || !itemStack.getTagCompound().hasKey(NbtDataUtil.Item.Book.PAGES)) {
             return Optional.empty();
         }
         return Optional.of(NbtDataUtil.getPagesFromNBT(getTagCompound(itemStack)));

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemPotionDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemPotionDataProcessor.java
@@ -65,7 +65,7 @@ public class ItemPotionDataProcessor extends AbstractItemSingleDataProcessor<Lis
             ((net.minecraft.potion.PotionEffect) effect).writeCustomPotionEffectToNBT(potionCompound);
             potionList.appendTag(potionCompound);
         }
-        mainCompound.setTag(NbtDataUtil.CUSTOM_POTION_EFFECTS, potionList);
+        mainCompound.setTag(NbtDataUtil.Item.CUSTOM_POTION_EFFECTS, potionList);
         return true;
     }
 
@@ -111,7 +111,7 @@ public class ItemPotionDataProcessor extends AbstractItemSingleDataProcessor<Lis
         }
 
         final NBTTagCompound tagCompound = itemStack.getTagCompound();
-        tagCompound.setTag(NbtDataUtil.CUSTOM_POTION_EFFECTS, new NBTTagList());
+        tagCompound.setTag(NbtDataUtil.Item.CUSTOM_POTION_EFFECTS, new NBTTagList());
         if (currentEffects.isPresent()) {
             return DataTransactionResult.successRemove(constructImmutableValue(currentEffects.get()));
         } else {

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/ItemSignDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/ItemSignDataProcessor.java
@@ -64,13 +64,13 @@ public class ItemSignDataProcessor extends AbstractItemSingleDataProcessor<List<
             return Optional.empty();
         }
         final NBTTagCompound mainCompound = itemStack.getTagCompound();
-        if (!mainCompound.hasKey(NbtDataUtil.BLOCK_ENTITY_TAG, NbtDataUtil.TAG_COMPOUND)
-                || !mainCompound.getCompoundTag(NbtDataUtil.BLOCK_ENTITY_TAG).hasKey(NbtDataUtil.BLOCK_ENTITY_ID)) {
+        if (!mainCompound.hasKey(NbtDataUtil.TileEntity.TILE_ENTITY_ROOT, NbtDataUtil.TAG_COMPOUND)
+                || !mainCompound.getCompoundTag(NbtDataUtil.TileEntity.TILE_ENTITY_ROOT).hasKey(NbtDataUtil.TileEntity.TILE_ENTITY_ID)) {
             return Optional.empty();
         }
-        final NBTTagCompound tileCompound = mainCompound.getCompoundTag(NbtDataUtil.BLOCK_ENTITY_TAG);
-        final String id = tileCompound.getString(NbtDataUtil.BLOCK_ENTITY_ID);
-        if (!id.equalsIgnoreCase(NbtDataUtil.SIGN)) {
+        final NBTTagCompound tileCompound = mainCompound.getCompoundTag(NbtDataUtil.TileEntity.TILE_ENTITY_ROOT);
+        final String id = tileCompound.getString(NbtDataUtil.TileEntity.TILE_ENTITY_ID);
+        if (!id.equalsIgnoreCase(NbtDataUtil.TileEntity.SIGN)) {
             return Optional.empty();
         }
         final List<Text> texts = Lists.newArrayListWithCapacity(4);
@@ -101,8 +101,8 @@ public class ItemSignDataProcessor extends AbstractItemSingleDataProcessor<List<
     @Override
     protected boolean set(ItemStack itemStack, List<Text> lines) {
         final NBTTagCompound mainCompound = NbtDataUtil.getOrCreateCompound(itemStack);
-        final NBTTagCompound tileCompound = NbtDataUtil.getOrCreateSubCompound(mainCompound, NbtDataUtil.BLOCK_ENTITY_TAG);
-        tileCompound.setString(NbtDataUtil.BLOCK_ENTITY_ID, NbtDataUtil.SIGN);
+        final NBTTagCompound tileCompound = NbtDataUtil.getOrCreateSubCompound(mainCompound, NbtDataUtil.TileEntity.TILE_ENTITY_ROOT);
+        tileCompound.setString(NbtDataUtil.TileEntity.TILE_ENTITY_ID, NbtDataUtil.TileEntity.SIGN);
         for (int i = 0; i < 4; i++) {
             Text line = lines.size() > i ? lines.get(i) : Text.EMPTY;
             if (line == null) {
@@ -124,7 +124,7 @@ public class ItemSignDataProcessor extends AbstractItemSingleDataProcessor<List<
             return DataTransactionResult.successNoData();
         }
         try {
-            NbtDataUtil.getItemCompound(itemStack).get().removeTag(NbtDataUtil.BLOCK_ENTITY_TAG);
+            NbtDataUtil.getItemCompound(itemStack).get().removeTag(NbtDataUtil.TileEntity.TILE_ENTITY_ROOT);
             return DataTransactionResult.successRemove(constructImmutableValue(old.get()));
         } catch (Exception e) {
             return DataTransactionResult.builder().result(DataTransactionResult.Type.ERROR).build();

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/PlaceableDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/PlaceableDataProcessor.java
@@ -58,12 +58,12 @@ public class PlaceableDataProcessor
 
     @Override
     protected Optional<Set<BlockType>> getVal(ItemStack itemStack) {
-        return BreakablePlaceableUtils.get(itemStack, NbtDataUtil.ITEM_PLACEABLE_BLOCKS);
+        return BreakablePlaceableUtils.get(itemStack, NbtDataUtil.Item.CAN_PLACE_ON);
     }
 
     @Override
     protected boolean set(ItemStack itemStack, Set<BlockType> value) {
-        return BreakablePlaceableUtils.set(itemStack, NbtDataUtil.ITEM_PLACEABLE_BLOCKS, value);
+        return BreakablePlaceableUtils.set(itemStack, NbtDataUtil.Item.CAN_PLACE_ON, value);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/data/processor/data/item/StoredEnchantmentDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/item/StoredEnchantmentDataProcessor.java
@@ -66,26 +66,26 @@ public class StoredEnchantmentDataProcessor extends
         NBTTagList list = new NBTTagList();
         for (ItemEnchantment enchantment : value) {
             NBTTagCompound tag = new NBTTagCompound();
-            tag.setShort(NbtDataUtil.ITEM_ENCHANTMENT_ID, (short) ((net.minecraft.enchantment.Enchantment) enchantment.getEnchantment()).effectId);
-            tag.setShort(NbtDataUtil.ITEM_ENCHANTMENT_LEVEL, (short) enchantment.getLevel());
+            tag.setShort(NbtDataUtil.Item.ENCHANTMENT_ID, (short) ((net.minecraft.enchantment.Enchantment) enchantment.getEnchantment()).effectId);
+            tag.setShort(NbtDataUtil.Item.ENCHANTMENT_LEVEL, (short) enchantment.getLevel());
             list.appendTag(tag);
         }
-        entity.getTagCompound().setTag(NbtDataUtil.ITEM_STORED_ENCHANTMENTS_LIST, list);
+        entity.getTagCompound().setTag(NbtDataUtil.Item.STORED_ENCHANTMENTS, list);
         return true;
     }
 
     @Override
     protected Optional<List<ItemEnchantment>> getVal(ItemStack entity) {
-        if (!entity.hasTagCompound() || !entity.getTagCompound().hasKey(NbtDataUtil.ITEM_STORED_ENCHANTMENTS_LIST, NbtDataUtil.TAG_LIST)) {
+        if (!entity.hasTagCompound() || !entity.getTagCompound().hasKey(NbtDataUtil.Item.STORED_ENCHANTMENTS, NbtDataUtil.TAG_LIST)) {
             return Optional.empty();
         }
         List<ItemEnchantment> list = Lists.newArrayList();
-        NBTTagList tags = entity.getTagCompound().getTagList(NbtDataUtil.ITEM_STORED_ENCHANTMENTS_LIST, NbtDataUtil.TAG_COMPOUND);
+        NBTTagList tags = entity.getTagCompound().getTagList(NbtDataUtil.Item.STORED_ENCHANTMENTS, NbtDataUtil.TAG_COMPOUND);
         for (int i = 0; i < tags.tagCount(); i++) {
             NBTTagCompound tag = tags.getCompoundTagAt(i);
             list.add(new ItemEnchantment(
-                    (Enchantment) net.minecraft.enchantment.Enchantment.getEnchantmentById(tag.getShort(NbtDataUtil.ITEM_ENCHANTMENT_ID)),
-                    tag.getShort(NbtDataUtil.ITEM_ENCHANTMENT_LEVEL)));
+                    (Enchantment) net.minecraft.enchantment.Enchantment.getEnchantmentById(tag.getShort(NbtDataUtil.Item.ENCHANTMENT_ID)),
+                    tag.getShort(NbtDataUtil.Item.ENCHANTMENT_LEVEL)));
         }
         return Optional.of(list);
     }
@@ -104,8 +104,8 @@ public class StoredEnchantmentDataProcessor extends
     public DataTransactionResult removeFrom(ValueContainer<?> container) {
         if (supports(container)) {
             ItemStack stack = (ItemStack) container;
-            if (stack.hasTagCompound() && stack.getTagCompound().hasKey(NbtDataUtil.ITEM_STORED_ENCHANTMENTS_LIST, NbtDataUtil.TAG_COMPOUND)) {
-                stack.getTagCompound().removeTag(NbtDataUtil.ITEM_STORED_ENCHANTMENTS_LIST);
+            if (stack.hasTagCompound() && stack.getTagCompound().hasKey(NbtDataUtil.Item.STORED_ENCHANTMENTS, NbtDataUtil.TAG_COMPOUND)) {
+                stack.getTagCompound().removeTag(NbtDataUtil.Item.STORED_ENCHANTMENTS);
             }
             return DataTransactionResult.successNoData();
         }

--- a/src/main/java/org/spongepowered/common/data/processor/multi/item/DurabilityDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/item/DurabilityDataProcessor.java
@@ -62,15 +62,15 @@ public class DurabilityDataProcessor extends AbstractItemDataProcessor<Durabilit
         if (!itemStack.hasTagCompound()) {
             itemStack.setTagCompound(new NBTTagCompound());
         }
-        itemStack.getTagCompound().setBoolean(NbtDataUtil.ITEM_UNBREAKABLE, unbreakable);
+        itemStack.getTagCompound().setBoolean(NbtDataUtil.Item.UNBREAKABLE, unbreakable);
         return true;
     }
 
     @Override
     public Map<Key<?>, ?> getValues(ItemStack itemStack) {
-        if (itemStack.hasTagCompound() && itemStack.getTagCompound().hasKey(NbtDataUtil.ITEM_UNBREAKABLE)) {
+        if (itemStack.hasTagCompound() && itemStack.getTagCompound().hasKey(NbtDataUtil.Item.UNBREAKABLE)) {
             return ImmutableMap.of(Keys.ITEM_DURABILITY, itemStack.getMaxDamage() - itemStack.getItemDamage(),
-                    Keys.UNBREAKABLE, itemStack.getTagCompound().getBoolean(NbtDataUtil.ITEM_UNBREAKABLE));
+                    Keys.UNBREAKABLE, itemStack.getTagCompound().getBoolean(NbtDataUtil.Item.UNBREAKABLE));
         }
         return ImmutableMap.of(Keys.ITEM_DURABILITY, itemStack.getMaxDamage() - itemStack.getItemDamage(), Keys.UNBREAKABLE, false);
     }

--- a/src/main/java/org/spongepowered/common/data/processor/multi/item/HideDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/item/HideDataProcessor.java
@@ -77,7 +77,7 @@ public class HideDataProcessor extends AbstractMultiDataSingleTargetProcessor<It
         if ((boolean) keyValues.get(Keys.HIDE_MISCELLANEOUS)) {
             flag |= DataConstants.HIDE_MISCELLANEOUS_FLAG;
         }
-        dataHolder.getTagCompound().setInteger(NbtDataUtil.ITEM_HIDE_FLAGS, flag);
+        dataHolder.getTagCompound().setInteger(NbtDataUtil.Item.HIDE_FLAGS, flag);
         return true;
     }
 
@@ -87,7 +87,7 @@ public class HideDataProcessor extends AbstractMultiDataSingleTargetProcessor<It
             return Maps.newHashMap();
         }
         Map<Key<?>, Boolean> map = Maps.newHashMap();
-        int flag = dataHolder.getTagCompound().getInteger(NbtDataUtil.ITEM_HIDE_FLAGS);
+        int flag = dataHolder.getTagCompound().getInteger(NbtDataUtil.Item.HIDE_FLAGS);
 
         map.put(Keys.HIDE_MISCELLANEOUS, (flag & DataConstants.HIDE_MISCELLANEOUS_FLAG) != 0);
         map.put(Keys.HIDE_CAN_PLACE, (flag & DataConstants.HIDE_CAN_PLACE_FLAG) != 0);
@@ -124,8 +124,8 @@ public class HideDataProcessor extends AbstractMultiDataSingleTargetProcessor<It
     public DataTransactionResult remove(DataHolder dataHolder) {
         if (supports(dataHolder)) {
             ItemStack data = (ItemStack) dataHolder;
-            if (data.hasTagCompound() && data.getTagCompound().hasKey(NbtDataUtil.ITEM_HIDE_FLAGS, NbtDataUtil.TAG_INT)) {
-                data.getTagCompound().removeTag(NbtDataUtil.ITEM_HIDE_FLAGS);
+            if (data.hasTagCompound() && data.getTagCompound().hasKey(NbtDataUtil.Item.HIDE_FLAGS, NbtDataUtil.TAG_INT)) {
+                data.getTagCompound().removeTag(NbtDataUtil.Item.HIDE_FLAGS);
             }
             return DataTransactionResult.successNoData();
         }

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/AbstractHideFlagsValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/AbstractHideFlagsValueProcessor.java
@@ -56,19 +56,19 @@ public abstract class AbstractHideFlagsValueProcessor extends AbstractSpongeValu
         if (!container.hasTagCompound()) {
             container.setTagCompound(new NBTTagCompound());
         }
-        if (container.getTagCompound().hasKey(NbtDataUtil.ITEM_HIDE_FLAGS, NbtDataUtil.TAG_INT)) {
-            int flag = container.getTagCompound().getInteger(NbtDataUtil.ITEM_HIDE_FLAGS);
+        if (container.getTagCompound().hasKey(NbtDataUtil.Item.HIDE_FLAGS, NbtDataUtil.TAG_INT)) {
+            int flag = container.getTagCompound().getInteger(NbtDataUtil.Item.HIDE_FLAGS);
             if (value) {
                 container.getTagCompound()
-                        .setInteger(NbtDataUtil.ITEM_HIDE_FLAGS, flag | this.flag);
+                        .setInteger(NbtDataUtil.Item.HIDE_FLAGS, flag | this.flag);
             } else {
                 container.getTagCompound()
-                        .setInteger(NbtDataUtil.ITEM_HIDE_FLAGS,
+                        .setInteger(NbtDataUtil.Item.HIDE_FLAGS,
                                 flag & ~this.flag);
             }
         } else {
             if (value) {
-                container.getTagCompound().setInteger(NbtDataUtil.ITEM_HIDE_FLAGS, this.flag);
+                container.getTagCompound().setInteger(NbtDataUtil.Item.HIDE_FLAGS, this.flag);
             }
         }
         return true;
@@ -76,8 +76,8 @@ public abstract class AbstractHideFlagsValueProcessor extends AbstractSpongeValu
 
     @Override
     protected Optional<Boolean> getVal(ItemStack container) {
-        if (container.hasTagCompound() && container.getTagCompound().hasKey(NbtDataUtil.ITEM_HIDE_FLAGS, NbtDataUtil.TAG_INT)) {
-            int flag = container.getTagCompound().getInteger(NbtDataUtil.ITEM_HIDE_FLAGS);
+        if (container.hasTagCompound() && container.getTagCompound().hasKey(NbtDataUtil.Item.HIDE_FLAGS, NbtDataUtil.TAG_INT)) {
+            int flag = container.getTagCompound().getInteger(NbtDataUtil.Item.HIDE_FLAGS);
             if ((flag & this.flag) != 0) {
                 return Optional.of(true);
             } else {

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/ItemDisplayNameValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/ItemDisplayNameValueProcessor.java
@@ -33,10 +33,8 @@ import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
-import org.spongepowered.common.data.util.DataConstants;
 import org.spongepowered.common.data.util.NbtDataUtil;
 import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
 import org.spongepowered.common.data.value.mutable.SpongeValue;
@@ -61,7 +59,7 @@ public class ItemDisplayNameValueProcessor extends AbstractSpongeValueProcessor<
         final String legacy = SpongeTexts.toLegacy(value);
         if (container.getItem() == Items.written_book) {
             NBTTagCompound mainCompound = container.getTagCompound();
-            mainCompound.setString(NbtDataUtil.ITEM_BOOK_TITLE, legacy);
+            mainCompound.setString(NbtDataUtil.Item.Book.TITLE, legacy);
         } else {
             container.setStackDisplayName(legacy);
         }
@@ -76,12 +74,12 @@ public class ItemDisplayNameValueProcessor extends AbstractSpongeValueProcessor<
             if (mainCompound == null) {
                 return Optional.empty(); // Basically, this book wasn't initialized properly.
             }
-            final String titleString = mainCompound.getString(NbtDataUtil.ITEM_BOOK_TITLE);
+            final String titleString = mainCompound.getString(NbtDataUtil.Item.Book.TITLE);
             return Optional.of(SpongeTexts.fromLegacy(titleString));
         }
-        final NBTTagCompound mainCompound = container.getSubCompound(NbtDataUtil.ITEM_DISPLAY, false);
-        if (mainCompound != null && mainCompound.hasKey(NbtDataUtil.ITEM_DISPLAY_NAME, NbtDataUtil.TAG_STRING)) {
-            final String displayString = mainCompound.getString(NbtDataUtil.ITEM_DISPLAY_NAME);
+        final NBTTagCompound mainCompound = container.getSubCompound(NbtDataUtil.Item.DISPLAY_TAG, false);
+        if (mainCompound != null && mainCompound.hasKey(NbtDataUtil.Item.DISPLAY_NAME, NbtDataUtil.TAG_STRING)) {
+            final String displayString = mainCompound.getString(NbtDataUtil.Item.DISPLAY_NAME);
             return Optional.of(SpongeTexts.fromLegacy(displayString));
         } else {
             return Optional.empty();

--- a/src/main/java/org/spongepowered/common/data/processor/value/item/UnbreakableValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/item/UnbreakableValueProcessor.java
@@ -61,14 +61,14 @@ public class UnbreakableValueProcessor extends AbstractSpongeValueProcessor<Item
         if (!container.hasTagCompound()) {
             container.setTagCompound(new NBTTagCompound());
         }
-        container.getTagCompound().setBoolean(NbtDataUtil.ITEM_UNBREAKABLE, value);
+        container.getTagCompound().setBoolean(NbtDataUtil.Item.UNBREAKABLE, value);
         return true;
     }
 
     @Override
     public Optional<Boolean> getVal(ItemStack container) {
-        if (container.hasTagCompound() && container.getTagCompound().hasKey(NbtDataUtil.ITEM_UNBREAKABLE)) {
-            return Optional.of(container.getTagCompound().getBoolean(NbtDataUtil.ITEM_UNBREAKABLE));
+        if (container.hasTagCompound() && container.getTagCompound().hasKey(NbtDataUtil.Item.UNBREAKABLE)) {
+            return Optional.of(container.getTagCompound().getBoolean(NbtDataUtil.Item.UNBREAKABLE));
         }
         return Optional.of(false);
     }

--- a/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
+++ b/src/main/java/org/spongepowered/common/data/util/NbtDataUtil.java
@@ -51,55 +51,8 @@ import java.util.Optional;
  */
 public final class NbtDataUtil {
 
-    public static final String BANNER_PATTERN_ID = "Pattern";
-    public static final String BANNER_PATTERN_COLOR = "Color";
-    public static final String ENTITY_ROTATION = "Rotation";
-
     private NbtDataUtil() {
     }
-
-    // These are the various tag compound id's for getting to various places
-    public static final String BLOCK_ENTITY_TAG = "BlockEntityTag";
-    public static final String BLOCK_ENTITY_ID = "id";
-    public static final String SIGN = "Sign";
-
-    public static final String TILE_ENTITY_POSITION_X = "x";
-    public static final String TILE_ENTITY_POSITION_Y = "y";
-    public static final String TILE_ENTITY_POSITION_Z = "z";
-
-    public static final String ITEM_ENCHANTMENT_LIST = "ench";
-    public static final String ITEM_STORED_ENCHANTMENTS_LIST = "StoredEnchantments";
-    public static final String ITEM_ENCHANTMENT_ID = "id";
-    public static final String ITEM_ENCHANTMENT_LEVEL = "lvl";
-
-    public static final String ITEM_DISPLAY = "display";
-    public static final String ITEM_DISPLAY_NAME = "Name";
-    public static final String ITEM_LORE = "Lore";
-    public static final String ITEM_COLOR = "color";
-
-    public static final String ITEM_BOOK_PAGES = "pages";
-    public static final String ITEM_BOOK_TITLE = "title";
-    public static final String ITEM_BOOK_AUTHOR = "author";
-    public static final String ITEM_BOOK_RESOLVED = "resolved";
-    public static final String ITEM_BOOK_GENERATION = "generation";
-
-    public static final String ITEM_BREAKABLE_BLOCKS = "CanDestroy";
-    public static final String ITEM_PLACEABLE_BLOCKS = "CanPlaceOn";
-
-    public static final String ITEM_SKULL_OWNER = "SkullOwner";
-
-    public static final String ITEM_UNBREAKABLE = "Unbreakable";
-
-    public static final String ITEM_HIDE_FLAGS = "HideFlags";
-
-    public static final String CUSTOM_POTION_EFFECTS = "CustomPotionEffects";
-
-    public static final String USER_SPAWN_X = "SpawnX";
-    public static final String USER_SPAWN_Y = "SpawnY";
-    public static final String USER_SPAWN_Z = "SpawnZ";
-    public static final String USER_SPAWN_FORCED = "SpawnForced";
-    public static final String USER_SPAWN_LIST = "Spawns";
-    public static final String USER_SPAWN_DIM = "Dim";
 
     // These are the NBT Tag byte id's that can be used in various places while manipulating compound tags
     public static final byte TAG_END = 0;
@@ -116,42 +69,132 @@ public final class NbtDataUtil {
     public static final byte TAG_INT_ARRAY = 11;
     public static final byte TAG_ANY_NUMERIC = 99;
 
-    // These are Sponge's NBT tag keys
-    public static final String SPONGE_DATA = "SpongeData";
-    public static final String SPONGE_ENTITY_CREATOR = "Creator";
-    public static final String SPONGE_ENTITY_NOTIFIER = "Notifier";
-    public static final String SPONGE_BLOCK_POS_TABLE = "BlockPosTable";
-    public static final String SPONGE_PLAYER_UUID_TABLE = "PlayerIdTable";
-    public static final String CUSTOM_MANIPULATOR_TAG_LIST = "CustomManipulators";
-    public static final String PROJECTILE_DAMAGE_AMOUNT = "damageAmount";
-    public static final String BOAT_MAX_SPEED = "maxSpeed";
-    public static final String BOAT_MOVE_ON_LAND = "moveOnLand";
-    public static final String BOAT_OCCUPIED_DECELERATION_SPEED = "occupiedDecelerationSpeed";
-    public static final String BOAT_UNOCCUPIED_DECELERATION_SPEED = "unoccupiedDecelerationSpeed";
+    public static final class General {
+
+        // These are Sponge's NBT tag keys
+        public static final String SPONGE_DATA = "SpongeData";
+        public static final String CUSTOM_MANIPULATOR_TAG_LIST = "CustomManipulators";
+
+        public static final class Player {
+
+        }
+    }
+
+    public static final class Entity {
+
+        public static final String SPONGE_ENTITY_CREATOR = "Creator";
+        public static final String SPONGE_ENTITY_NOTIFIER = "Notifier";
+        public static final String CAN_GRIEF = "CanGrief";
+        public static final String ENTITY_TYPE_ID = "id";
+        public static final String ENTITY_POSITION = "Pos";
+        public static final String ENTITY_ROTATION = "Rotation";
+
+        public static final class Boat {
+
+            public static final String MAX_SPEED = "maxSpeed";
+            public static final String MOVE_ON_LAND = "moveOnLand";
+            public static final String OCCUPIED_DECELERATION_SPEED = "occupiedDecelerationSpeed";
+            public static final String UNOCCUPIED_DECELERATION_SPEED = "unoccupiedDecelerationSpeed";
+        }
+
+        public static final class Projectile {
+
+            public static final String DAMAGE_AMOUNT = "damageAmount";
+        }
+
+        public static final class Minecart {
+
+            public static final String MINECART_TYPE = "Type";
+        }
+    }
+
+    public static final class TileEntity {
+
+        public static final String BANNER_PATTERN_ID = "Pattern";
+        public static final String BANNER_PATTERN_COLOR = "Color";
+        // These are the various tag compound id's for getting to various places
+        public static final String TILE_ENTITY_ROOT = "BlockEntityTag";
+        public static final String TILE_ENTITY_ID = "id";
+        public static final String SIGN = "Sign";
+        public static final String POS_X = "x";
+        public static final String POS_Y = "y";
+        public static final String POS_Z = "z";
+    }
+
+    public static final class Compatibility {
+
+        public static final String USER_SPAWN_X = "SpawnX";
+        public static final String USER_SPAWN_Y = "SpawnY";
+        public static final String USER_SPAWN_Z = "SpawnZ";
+        public static final String USER_SPAWN_FORCED = "SpawnForced";
+        public static final String USER_SPAWN_LIST = "Spawns";
+        public static final String USER_SPAWN_DIM = "Dim";
+
+        public static final class Bukkit {
+
+            // Legacy migration tags from Bukkit
+            public static final String BUKKIT_ROOT = "bukkit";
+            public static final String FIRST_PLAYED = "firstPlayed";
+            public static final String LAST_PLAYED = "lastPlayed";
+        }
+
+        public static final class Forge {
+
+            // Compatibility tags for Forge
+            public static final String FORGE_ROOT = "ForgeData";
+            public static final String FORGE_ENTITY_TYPE = "entity_name";
+        }
+
+    }
+
+    public static final class World {
+
+        public static final String DIMENSION_TYPE = "dimensionType";
+        public static final String DIMENSION_ID = "dimensionId";
+        public static final String IS_MOD = "isMod";
+    }
+
+    public static final class Chunk {
+
+
+        public static final String SPONGE_BLOCK_POS_TABLE = "BlockPosTable";
+        public static final String SPONGE_PLAYER_UUID_TABLE = "PlayerIdTable";
+    }
+
+    public static final class Item {
+
+        public static final String CUSTOM_POTION_EFFECTS = "CustomPotionEffects";
+        public static final String HIDE_FLAGS = "HideFlags";
+        public static final String UNBREAKABLE = "Unbreakable";
+        public static final String SKULL_OWNER = "SkullOwner";
+        public static final String ENCHANTMENT_LIST = "ench";
+        public static final String STORED_ENCHANTMENTS = "StoredEnchantments";
+        public static final String ENCHANTMENT_ID = "id";
+        public static final String ENCHANTMENT_LEVEL = "lvl";
+        public static final String DISPLAY_TAG = "display";
+        public static final String DISPLAY_NAME = "Name";
+        public static final String LORE = "Lore";
+        public static final String COLOR = "color";
+        public static final String CAN_DESTROY = "CanDestroy";
+        public static final String CAN_PLACE_ON = "CanPlaceOn";
+
+        public static final class Book {
+
+            public static final String PAGES = "pages";
+            public static final String TITLE = "title";
+            public static final String AUTHOR = "author";
+            public static final String RESOLVED = "resolved";
+            public static final String GENERATION = "generation";
+            public static final String INVALID_TITLE = "invalid";
+        }
+    }
+
     public static final String LEVEL_NAME = "LevelName";
     public static final String WORLD_UUID_MOST = "uuid_most";
     public static final String WORLD_UUID_LEAST = "uuid_least";
-    public static final String CAN_GRIEF = "CanGrief";
 
-    // Compatibility tags for Forge
-    public static final String FORGE_DATA_TAG = "ForgeData";
     public static final String UUID_MOST = "UUIDMost";
     public static final String UUID_LEAST = "UUIDLeast";
-    public static final String DIMENSION_TYPE = "dimensionType";
-    public static final String DIMENSION_ID = "dimensionId";
-    public static final String INVALID_TITLE = "invalid";
-    public static final String IS_MOD = "isMod";
-    public static final String FORGE_ENTITY_TYPE = "entity_name";
-
-    // Legacy migration tags from Bukkit
-    public static final String BUKKIT = "bukkit";
-    public static final String BUKKIT_FIRST_PLAYED = "firstPlayed";
-    public static final String BUKKIT_LAST_PLAYED = "lastPlayed";
-
-    // These are used by Minecraft's internals for entity spawning
-    public static final String ENTITY_TYPE_ID = "id";
-    public static final String MINECART_TYPE = "Type";
-    public static final String ENTITY_POSITION = "Pos";
 
     // These methods are provided as API like getters since the internal ItemStack does return nullable NBTTagCompounds.
 
@@ -211,13 +254,13 @@ public final class NbtDataUtil {
     }
 
     public static NBTTagCompound filterSpongeCustomData(NBTTagCompound rootCompound) {
-        if (rootCompound.hasKey(FORGE_DATA_TAG, TAG_COMPOUND)) {
-            final NBTTagCompound forgeCompound = rootCompound.getCompoundTag(FORGE_DATA_TAG);
-            if (forgeCompound.hasKey(SPONGE_DATA, TAG_COMPOUND)) {
-                cleanseInnerCompound(forgeCompound, SPONGE_DATA);
+        if (rootCompound.hasKey(Compatibility.Forge.FORGE_ROOT, TAG_COMPOUND)) {
+            final NBTTagCompound forgeCompound = rootCompound.getCompoundTag(Compatibility.Forge.FORGE_ROOT);
+            if (forgeCompound.hasKey(General.SPONGE_DATA, TAG_COMPOUND)) {
+                cleanseInnerCompound(forgeCompound, General.SPONGE_DATA);
             }
-        } else if (rootCompound.hasKey(SPONGE_DATA, TAG_COMPOUND)) {
-            cleanseInnerCompound(rootCompound, SPONGE_DATA);
+        } else if (rootCompound.hasKey(General.SPONGE_DATA, TAG_COMPOUND)) {
+            cleanseInnerCompound(rootCompound, General.SPONGE_DATA);
         }
         return rootCompound;
     }
@@ -230,49 +273,49 @@ public final class NbtDataUtil {
     }
 
     public static List<Text> getLoreFromNBT(NBTTagCompound subCompound) {
-        final NBTTagList list = subCompound.getTagList(ITEM_LORE, TAG_STRING);
+        final NBTTagList list = subCompound.getTagList(Item.LORE, TAG_STRING);
         return SpongeTexts.fromNbtLegacy(list);
     }
 
     public static void removeLoreFromNBT(ItemStack stack) {
-        if(stack.getSubCompound(ITEM_DISPLAY, false) == null) {
+        if(stack.getSubCompound(Item.DISPLAY_TAG, false) == null) {
             return;
         }
-        stack.getSubCompound(ITEM_DISPLAY, false).removeTag(ITEM_LORE);
+        stack.getSubCompound(Item.DISPLAY_TAG, false).removeTag(Item.LORE);
     }
 
     public static void setLoreToNBT(ItemStack stack, List<Text> lore) {
         final NBTTagList list =  SpongeTexts.asLegacy(lore);
-        stack.getSubCompound(ITEM_DISPLAY, true).setTag(ITEM_LORE, list);
+        stack.getSubCompound(Item.DISPLAY_TAG, true).setTag(Item.LORE, list);
     }
 
     public static boolean hasColorFromNBT(ItemStack stack) {
         return stack.hasTagCompound() &&
-                stack.getTagCompound().hasKey(ITEM_DISPLAY) &&
-                stack.getTagCompound().getCompoundTag(ITEM_DISPLAY).hasKey(ITEM_COLOR);
+               stack.getTagCompound().hasKey(Item.DISPLAY_TAG) &&
+               stack.getTagCompound().getCompoundTag(Item.DISPLAY_TAG).hasKey(Item.COLOR);
     }
 
     public static Optional<Color> getColorFromNBT(NBTTagCompound subCompound) {
-        if (!subCompound.hasKey(ITEM_COLOR)) {
+        if (!subCompound.hasKey(Item.COLOR)) {
             return Optional.empty();
         }
-        return Optional.of(Color.ofRgb(subCompound.getInteger(ITEM_COLOR)));
+        return Optional.of(Color.ofRgb(subCompound.getInteger(Item.COLOR)));
     }
 
     public static void removeColorFromNBT(ItemStack stack) {
-        if(stack.getSubCompound(ITEM_DISPLAY, false) == null) {
+        if(stack.getSubCompound(Item.DISPLAY_TAG, false) == null) {
             return;
         }
-        stack.getSubCompound(ITEM_DISPLAY, false).removeTag(ITEM_COLOR);
+        stack.getSubCompound(Item.DISPLAY_TAG, false).removeTag(Item.COLOR);
     }
 
     public static void setColorToNbt(ItemStack stack, Color color) {
         final int mojangColor = ColorUtil.javaColorToMojangColor(color);
-        stack.getSubCompound(ITEM_DISPLAY, true).setInteger(ITEM_COLOR, mojangColor);
+        stack.getSubCompound(Item.DISPLAY_TAG, true).setInteger(Item.COLOR, mojangColor);
     }
 
     public static List<Text> getPagesFromNBT(NBTTagCompound compound) {
-        final NBTTagList list = compound.getTagList(ITEM_BOOK_PAGES, TAG_STRING);
+        final NBTTagList list = compound.getTagList(Item.Book.PAGES, TAG_STRING);
         if (list.hasNoTags()) {
             return new ArrayList<>();
         }
@@ -284,20 +327,20 @@ public final class NbtDataUtil {
         if (!stack.hasTagCompound()) {
             return;
         }
-        stack.getTagCompound().setTag(ITEM_BOOK_PAGES, list);
+        stack.getTagCompound().setTag(Item.Book.PAGES, list);
     }
 
     public static void setPagesToNBT(ItemStack stack, List<Text> pages){
         final NBTTagList list = SpongeTexts.asJsonNBT(pages);
         final NBTTagCompound compound = getOrCreateCompound(stack);
-        compound.setTag(ITEM_BOOK_PAGES, list);
-        if (!compound.hasKey(ITEM_BOOK_TITLE)) {
-            compound.setString(ITEM_BOOK_TITLE, INVALID_TITLE);
+        compound.setTag(Item.Book.PAGES, list);
+        if (!compound.hasKey(Item.Book.TITLE)) {
+            compound.setString(Item.Book.TITLE, Item.Book.INVALID_TITLE);
         }
-        if (!compound.hasKey(ITEM_BOOK_AUTHOR)) {
-            compound.setString(ITEM_BOOK_AUTHOR, INVALID_TITLE);
+        if (!compound.hasKey(Item.Book.AUTHOR)) {
+            compound.setString(Item.Book.AUTHOR, Item.Book.INVALID_TITLE);
         }
-        compound.setBoolean(ITEM_BOOK_RESOLVED, true);
+        compound.setBoolean(Item.Book.RESOLVED, true);
     }
 
     public static List<ItemEnchantment> getItemEnchantments(ItemStack itemStack) {
@@ -308,8 +351,8 @@ public final class NbtDataUtil {
         final NBTTagList list = itemStack.getEnchantmentTagList();
         for (int i = 0; i < list.tagCount(); i++) {
             final NBTTagCompound compound = list.getCompoundTagAt(i);
-            final short enchantmentId = compound.getShort(NbtDataUtil.ITEM_ENCHANTMENT_ID);
-            final short level = compound.getShort(NbtDataUtil.ITEM_ENCHANTMENT_LEVEL);
+            final short enchantmentId = compound.getShort(Item.ENCHANTMENT_ID);
+            final short level = compound.getShort(Item.ENCHANTMENT_LEVEL);
 
             final Enchantment enchantment = (Enchantment) net.minecraft.enchantment.Enchantment.getEnchantmentById(enchantmentId);
             if (enchantment == null) {
@@ -328,13 +371,13 @@ public final class NbtDataUtil {
         } else {
             compound = itemStack.getTagCompound();
         }
-        final NBTTagList enchantments = compound.getTagList(NbtDataUtil.ITEM_ENCHANTMENT_LIST, NbtDataUtil.TAG_COMPOUND);
+        final NBTTagList enchantments = compound.getTagList(Item.ENCHANTMENT_LIST, NbtDataUtil.TAG_COMPOUND);
         final Map<Enchantment, Integer> mergedMap = Maps.newLinkedHashMap(); // We need to retain insertion order.
         if (enchantments.tagCount() != 0) {
             for (int i = 0; i < enchantments.tagCount(); i++) { // we have to filter out the enchantments we're replacing...
                 final NBTTagCompound enchantmentCompound = enchantments.getCompoundTagAt(i);
-                final short enchantmentId = enchantmentCompound.getShort(NbtDataUtil.ITEM_ENCHANTMENT_ID);
-                final short level = enchantmentCompound.getShort(NbtDataUtil.ITEM_ENCHANTMENT_LEVEL);
+                final short enchantmentId = enchantmentCompound.getShort(Item.ENCHANTMENT_ID);
+                final short level = enchantmentCompound.getShort(Item.ENCHANTMENT_LEVEL);
                 final Enchantment enchantment = (Enchantment) net.minecraft.enchantment.Enchantment.getEnchantmentById(enchantmentId);
                 mergedMap.put(enchantment, (int) level);
             }
@@ -345,10 +388,10 @@ public final class NbtDataUtil {
         final NBTTagList newList = new NBTTagList(); // Reconstruct the newly merged enchantment list
         for (Map.Entry<Enchantment, Integer> entry : mergedMap.entrySet()) {
             final NBTTagCompound enchantmentCompound = new NBTTagCompound();
-            enchantmentCompound.setShort(NbtDataUtil.ITEM_ENCHANTMENT_ID, (short) ((net.minecraft.enchantment.Enchantment) entry.getKey()).effectId);
-            enchantmentCompound.setShort(NbtDataUtil.ITEM_ENCHANTMENT_LEVEL, entry.getValue().shortValue());
+            enchantmentCompound.setShort(Item.ENCHANTMENT_ID, (short) ((net.minecraft.enchantment.Enchantment) entry.getKey()).effectId);
+            enchantmentCompound.setShort(Item.ENCHANTMENT_LEVEL, entry.getValue().shortValue());
             newList.appendTag(enchantmentCompound);
         }
-        compound.setTag(NbtDataUtil.ITEM_ENCHANTMENT_LIST, newList);
+        compound.setTag(Item.ENCHANTMENT_LIST, newList);
     }
 }

--- a/src/main/java/org/spongepowered/common/entity/player/SpongeUser.java
+++ b/src/main/java/org/spongepowered/common/entity/player/SpongeUser.java
@@ -92,30 +92,30 @@ public class SpongeUser implements ArmorEquipable, Tamer, DataSerializable, Carr
     public void readFromNbt(NBTTagCompound compound) {
         this.reset();
         // See EntityPlayer#readEntityFromNBT
-        if (compound.hasKey(NbtDataUtil.USER_SPAWN_X, NbtDataUtil.TAG_ANY_NUMERIC)
-                && compound.hasKey(NbtDataUtil.USER_SPAWN_Y, NbtDataUtil.TAG_ANY_NUMERIC)
-                && compound.hasKey(NbtDataUtil.USER_SPAWN_Z, NbtDataUtil.TAG_ANY_NUMERIC)) {
-            Vector3d pos = new Vector3d(compound.getInteger(NbtDataUtil.USER_SPAWN_X),
-                    compound.getInteger(NbtDataUtil.USER_SPAWN_Y),
-                    compound.getInteger(NbtDataUtil.USER_SPAWN_Z));
+        if (compound.hasKey(NbtDataUtil.Compatibility.USER_SPAWN_X, NbtDataUtil.TAG_ANY_NUMERIC)
+                && compound.hasKey(NbtDataUtil.Compatibility.USER_SPAWN_Y, NbtDataUtil.TAG_ANY_NUMERIC)
+                && compound.hasKey(NbtDataUtil.Compatibility.USER_SPAWN_Z, NbtDataUtil.TAG_ANY_NUMERIC)) {
+            Vector3d pos = new Vector3d(compound.getInteger(NbtDataUtil.Compatibility.USER_SPAWN_X),
+                    compound.getInteger(NbtDataUtil.Compatibility.USER_SPAWN_Y),
+                    compound.getInteger(NbtDataUtil.Compatibility.USER_SPAWN_Z));
             final UUID key = WorldPropertyRegistryModule.dimIdToUuid(0);
             this.spawnLocations.put(key, RespawnLocation.builder()
                     .world(key)
                     .position(pos)
-                    .forceSpawn(compound.getBoolean(NbtDataUtil.USER_SPAWN_FORCED))
+                    .forceSpawn(compound.getBoolean(NbtDataUtil.Compatibility.USER_SPAWN_FORCED))
                     .build());
         }
-        NBTTagList spawnlist = compound.getTagList(NbtDataUtil.USER_SPAWN_LIST, NbtDataUtil.TAG_COMPOUND);
+        NBTTagList spawnlist = compound.getTagList(NbtDataUtil.Compatibility.USER_SPAWN_LIST, NbtDataUtil.TAG_COMPOUND);
         for (int i = 0; i < spawnlist.tagCount(); i++) {
             NBTTagCompound spawndata = spawnlist.getCompoundTagAt(i);
-            UUID uuid = WorldPropertyRegistryModule.dimIdToUuid(spawndata.getInteger(NbtDataUtil.USER_SPAWN_DIM));
+            UUID uuid = WorldPropertyRegistryModule.dimIdToUuid(spawndata.getInteger(NbtDataUtil.Compatibility.USER_SPAWN_DIM));
             if (uuid != null) {
                 this.spawnLocations.put(uuid, RespawnLocation.builder()
                         .world(uuid)
-                        .position(new Vector3d(spawndata.getInteger(NbtDataUtil.USER_SPAWN_X),
-                                spawndata.getInteger(NbtDataUtil.USER_SPAWN_Y),
-                                spawndata.getInteger(NbtDataUtil.USER_SPAWN_Z)))
-                        .forceSpawn(spawndata.getBoolean(NbtDataUtil.USER_SPAWN_FORCED))
+                        .position(new Vector3d(spawndata.getInteger(NbtDataUtil.Compatibility.USER_SPAWN_X),
+                                spawndata.getInteger(NbtDataUtil.Compatibility.USER_SPAWN_Y),
+                                spawndata.getInteger(NbtDataUtil.Compatibility.USER_SPAWN_Z)))
+                        .forceSpawn(spawndata.getBoolean(NbtDataUtil.Compatibility.USER_SPAWN_FORCED))
                         .build());
             }
         }
@@ -125,10 +125,10 @@ public class SpongeUser implements ArmorEquipable, Tamer, DataSerializable, Carr
 
     public void writeToNbt(NBTTagCompound compound) {
         // Clear data that we may or may not write back
-        compound.removeTag(NbtDataUtil.USER_SPAWN_X);
-        compound.removeTag(NbtDataUtil.USER_SPAWN_Y);
-        compound.removeTag(NbtDataUtil.USER_SPAWN_Z);
-        compound.removeTag(NbtDataUtil.USER_SPAWN_LIST);
+        compound.removeTag(NbtDataUtil.Compatibility.USER_SPAWN_X);
+        compound.removeTag(NbtDataUtil.Compatibility.USER_SPAWN_Y);
+        compound.removeTag(NbtDataUtil.Compatibility.USER_SPAWN_Z);
+        compound.removeTag(NbtDataUtil.Compatibility.USER_SPAWN_LIST);
 
         NBTTagList spawnlist = new NBTTagList();
         for (Entry<UUID, RespawnLocation> entry : this.spawnLocations.entrySet()) {
@@ -139,22 +139,22 @@ public class SpongeUser implements ArmorEquipable, Tamer, DataSerializable, Carr
             Vector3d position = entry.getValue().getPosition();
             boolean forced = entry.getValue().isForced();
             if (dim == 0) { // Overworld
-                compound.setDouble(NbtDataUtil.USER_SPAWN_X, position.getX());
-                compound.setDouble(NbtDataUtil.USER_SPAWN_Y, position.getY());
-                compound.setDouble(NbtDataUtil.USER_SPAWN_Z, position.getZ());
-                compound.setBoolean(NbtDataUtil.USER_SPAWN_FORCED, forced);
+                compound.setDouble(NbtDataUtil.Compatibility.USER_SPAWN_X, position.getX());
+                compound.setDouble(NbtDataUtil.Compatibility.USER_SPAWN_Y, position.getY());
+                compound.setDouble(NbtDataUtil.Compatibility.USER_SPAWN_Z, position.getZ());
+                compound.setBoolean(NbtDataUtil.Compatibility.USER_SPAWN_FORCED, forced);
             } else {
                 NBTTagCompound spawndata = new NBTTagCompound();
-                spawndata.setInteger(NbtDataUtil.USER_SPAWN_DIM, dim);
-                spawndata.setDouble(NbtDataUtil.USER_SPAWN_X, position.getX());
-                spawndata.setDouble(NbtDataUtil.USER_SPAWN_Y, position.getY());
-                spawndata.setDouble(NbtDataUtil.USER_SPAWN_Z, position.getZ());
-                spawndata.setBoolean(NbtDataUtil.USER_SPAWN_FORCED, forced);
+                spawndata.setInteger(NbtDataUtil.Compatibility.USER_SPAWN_DIM, dim);
+                spawndata.setDouble(NbtDataUtil.Compatibility.USER_SPAWN_X, position.getX());
+                spawndata.setDouble(NbtDataUtil.Compatibility.USER_SPAWN_Y, position.getY());
+                spawndata.setDouble(NbtDataUtil.Compatibility.USER_SPAWN_Z, position.getZ());
+                spawndata.setBoolean(NbtDataUtil.Compatibility.USER_SPAWN_FORCED, forced);
                 spawnlist.appendTag(spawndata);
             }
         }
         if (!spawnlist.hasNoTags()) {
-            compound.setTag(NbtDataUtil.USER_SPAWN_LIST, spawnlist);
+            compound.setTag(NbtDataUtil.Compatibility.USER_SPAWN_LIST, spawnlist);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/event/CauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/CauseTracker.java
@@ -329,13 +329,13 @@ public final class CauseTracker {
             if (cause.first(User.class).isPresent()) {
                 // store user UUID with entity to track later
                 User user = cause.first(User.class).get();
-                ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, user.getUniqueId());
+                ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, user.getUniqueId());
             } else if (cause.first(Entity.class).isPresent()) {
                 IMixinEntity spongeEntity = (IMixinEntity) cause.first(Entity.class).get();
-                Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+                Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
                 if (owner.isPresent() && !cause.containsNamed(NamedCause.OWNER)) {
                     cause = cause.with(NamedCause.of(NamedCause.OWNER, owner.get()));
-                    ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, owner.get().getUniqueId());
+                    ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, owner.get().getUniqueId());
                 }
             }
             entitySnapshotBuilder.add(currentEntity.createSnapshot());
@@ -440,7 +440,7 @@ public final class CauseTracker {
                         cause = cause.with(NamedCause.owner(tameable.getOwner()));
                     }
                 } else {
-                    Optional<User> owner = ((IMixinEntity) entity).getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+                    Optional<User> owner = ((IMixinEntity) entity).getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
                     if (owner.isPresent() && !cause.contains(NamedCause.OWNER)) {
                         cause = cause.with(NamedCause.owner(owner.get()));
                     }
@@ -523,15 +523,15 @@ public final class CauseTracker {
             if (cause.first(User.class).isPresent()) {
                 // store user UUID with entity to track later
                 User user = cause.first(User.class).get();
-                ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, user.getUniqueId());
+                ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, user.getUniqueId());
             } else if (cause.first(Entity.class).isPresent()) {
                 IMixinEntity spongeEntity = (IMixinEntity) cause.first(Entity.class).get();
-                Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+                Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
                 if (owner.isPresent()) {
                     if (!cause.containsNamed(NamedCause.OWNER)) {
                         cause = cause.with(NamedCause.of(NamedCause.OWNER, owner.get()));
                     }
-                    ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, owner.get().getUniqueId());
+                    ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, owner.get().getUniqueId());
                 }
                 if (spongeEntity instanceof EntityLivingBase) {
                     DamageSource lastDamageSource = spongeEntity.getLastDamageSource();
@@ -994,9 +994,9 @@ public final class CauseTracker {
                             PlayerTracker.Type.NOTIFIER);
                 }
                 if (this.currentTickEntity != null) {
-                    Optional<User> creator = ((IMixinEntity) this.currentTickEntity).getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+                    Optional<User> creator = ((IMixinEntity) this.currentTickEntity).getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
                     if (creator.isPresent()) { // transfer user to next entity. This occurs with falling blocks that change into items
-                        ((IMixinEntity) entityIn).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, creator.get().getUniqueId());
+                        ((IMixinEntity) entityIn).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, creator.get().getUniqueId());
                     }
                 }
                 if (entityIn instanceof EntityItem) {
@@ -1024,7 +1024,7 @@ public final class CauseTracker {
                         causeName = NamedCause.THROWER;
                         if (specialCause instanceof Player) {
                             Player player = (Player) specialCause;
-                            ((IMixinEntity) entityIn).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, player.getUniqueId());
+                            ((IMixinEntity) entityIn).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, player.getUniqueId());
                         }
                     }
                 }
@@ -1036,7 +1036,7 @@ public final class CauseTracker {
 
                     if (specialCause instanceof Player) {
                         Player player = (Player) specialCause;
-                        ((IMixinEntity) entityIn).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, player.getUniqueId());
+                        ((IMixinEntity) entityIn).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, player.getUniqueId());
                     }
                 }
                 // Special case for Tameables
@@ -1147,8 +1147,8 @@ public final class CauseTracker {
                         } else if (this.hasTickingEntity()) { // Falling Blocks
                             IMixinEntity spongeEntity = (IMixinEntity) this.getCurrentTickEntity().get();
                             sourcePos = ((net.minecraft.entity.Entity) this.getCurrentTickEntity().get()).getPosition();
-                            Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
-                            Optional<User> notifier = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_NOTIFIER);
+                            Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
+                            Optional<User> notifier = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_NOTIFIER);
                             if (notifier.isPresent()) {
                                 IMixinChunk spongeChunk = (IMixinChunk) this.getMinecraftWorld().getChunkFromBlockCoords(notifyPos);
                                 spongeChunk.addTrackedBlockPosition(iblockstate.getBlock(), notifyPos, notifier.get(), PlayerTracker.Type.NOTIFIER);

--- a/src/main/java/org/spongepowered/common/event/DamageEventHandler.java
+++ b/src/main/java/org/spongepowered/common/event/DamageEventHandler.java
@@ -256,8 +256,8 @@ public class DamageEventHandler {
                 continue;
             }
             for (int i = 0; i < enchantmentList.tagCount(); ++i) {
-                final short enchantmentId = enchantmentList.getCompoundTagAt(i).getShort(NbtDataUtil.ITEM_ENCHANTMENT_ID);
-                final short level = enchantmentList.getCompoundTagAt(i).getShort(NbtDataUtil.ITEM_ENCHANTMENT_LEVEL);
+                final short enchantmentId = enchantmentList.getCompoundTagAt(i).getShort(NbtDataUtil.Item.ENCHANTMENT_ID);
+                final short level = enchantmentList.getCompoundTagAt(i).getShort(NbtDataUtil.Item.ENCHANTMENT_LEVEL);
 
                 if (Enchantment.getEnchantmentById(enchantmentId) != null) {
                     // Ok, we have an enchantment!
@@ -360,7 +360,7 @@ public class DamageEventHandler {
     public static Cause generateCauseFor(DamageSource damageSource) {
         if (damageSource instanceof EntityDamageSourceIndirect) {
             net.minecraft.entity.Entity source = damageSource.getEntity();
-            Optional<User> owner = source == null ? Optional.empty() : ((IMixinEntity) source).getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+            Optional<User> owner = source == null ? Optional.empty() : ((IMixinEntity) source).getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
             if (owner.isPresent()) {
                 return Cause.of(NamedCause.source(damageSource),
                                  NamedCause.of(DamageEntityEvent.CREATOR, owner.get()));
@@ -369,8 +369,8 @@ public class DamageEventHandler {
             }
         } else if (damageSource instanceof EntityDamageSource) {
             net.minecraft.entity.Entity source = damageSource.getEntity();
-            Optional<User> owner = ((IMixinEntity) source).getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
-            Optional<User> notifier = ((IMixinEntity) source).getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_NOTIFIER);
+            Optional<User> owner = ((IMixinEntity) source).getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
+            Optional<User> notifier = ((IMixinEntity) source).getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_NOTIFIER);
             List<NamedCause> causeObjects = new ArrayList<>();
             causeObjects.add(NamedCause.source(damageSource));
             if (notifier.isPresent()) {

--- a/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
+++ b/src/main/java/org/spongepowered/common/event/SpongeCommonEventFactory.java
@@ -248,7 +248,7 @@ public class SpongeCommonEventFactory {
             ImmutableList.Builder<EntitySnapshot> entitySnapshotBuilder = new ImmutableList.Builder<>();
             while (iterator.hasNext()) {
                 Entity currentEntity = iterator.next();
-                ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, player.getUniqueID());
+                ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, player.getUniqueID());
                 entitySnapshotBuilder.add(currentEntity.createSnapshot());
             }
             final Cause.Builder builder = Cause.source(SpawnCause.builder().type(SpawnTypes.DROPPED_ITEM).build());
@@ -323,7 +323,7 @@ public class SpongeCommonEventFactory {
                     ImmutableList.Builder<EntitySnapshot> entitySnapshotBuilder = new ImmutableList.Builder<>();
                     while (iterator.hasNext()) {
                         Entity currentEntity = iterator.next();
-                        ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, player.getUniqueID());
+                        ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, player.getUniqueID());
                         entitySnapshotBuilder.add(currentEntity.createSnapshot());
                     }
                     final Cause.Builder builder = Cause.source(SpawnCause.builder().type(SpawnTypes.DROPPED_ITEM).build());
@@ -351,7 +351,7 @@ public class SpongeCommonEventFactory {
                     ImmutableList.Builder<EntitySnapshot> entitySnapshotBuilder = new ImmutableList.Builder<>();
                     while (iterator.hasNext()) {
                         Entity currentEntity = iterator.next();
-                        ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, player.getUniqueID());
+                        ((IMixinEntity) currentEntity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, player.getUniqueID());
                         entitySnapshotBuilder.add(currentEntity.createSnapshot());
                     }
                     final Cause.Builder builder = Cause.source(SpawnCause.builder().type(SpawnTypes.DROPPED_ITEM).build());
@@ -611,7 +611,7 @@ public class SpongeCommonEventFactory {
         Cause cause = Cause.of(NamedCause.of(NamedCause.PHYSICAL, entity));
         if (!(entity instanceof EntityPlayer)) {
             IMixinEntity spongeEntity = (IMixinEntity) entity;
-            Optional<User> user = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+            Optional<User> user = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
             if (user.isPresent()) {
                 cause = cause.with(NamedCause.owner(user.get()));
             }
@@ -627,7 +627,7 @@ public class SpongeCommonEventFactory {
         MovingObjectType movingObjectType = movingObjectPosition.typeOfHit;
         Cause cause = Cause.source(projectile).named("ProjectileSource", projectileSource == null ? ProjectileSource.UNKNOWN : projectileSource).build();
         IMixinEntity spongeEntity = (IMixinEntity) projectile;
-        Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+        Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
         if (owner.isPresent() && !cause.containsNamed(NamedCause.OWNER)) {
             cause = cause.with(NamedCause.of(NamedCause.OWNER, owner.get()));
         }
@@ -913,7 +913,7 @@ public class SpongeCommonEventFactory {
                 causeName = NamedCause.THROWER;
                 if (specialCause instanceof Player) {
                     Player player = (Player) specialCause;
-                    ((IMixinEntity) spawning).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, player.getUniqueId());
+                    ((IMixinEntity) spawning).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, player.getUniqueId());
                 }
             }
         }
@@ -925,7 +925,7 @@ public class SpongeCommonEventFactory {
 
             if (specialCause instanceof Player) {
                 Player player = (Player) specialCause;
-                ((IMixinEntity) spawning).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, player.getUniqueId());
+                ((IMixinEntity) spawning).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, player.getUniqueId());
             }
         }
         // Special case for Tameables

--- a/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinTileEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/block/tile/IMixinTileEntity.java
@@ -50,10 +50,10 @@ public interface IMixinTileEntity {
      */
     default NBTTagCompound getSpongeData() {
         NBTTagCompound data = this.getTileData();
-        if (!data.hasKey(NbtDataUtil.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
-            data.setTag(NbtDataUtil.SPONGE_DATA, new NBTTagCompound());
+        if (!data.hasKey(NbtDataUtil.General.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
+            data.setTag(NbtDataUtil.General.SPONGE_DATA, new NBTTagCompound());
         }
-        return data.getCompoundTag(NbtDataUtil.SPONGE_DATA);
+        return data.getCompoundTag(NbtDataUtil.General.SPONGE_DATA);
     }
 
     /**

--- a/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
+++ b/src/main/java/org/spongepowered/common/interfaces/entity/IMixinEntity.java
@@ -72,10 +72,10 @@ public interface IMixinEntity extends org.spongepowered.api.entity.Entity {
 
     default NBTTagCompound getSpongeData() {
         final NBTTagCompound data = this.getEntityData();
-        if (!data.hasKey(NbtDataUtil.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
-            data.setTag(NbtDataUtil.SPONGE_DATA, new NBTTagCompound());
+        if (!data.hasKey(NbtDataUtil.General.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
+            data.setTag(NbtDataUtil.General.SPONGE_DATA, new NBTTagCompound());
         }
-        return data.getCompoundTag(NbtDataUtil.SPONGE_DATA);
+        return data.getCompoundTag(NbtDataUtil.General.SPONGE_DATA);
     }
 
     default void supplyVanillaManipulators(List<DataManipulator<?, ?>> manipulators) { }

--- a/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/SpongeItemStackBuilder.java
@@ -163,8 +163,8 @@ public class SpongeItemStackBuilder implements ItemStack.Builder {
         this.damageValue = getData(container, DataQueries.ITEM_DAMAGE_VALUE, Integer.class);
         if (container.contains(DataQueries.UNSAFE_NBT)) {
             final NBTTagCompound compound = NbtTranslator.getInstance().translateData(container.getView(DataQueries.UNSAFE_NBT).get());
-            if (compound.hasKey(NbtDataUtil.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
-                compound.removeTag(NbtDataUtil.SPONGE_DATA);
+            if (compound.hasKey(NbtDataUtil.General.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
+                compound.removeTag(NbtDataUtil.General.SPONGE_DATA);
             }
             this.compound = compound;
         }
@@ -213,7 +213,7 @@ public class SpongeItemStackBuilder implements ItemStack.Builder {
             final Optional<NBTTagCompound> compound = ((SpongeBlockSnapshot) blockSnapshot).getCompound();
             if (compound.isPresent()) {
                 this.compound = new NBTTagCompound();
-                this.compound.setTag(NbtDataUtil.BLOCK_ENTITY_TAG, compound.get());
+                this.compound.setTag(NbtDataUtil.TileEntity.TILE_ENTITY_ROOT, compound.get());
             }
             // todo probably needs more testing, but this'll do donkey...
         } else { // TODO handle through the API specifically handling the rest of the data stuff

--- a/src/main/java/org/spongepowered/common/mixin/core/command/server/MixinCommandSummon.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/server/MixinCommandSummon.java
@@ -67,12 +67,12 @@ public abstract class MixinCommandSummon extends CommandBase {
 
     @Redirect(method = "processCommand", at = @At(value = "INVOKE", target = ENTITY_LIST_CREATE_FROM_NBT))
     private Entity onAttemptSpawnEntity(NBTTagCompound nbt, World world, ICommandSender sender, String[] args) {
-        if ("Minecart".equals(nbt.getString(NbtDataUtil.ENTITY_TYPE_ID))) {
-            nbt.setString(NbtDataUtil.ENTITY_TYPE_ID,
-                    EntityMinecart.EnumMinecartType.byNetworkID(nbt.getInteger(NbtDataUtil.MINECART_TYPE)).getName());
-            nbt.removeTag(NbtDataUtil.MINECART_TYPE);
+        if ("Minecart".equals(nbt.getString(NbtDataUtil.Entity.ENTITY_TYPE_ID))) {
+            nbt.setString(NbtDataUtil.Entity.ENTITY_TYPE_ID,
+                    EntityMinecart.EnumMinecartType.byNetworkID(nbt.getInteger(NbtDataUtil.Entity.Minecart.MINECART_TYPE)).getName());
+            nbt.removeTag(NbtDataUtil.Entity.Minecart.MINECART_TYPE);
         }
-        Class<? extends Entity> entityClass = EntityList.stringToClassMapping.get(nbt.getString(NbtDataUtil.ENTITY_TYPE_ID));
+        Class<? extends Entity> entityClass = EntityList.stringToClassMapping.get(nbt.getString(NbtDataUtil.Entity.ENTITY_TYPE_ID));
         if (entityClass == null) {
             return null;
         }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -847,8 +847,8 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         if (this instanceof IMixinCustomDataHolder) {
-            if (compound.hasKey(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_LIST)) {
-                final NBTTagList list = compound.getTagList(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_COMPOUND);
+            if (compound.hasKey(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_LIST)) {
+                final NBTTagList list = compound.getTagList(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_COMPOUND);
                 final ImmutableList.Builder<DataView> builder = ImmutableList.builder();
                 if (list != null && list.tagCount() != 0) {
                     for (int i = 0; i < list.tagCount(); i++) {
@@ -866,8 +866,8 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
                 }
             }
         }
-        if (this instanceof IMixinGriefer && ((IMixinGriefer) this).isGriefer() && compound.hasKey(NbtDataUtil.CAN_GRIEF)) {
-            ((IMixinGriefer) this).setCanGrief(compound.getBoolean(NbtDataUtil.CAN_GRIEF));
+        if (this instanceof IMixinGriefer && ((IMixinGriefer) this).isGriefer() && compound.hasKey(NbtDataUtil.Entity.CAN_GRIEF)) {
+            ((IMixinGriefer) this).setCanGrief(compound.getBoolean(NbtDataUtil.Entity.CAN_GRIEF));
         }
     }
 
@@ -886,11 +886,11 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
                 for (DataView dataView : manipulatorViews) {
                     manipulatorTagList.appendTag(NbtTranslator.getInstance().translateData(dataView));
                 }
-                compound.setTag(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, manipulatorTagList);
+                compound.setTag(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, manipulatorTagList);
             }
         }
         if (this instanceof IMixinGriefer && ((IMixinGriefer) this).isGriefer()) {
-            compound.setBoolean(NbtDataUtil.CAN_GRIEF, ((IMixinGriefer) this).canGrief());
+            compound.setBoolean(NbtDataUtil.Entity.CAN_GRIEF, ((IMixinGriefer) this).canGrief());
         }
     }
 
@@ -1009,7 +1009,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
 
     @Override
     public Optional<UUID> getCreator() {
-       Optional<User> user = getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+       Optional<User> user = getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
        if (user.isPresent()) {
            return Optional.of(user.get().getUniqueId());
        } else {
@@ -1019,7 +1019,7 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
 
     @Override
     public Optional<UUID> getNotifier() {
-        Optional<User> user = getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_NOTIFIER);
+        Optional<User> user = getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_NOTIFIER);
         if (user.isPresent()) {
             return Optional.of(user.get().getUniqueId());
         } else {
@@ -1029,12 +1029,12 @@ public abstract class MixinEntity implements Entity, IMixinEntity {
 
     @Override
     public void setCreator(@Nullable UUID uuid) {
-        trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, uuid);
+        trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, uuid);
     }
 
     @Override
     public void setNotifier(@Nullable UUID uuid) {
-        trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_NOTIFIER, uuid);
+        trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_NOTIFIER, uuid);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityBoat.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityBoat.java
@@ -161,26 +161,26 @@ public abstract class MixinEntityBoat extends MixinEntity implements Boat {
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.BOAT_MAX_SPEED)) {
-            this.maxSpeed = compound.getDouble(NbtDataUtil.BOAT_MAX_SPEED);
+        if (compound.hasKey(NbtDataUtil.Entity.Boat.MAX_SPEED)) {
+            this.maxSpeed = compound.getDouble(NbtDataUtil.Entity.Boat.MAX_SPEED);
         }
-        if (compound.hasKey(NbtDataUtil.BOAT_MOVE_ON_LAND)) {
-            this.moveOnLand = compound.getBoolean(NbtDataUtil.BOAT_MOVE_ON_LAND);
+        if (compound.hasKey(NbtDataUtil.Entity.Boat.MOVE_ON_LAND)) {
+            this.moveOnLand = compound.getBoolean(NbtDataUtil.Entity.Boat.MOVE_ON_LAND);
         }
-        if (compound.hasKey(NbtDataUtil.BOAT_OCCUPIED_DECELERATION_SPEED)) {
-            this.occupiedDecelerationSpeed = compound.getDouble(NbtDataUtil.BOAT_OCCUPIED_DECELERATION_SPEED);
+        if (compound.hasKey(NbtDataUtil.Entity.Boat.OCCUPIED_DECELERATION_SPEED)) {
+            this.occupiedDecelerationSpeed = compound.getDouble(NbtDataUtil.Entity.Boat.OCCUPIED_DECELERATION_SPEED);
         }
-        if (compound.hasKey(NbtDataUtil.BOAT_UNOCCUPIED_DECELERATION_SPEED)) {
-            this.unoccupiedDecelerationSpeed = compound.getDouble(NbtDataUtil.BOAT_UNOCCUPIED_DECELERATION_SPEED);
+        if (compound.hasKey(NbtDataUtil.Entity.Boat.UNOCCUPIED_DECELERATION_SPEED)) {
+            this.unoccupiedDecelerationSpeed = compound.getDouble(NbtDataUtil.Entity.Boat.UNOCCUPIED_DECELERATION_SPEED);
         }
     }
 
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
-        compound.setDouble(NbtDataUtil.BOAT_MAX_SPEED, this.maxSpeed);
-        compound.setBoolean(NbtDataUtil.BOAT_MOVE_ON_LAND, this.moveOnLand);
-        compound.setDouble(NbtDataUtil.BOAT_OCCUPIED_DECELERATION_SPEED, this.occupiedDecelerationSpeed);
-        compound.setDouble(NbtDataUtil.BOAT_UNOCCUPIED_DECELERATION_SPEED, this.unoccupiedDecelerationSpeed);
+        compound.setDouble(NbtDataUtil.Entity.Boat.MAX_SPEED, this.maxSpeed);
+        compound.setBoolean(NbtDataUtil.Entity.Boat.MOVE_ON_LAND, this.moveOnLand);
+        compound.setDouble(NbtDataUtil.Entity.Boat.OCCUPIED_DECELERATION_SPEED, this.occupiedDecelerationSpeed);
+        compound.setDouble(NbtDataUtil.Entity.Boat.UNOCCUPIED_DECELERATION_SPEED, this.unoccupiedDecelerationSpeed);
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderPearl.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityEnderPearl.java
@@ -48,15 +48,15 @@ public abstract class MixinEntityEnderPearl extends MixinEntityThrowable impleme
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT)) {
-            this.damageAmount = compound.getDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+        if (compound.hasKey(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT)) {
+            this.damageAmount = compound.getDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
         }
     }
 
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
-        compound.setDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT, this.damageAmount);
+        compound.setDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT, this.damageAmount);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityEgg.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityEgg.java
@@ -47,14 +47,14 @@ public abstract class MixinEntityEgg extends MixinEntityThrowable implements Egg
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT)) {
-            this.damageAmount = compound.getDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+        if (compound.hasKey(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT)) {
+            this.damageAmount = compound.getDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
         }
     }
 
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
-        compound.setDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT, this.damageAmount);
+        compound.setDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT, this.damageAmount);
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityFishHook.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityFishHook.java
@@ -218,8 +218,8 @@ public abstract class MixinEntityFishHook extends MixinEntity implements FishHoo
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT)) {
-            this.damageAmount = compound.getDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+        if (compound.hasKey(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT)) {
+            this.damageAmount = compound.getDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
         }
         ProjectileSourceSerializer.readSourceFromNbt(compound, this);
     }
@@ -227,7 +227,7 @@ public abstract class MixinEntityFishHook extends MixinEntity implements FishHoo
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
-        compound.setDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT, this.damageAmount);
+        compound.setDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT, this.damageAmount);
         ProjectileSourceSerializer.writeSourceToNbt(compound, this.projectileSource, this.angler);
     }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityLargeFireball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityLargeFireball.java
@@ -77,15 +77,15 @@ public abstract class MixinEntityLargeFireball extends MixinEntityFireball imple
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT)) {
-            this.damage = compound.getFloat(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+        if (compound.hasKey(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT)) {
+            this.damage = compound.getFloat(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
         }
     }
 
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
-        compound.setFloat(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT, this.damage);
+        compound.setFloat(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT, this.damage);
     }
 
     @Redirect(method = "onImpact", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Ljava/lang/String;)Z"))

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySmallFireball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySmallFireball.java
@@ -57,15 +57,15 @@ public abstract class MixinEntitySmallFireball extends MixinEntityFireball imple
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT)) {
-            this.damage = compound.getFloat(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+        if (compound.hasKey(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT)) {
+            this.damage = compound.getFloat(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
         }
     }
 
     @Override
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
-        compound.setFloat(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT, this.damage);
+        compound.setFloat(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT, this.damage);
     }
 
     @Redirect(method = "onImpact", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Ljava/lang/String;)Z"))

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySnowball.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntitySnowball.java
@@ -47,8 +47,8 @@ public abstract class MixinEntitySnowball extends MixinEntityThrowable implement
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT)) {
-            this.damageAmount = compound.getDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+        if (compound.hasKey(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT)) {
+            this.damageAmount = compound.getDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
             this.damageSet = true;
         }
     }
@@ -57,9 +57,9 @@ public abstract class MixinEntitySnowball extends MixinEntityThrowable implement
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
         if (this.damageSet) {
-            compound.setDouble(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT, this.damageAmount);
+            compound.setDouble(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT, this.damageAmount);
         } else {
-            compound.removeTag(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+            compound.removeTag(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityWitherSkull.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/projectile/MixinEntityWitherSkull.java
@@ -67,8 +67,8 @@ public abstract class MixinEntityWitherSkull extends MixinEntityFireball impleme
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         super.readFromNbt(compound);
-        if (compound.hasKey(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT)) {
-            this.damage = compound.getFloat(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+        if (compound.hasKey(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT)) {
+            this.damage = compound.getFloat(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
             this.damageSet = true;
         }
     }
@@ -77,9 +77,9 @@ public abstract class MixinEntityWitherSkull extends MixinEntityFireball impleme
     public void writeToNbt(NBTTagCompound compound) {
         super.writeToNbt(compound);
         if (this.damageSet) {
-            compound.setFloat(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT, this.damage);
+            compound.setFloat(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT, this.damage);
         } else {
-            compound.removeTag(NbtDataUtil.PROJECTILE_DAMAGE_AMOUNT);
+            compound.removeTag(NbtDataUtil.Entity.Projectile.DAMAGE_AMOUNT);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/event/cause/entity/damage/MixinIndirectEntityDamageSource.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/event/cause/entity/damage/MixinIndirectEntityDamageSource.java
@@ -49,7 +49,7 @@ public abstract class MixinIndirectEntityDamageSource extends MixinEntityDamageS
     @Inject(method = "<init>", at = @At("RETURN"))
     private void onConstruct(CallbackInfo callbackInfo) {
         if (!(this.indirectEntity instanceof User)) {
-            this.owner = ((IMixinEntity) super.getSource()).getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+            this.owner = ((IMixinEntity) super.getSource()).getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
             if (this.indirectEntity == null && this.owner.isPresent() && this.owner.get() instanceof Entity) {
                 this.indirectEntity = (Entity) this.owner.get();
             }

--- a/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/item/MixinItemStack.java
@@ -100,8 +100,8 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
 
     @Inject(method = "readFromNBT", at = @At("RETURN"))
     private void onRead(NBTTagCompound compound, CallbackInfo info) {
-        if (hasTagCompound() && getTagCompound().hasKey(NbtDataUtil.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
-            readFromNbt(getTagCompound().getCompoundTag(NbtDataUtil.SPONGE_DATA));
+        if (hasTagCompound() && getTagCompound().hasKey(NbtDataUtil.General.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
+            readFromNbt(getTagCompound().getCompoundTag(NbtDataUtil.General.SPONGE_DATA));
         }
     }
 
@@ -127,8 +127,8 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
 
     @Inject(method = "setTagCompound", at = @At("RETURN"))
     private void onSet(NBTTagCompound compound, CallbackInfo callbackInfo) {
-        if (hasTagCompound() && getTagCompound().hasKey(NbtDataUtil.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
-            readFromNbt(getTagCompound().getCompoundTag(NbtDataUtil.SPONGE_DATA));
+        if (hasTagCompound() && getTagCompound().hasKey(NbtDataUtil.General.SPONGE_DATA, NbtDataUtil.TAG_COMPOUND)) {
+            readFromNbt(getTagCompound().getCompoundTag(NbtDataUtil.General.SPONGE_DATA));
         }
     }
 
@@ -186,10 +186,10 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
                 .set(DataQueries.ITEM_DAMAGE_VALUE, this.getItemDamage());
         if (hasTagCompound()) { // no tag? no data, simple as that.
             final NBTTagCompound compound = (NBTTagCompound) getTagCompound().copy();
-            if (compound.hasKey(NbtDataUtil.SPONGE_DATA)) {
-                final NBTTagCompound spongeCompound = compound.getCompoundTag(NbtDataUtil.SPONGE_DATA);
-                if (spongeCompound.hasKey(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST)) {
-                    spongeCompound.removeTag(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST);
+            if (compound.hasKey(NbtDataUtil.General.SPONGE_DATA)) {
+                final NBTTagCompound spongeCompound = compound.getCompoundTag(NbtDataUtil.General.SPONGE_DATA);
+                if (spongeCompound.hasKey(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST)) {
+                    spongeCompound.removeTag(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST);
                 }
             }
             NbtDataUtil.filterSpongeCustomData(compound); // We must filter the custom data so it isn't stored twice
@@ -239,10 +239,10 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
 
     @Override
     public void readFromNbt(NBTTagCompound compound) {
-        if (compound.hasKey(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_LIST)) {
-            final NBTTagList list = compound.getTagList(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_COMPOUND);
+        if (compound.hasKey(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_LIST)) {
+            final NBTTagList list = compound.getTagList(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_COMPOUND);
             if (!list.hasNoTags()) {
-                compound.removeTag(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST);
+                compound.removeTag(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST);
                 final List<DataView> views = Lists.newArrayList();
                 for (int i = 0; i < list.tagCount(); i++) {
                     final NBTTagCompound dataCompound = list.getCompoundTagAt(i);
@@ -253,15 +253,15 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
                     offerCustom(manipulator, MergeFunction.IGNORE_ALL);
                 }
             } else {
-                compound.removeTag(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST);
+                compound.removeTag(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST);
                 if (compound.hasNoTags()) {
-                    getTagCompound().removeTag(NbtDataUtil.SPONGE_DATA);
+                    getTagCompound().removeTag(NbtDataUtil.General.SPONGE_DATA);
                     return;
                 }
             }
         }
         if (compound.hasNoTags()) {
-            getTagCompound().removeTag(NbtDataUtil.SPONGE_DATA);
+            getTagCompound().removeTag(NbtDataUtil.General.SPONGE_DATA);
             if (getTagCompound().hasNoTags()) {
                 setTagCompound(null);
             }
@@ -316,11 +316,11 @@ public abstract class MixinItemStack implements ItemStack, IMixinItemStack, IMix
             for (DataView dataView : manipulatorViews) {
                 newList.appendTag(NbtTranslator.getInstance().translateData(dataView));
             }
-            final NBTTagCompound spongeCompound = getSubCompound(NbtDataUtil.SPONGE_DATA, true);
-            spongeCompound.setTag(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, newList);
+            final NBTTagCompound spongeCompound = getSubCompound(NbtDataUtil.General.SPONGE_DATA, true);
+            spongeCompound.setTag(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, newList);
         } else {
             if (hasTagCompound()) {
-                this.getTagCompound().removeTag(NbtDataUtil.SPONGE_DATA);
+                this.getTagCompound().removeTag(NbtDataUtil.General.SPONGE_DATA);
             }
             if (this.getTagCompound().hasNoTags()) {
                 this.setTagCompound(null);

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinMinecraftServer.java
@@ -492,16 +492,16 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
                 continue;
             }
 
-            if (compound.hasKey(NbtDataUtil.SPONGE_DATA)) {
-                final NBTTagCompound spongeData = compound.getCompoundTag(NbtDataUtil.SPONGE_DATA);
+            if (compound.hasKey(NbtDataUtil.General.SPONGE_DATA)) {
+                final NBTTagCompound spongeData = compound.getCompoundTag(NbtDataUtil.General.SPONGE_DATA);
 
-                if (!spongeData.hasKey(NbtDataUtil.DIMENSION_ID)) {
+                if (!spongeData.hasKey(NbtDataUtil.World.DIMENSION_ID)) {
                     SpongeImpl.getLogger().error("World [{}] has no dimension id. This is a critical error and should be reported to Sponge ASAP.",
                             worldCandidateFile.getName());
                     continue;
                 }
 
-                final int dimensionId = spongeData.getInteger(NbtDataUtil.DIMENSION_ID);
+                final int dimensionId = spongeData.getInteger(NbtDataUtil.World.DIMENSION_ID);
 
                 // Nether and The End are handled above
                 if (dimensionId == -1 || dimensionId == 1) {
@@ -510,8 +510,8 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
 
                 String dimensionType = "overworld";
 
-                if (spongeData.hasKey(NbtDataUtil.DIMENSION_TYPE)) {
-                    dimensionType = spongeData.getString(NbtDataUtil.DIMENSION_TYPE);
+                if (spongeData.hasKey(NbtDataUtil.World.DIMENSION_TYPE)) {
+                    dimensionType = spongeData.getString(NbtDataUtil.World.DIMENSION_TYPE);
 
                     // Temporary fix for old data, remove in future build
                     if (dimensionType.equalsIgnoreCase("net.minecraft.world.WorldProviderSurface")) {
@@ -526,7 +526,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
                             worldCandidateFile.getName(), dimensionId);
                 }
 
-                spongeData.setString(NbtDataUtil.DIMENSION_TYPE, dimensionType);
+                spongeData.setString(NbtDataUtil.World.DIMENSION_TYPE, dimensionType);
                 final SpongeConfig<?> activeConfig = SpongeHooks.getActiveConfig(dimensionType, worldCandidateFile.getName());
 
                 if (activeConfig.getType().equals(SpongeConfig.Type.WORLD) || activeConfig.getType().equals(SpongeConfig.Type.DIMENSION)) {
@@ -547,7 +547,7 @@ public abstract class MixinMinecraftServer implements Server, ConsoleSource, IMi
                 }
 
                 DimensionRegistryModule.getInstance().getAll().forEach(type -> {
-                    if (type.getId().equalsIgnoreCase(spongeData.getString(NbtDataUtil.DIMENSION_TYPE))) {
+                    if (type.getId().equalsIgnoreCase(spongeData.getString(NbtDataUtil.World.DIMENSION_TYPE))) {
                         DimensionRegistryModule.getInstance().registerWorldDimensionId(dimensionId, worldCandidateFile.getName());
                         if (!DimensionManager.isDimensionRegistered(dimensionId)) {
                             DimensionManager.registerDimension(dimensionId,

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntity.java
@@ -212,8 +212,8 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
     @Override
     public void readFromNbt(NBTTagCompound compound) {
         if (this instanceof IMixinCustomDataHolder) {
-            if (compound.hasKey(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_LIST)) {
-                final NBTTagList list = compound.getTagList(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_COMPOUND);
+            if (compound.hasKey(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_LIST)) {
+                final NBTTagList list = compound.getTagList(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, NbtDataUtil.TAG_COMPOUND);
                 final ImmutableList.Builder<DataView> builder = ImmutableList.builder();
                 if (list != null && list.tagCount() != 0) {
                     for (int i = 0; i < list.tagCount(); i++) {
@@ -246,7 +246,7 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
             for (DataView dataView : manipulatorViews) {
                 manipulatorTagList.appendTag(NbtTranslator.getInstance().translateData(dataView));
             }
-            compound.setTag(NbtDataUtil.CUSTOM_MANIPULATOR_TAG_LIST, manipulatorTagList);
+            compound.setTag(NbtDataUtil.General.CUSTOM_MANIPULATOR_TAG_LIST, manipulatorTagList);
         }
     }
 

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityBanner.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityBanner.java
@@ -102,10 +102,10 @@ public abstract class MixinTileEntityBanner extends MixinTileEntity implements B
             SpongeGameRegistry registry = SpongeImpl.getGame().getRegistry();
             for (int i = 0; i < this.patterns.tagCount(); i++) {
                 NBTTagCompound tagCompound = this.patterns.getCompoundTagAt(i);
-                String patternId = tagCompound.getString(NbtDataUtil.BANNER_PATTERN_ID);
+                String patternId = tagCompound.getString(NbtDataUtil.TileEntity.BANNER_PATTERN_ID);
                 this.patternLayers.add(new SpongePatternLayer(
                     SpongeImpl.getRegistry().getType(BannerPatternShape.class, patternId).get(),
-                    registry.getType(DyeColor.class, EnumDyeColor.byDyeDamage(tagCompound.getInteger(NbtDataUtil.BANNER_PATTERN_COLOR)).getName()).get()));
+                    registry.getType(DyeColor.class, EnumDyeColor.byDyeDamage(tagCompound.getInteger(NbtDataUtil.TileEntity.BANNER_PATTERN_COLOR)).getName()).get()));
             }
         }
         this.markDirtyAndUpdate();
@@ -123,8 +123,8 @@ public abstract class MixinTileEntityBanner extends MixinTileEntity implements B
         this.patterns = new NBTTagList();
         for (PatternLayer layer : this.patternLayers) {
             NBTTagCompound compound = new NBTTagCompound();
-            compound.setString(NbtDataUtil.BANNER_PATTERN_ID, ((TileEntityBanner.EnumBannerPattern) (Object) layer.getShape()).getPatternID());
-            compound.setInteger(NbtDataUtil.BANNER_PATTERN_COLOR, ((EnumDyeColor) (Object) layer.getColor()).getDyeDamage());
+            compound.setString(NbtDataUtil.TileEntity.BANNER_PATTERN_ID, ((TileEntityBanner.EnumBannerPattern) (Object) layer.getShape()).getPatternID());
+            compound.setInteger(NbtDataUtil.TileEntity.BANNER_PATTERN_COLOR, ((EnumDyeColor) (Object) layer.getColor()).getDyeDamage());
             this.patterns.appendTag(compound);
         }
         markDirtyAndUpdate();

--- a/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityHopper.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/tileentity/MixinTileEntityHopper.java
@@ -61,7 +61,7 @@ public abstract class MixinTileEntityHopper extends MixinTileEntityLockable impl
     @Inject(method = "putDropInInventoryAllSlots", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/item/EntityItem;getEntityItem()Lnet/minecraft/item/ItemStack;"))
     private static void onPutDrop(IInventory inventory, EntityItem entityItem, CallbackInfoReturnable<Boolean> callbackInfo) {
         IMixinEntity spongeEntity = (IMixinEntity) entityItem;
-        Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
+        Optional<User> owner = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
         if (owner.isPresent()) {
             if (inventory instanceof TileEntity) {
                 TileEntity te = (TileEntity) inventory;

--- a/src/main/java/org/spongepowered/common/mixin/core/world/chunk/storage/MixinAnvilChunkLoader.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/chunk/storage/MixinAnvilChunkLoader.java
@@ -32,11 +32,9 @@ import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.world.World;
-import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.storage.AnvilChunkLoader;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.Transform;
-import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
@@ -71,8 +69,8 @@ public class MixinAnvilChunkLoader {
         if (chunk.getTrackedShortPlayerPositions().size() > 0 || chunk.getTrackedIntPlayerPositions().size() > 0) {
             NBTTagCompound trackedNbt = new NBTTagCompound();
             NBTTagList positions = new NBTTagList();
-            trackedNbt.setTag(NbtDataUtil.SPONGE_BLOCK_POS_TABLE, positions);
-            compound.setTag(NbtDataUtil.SPONGE_DATA, trackedNbt);
+            trackedNbt.setTag(NbtDataUtil.Chunk.SPONGE_BLOCK_POS_TABLE, positions);
+            compound.setTag(NbtDataUtil.General.SPONGE_DATA, trackedNbt);
 
             for (Map.Entry<Short, PlayerTracker> mapEntry : chunk.getTrackedShortPlayerPositions().entrySet()) {
                 Short pos = mapEntry.getKey();
@@ -100,10 +98,10 @@ public class MixinAnvilChunkLoader {
 
     @Inject(method = "readChunkFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;getIntArray(Ljava/lang/String;)[I", shift = At.Shift.BEFORE), locals = LocalCapture.CAPTURE_FAILHARD)
     public void onReadChunkFromNBT(World worldIn, NBTTagCompound compound, CallbackInfoReturnable<net.minecraft.world.chunk.Chunk> ci, int chunkX, int chunkZ, net.minecraft.world.chunk.Chunk chunkIn) {
-        if (compound.hasKey(NbtDataUtil.SPONGE_DATA)) {
+        if (compound.hasKey(NbtDataUtil.General.SPONGE_DATA)) {
             Map<Integer, PlayerTracker> trackedIntPlayerPositions = Maps.newHashMap();
             Map<Short, PlayerTracker> trackedShortPlayerPositions = Maps.newHashMap();
-            NBTTagList positions = compound.getCompoundTag(NbtDataUtil.SPONGE_DATA).getTagList(NbtDataUtil.SPONGE_BLOCK_POS_TABLE, 10);
+            NBTTagList positions = compound.getCompoundTag(NbtDataUtil.General.SPONGE_DATA).getTagList(NbtDataUtil.Chunk.SPONGE_BLOCK_POS_TABLE, 10);
             IMixinChunk chunk = (IMixinChunk) chunkIn;
             for (int i = 0; i < positions.tagCount(); i++) {
                 NBTTagCompound valueNbt = positions.getCompoundTagAt(i);
@@ -144,12 +142,12 @@ public class MixinAnvilChunkLoader {
     @Redirect(method = "readChunkFromNBT(Lnet/minecraft/world/World;Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/world/chunk/Chunk;",
             at = @At(value = "INVOKE", target = ENTITY_LIST_CREATE_FROM_NBT), require = 0, expect = 0)
     private Entity onReadEntity(NBTTagCompound compound, World world) {
-        if ("Minecart".equals(compound.getString(NbtDataUtil.ENTITY_TYPE_ID))) {
-            compound.setString(NbtDataUtil.ENTITY_TYPE_ID,
-                    EntityMinecart.EnumMinecartType.byNetworkID(compound.getInteger(NbtDataUtil.MINECART_TYPE)).getName());
-            compound.removeTag(NbtDataUtil.MINECART_TYPE);
+        if ("Minecart".equals(compound.getString(NbtDataUtil.Entity.ENTITY_TYPE_ID))) {
+            compound.setString(NbtDataUtil.Entity.ENTITY_TYPE_ID,
+                    EntityMinecart.EnumMinecartType.byNetworkID(compound.getInteger(NbtDataUtil.Entity.Minecart.MINECART_TYPE)).getName());
+            compound.removeTag(NbtDataUtil.Entity.Minecart.MINECART_TYPE);
         }
-        Class<? extends Entity> entityClass = EntityList.stringToClassMapping.get(compound.getString(NbtDataUtil.ENTITY_TYPE_ID));
+        Class<? extends Entity> entityClass = EntityList.stringToClassMapping.get(compound.getString(NbtDataUtil.Entity.ENTITY_TYPE_ID));
         if (entityClass == null) {
             return null;
         }
@@ -157,8 +155,8 @@ public class MixinAnvilChunkLoader {
         if (type == null) {
             return null;
         }
-        NBTTagList positionList = compound.getTagList(NbtDataUtil.ENTITY_POSITION, NbtDataUtil.TAG_DOUBLE);
-        NBTTagList rotationList = compound.getTagList(NbtDataUtil.ENTITY_ROTATION, NbtDataUtil.TAG_FLOAT);
+        NBTTagList positionList = compound.getTagList(NbtDataUtil.Entity.ENTITY_POSITION, NbtDataUtil.TAG_DOUBLE);
+        NBTTagList rotationList = compound.getTagList(NbtDataUtil.Entity.ENTITY_ROTATION, NbtDataUtil.TAG_FLOAT);
         Vector3d position = new Vector3d(positionList.getDoubleAt(0), positionList.getDoubleAt(1), positionList.getDoubleAt(2));
         Vector3d rotation = new Vector3d(rotationList.getFloatAt(0), rotationList.getFloatAt(1), 0);
         Transform<org.spongepowered.api.world.World> transform = new Transform<>((org.spongepowered.api.world.World) world, position, rotation);

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinSaveHandler.java
@@ -122,8 +122,8 @@ public abstract class MixinSaveHandler implements IMixinSaveHandler {
             final NBTTagCompound compound = CompressedStreamTools.readCompressed(new FileInputStream(spongeFile.exists() ? spongeFile :
                     spongeOldFile));
             ((IMixinWorldInfo) info).setSpongeRootLevelNBT(compound);
-            if (compound.hasKey(NbtDataUtil.SPONGE_DATA)) {
-                ((IMixinWorldInfo) info).readSpongeNbt(compound.getCompoundTag(NbtDataUtil.SPONGE_DATA));
+            if (compound.hasKey(NbtDataUtil.General.SPONGE_DATA)) {
+                ((IMixinWorldInfo) info).readSpongeNbt(compound.getCompoundTag(NbtDataUtil.General.SPONGE_DATA));
             }
         }
     }
@@ -208,10 +208,10 @@ public abstract class MixinSaveHandler implements IMixinSaveHandler {
         NBTTagCompound compound = CompressedStreamTools.readCompressed(inputStream);
         Instant lastPlayed = Instant.now();
         // first try to migrate bukkit join data stuff
-        if (compound.hasKey(NbtDataUtil.BUKKIT, NbtDataUtil.TAG_COMPOUND)) {
-            final NBTTagCompound bukkitCompound = compound.getCompoundTag(NbtDataUtil.BUKKIT);
-            creation = Instant.ofEpochMilli(bukkitCompound.getLong(NbtDataUtil.BUKKIT_FIRST_PLAYED));
-            lastPlayed = Instant.ofEpochMilli(bukkitCompound.getLong(NbtDataUtil.BUKKIT_LAST_PLAYED));
+        if (compound.hasKey(NbtDataUtil.Compatibility.Bukkit.BUKKIT_ROOT, NbtDataUtil.TAG_COMPOUND)) {
+            final NBTTagCompound bukkitCompound = compound.getCompoundTag(NbtDataUtil.Compatibility.Bukkit.BUKKIT_ROOT);
+            creation = Instant.ofEpochMilli(bukkitCompound.getLong(NbtDataUtil.Compatibility.Bukkit.FIRST_PLAYED));
+            lastPlayed = Instant.ofEpochMilli(bukkitCompound.getLong(NbtDataUtil.Compatibility.Bukkit.LAST_PLAYED));
         }
         UUID playerId = null;
         if (compound.hasKey(NbtDataUtil.UUID_MOST, NbtDataUtil.TAG_LONG) && compound.hasKey(NbtDataUtil.UUID_LEAST, NbtDataUtil.TAG_LONG)) {

--- a/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/storage/MixinWorldInfo.java
@@ -147,8 +147,8 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
         this.spongeRootLevelNbt = new NBTTagCompound();
         this.spongeNbt = new NBTTagCompound();
         this.playerUniqueIdNbt = new NBTTagList();
-        this.spongeNbt.setTag(NbtDataUtil.SPONGE_PLAYER_UUID_TABLE, this.playerUniqueIdNbt);
-        this.spongeRootLevelNbt.setTag(NbtDataUtil.SPONGE_DATA, this.spongeNbt);
+        this.spongeNbt.setTag(NbtDataUtil.Chunk.SPONGE_PLAYER_UUID_TABLE, this.playerUniqueIdNbt);
+        this.spongeRootLevelNbt.setTag(NbtDataUtil.General.SPONGE_DATA, this.spongeNbt);
 
         if (this.dimensionType == null) {
             this.dimensionType = DimensionTypes.OVERWORLD;
@@ -671,12 +671,12 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
     @Override
     public void setSpongeRootLevelNBT(NBTTagCompound nbt) {
         this.spongeRootLevelNbt = nbt;
-        if (nbt.hasKey(NbtDataUtil.SPONGE_DATA)) {
-            this.spongeNbt = nbt.getCompoundTag(NbtDataUtil.SPONGE_DATA);
-            if (this.spongeNbt.hasKey(NbtDataUtil.SPONGE_PLAYER_UUID_TABLE)) {
-                this.playerUniqueIdNbt = this.spongeNbt.getTagList(NbtDataUtil.SPONGE_PLAYER_UUID_TABLE, 10);
+        if (nbt.hasKey(NbtDataUtil.General.SPONGE_DATA)) {
+            this.spongeNbt = nbt.getCompoundTag(NbtDataUtil.General.SPONGE_DATA);
+            if (this.spongeNbt.hasKey(NbtDataUtil.Chunk.SPONGE_PLAYER_UUID_TABLE)) {
+                this.playerUniqueIdNbt = this.spongeNbt.getTagList(NbtDataUtil.Chunk.SPONGE_PLAYER_UUID_TABLE, 10);
             } else {
-                this.spongeNbt.setTag(NbtDataUtil.SPONGE_PLAYER_UUID_TABLE, this.playerUniqueIdNbt);
+                this.spongeNbt.setTag(NbtDataUtil.Chunk.SPONGE_PLAYER_UUID_TABLE, this.playerUniqueIdNbt);
             }
         } else {
             // Migrate old NBT data to new location
@@ -684,16 +684,16 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
             if (nbt.hasKey(SpongeImpl.ECOSYSTEM_NAME)) {
                 this.spongeNbt = nbt.getCompoundTag(SpongeImpl.ECOSYSTEM_NAME);
             }
-            this.spongeRootLevelNbt.setTag(NbtDataUtil.SPONGE_DATA, this.spongeNbt);
+            this.spongeRootLevelNbt.setTag(NbtDataUtil.General.SPONGE_DATA, this.spongeNbt);
         }
     }
 
     @Override
     public void readSpongeNbt(NBTTagCompound nbt) {
-        this.dimension = nbt.getInteger(NbtDataUtil.DIMENSION_ID);
+        this.dimension = nbt.getInteger(NbtDataUtil.World.DIMENSION_ID);
         this.uuid = new UUID(nbt.getLong(NbtDataUtil.WORLD_UUID_MOST), nbt.getLong(NbtDataUtil.WORLD_UUID_LEAST));
-        this.isMod = nbt.getBoolean(NbtDataUtil.IS_MOD);
-        DimensionRegistryModule.getInstance().getAll().stream().filter(type -> type.getId().equalsIgnoreCase(nbt.getString(NbtDataUtil.DIMENSION_TYPE)))
+        this.isMod = nbt.getBoolean(NbtDataUtil.World.IS_MOD);
+        DimensionRegistryModule.getInstance().getAll().stream().filter(type -> type.getId().equalsIgnoreCase(nbt.getString(NbtDataUtil.World.DIMENSION_TYPE)))
                 .forEach(type -> this.dimensionType = type);
         this.trackedUniqueIdCount = 0;
         for (int i = 0; i < this.playerUniqueIdNbt.tagCount(); i++) {
@@ -705,16 +705,16 @@ public abstract class MixinWorldInfo implements WorldProperties, IMixinWorldInfo
     }
 
     private void writeSpongeNbt() {
-        this.spongeNbt.setInteger(NbtDataUtil.DIMENSION_ID, this.dimension);
+        this.spongeNbt.setInteger(NbtDataUtil.World.DIMENSION_ID, this.dimension);
         if (this.dimensionType != null) {
-            this.spongeNbt.setString(NbtDataUtil.DIMENSION_TYPE, this.dimensionType.getId());
+            this.spongeNbt.setString(NbtDataUtil.World.DIMENSION_TYPE, this.dimensionType.getId());
         }
         if (this.uuid != null) {
             this.spongeNbt.setLong(NbtDataUtil.WORLD_UUID_MOST, this.uuid.getMostSignificantBits());
             this.spongeNbt.setLong(NbtDataUtil.WORLD_UUID_LEAST, this.uuid.getLeastSignificantBits());
         }
         if (this.isMod) {
-            this.spongeNbt.setBoolean(NbtDataUtil.IS_MOD, true);
+            this.spongeNbt.setBoolean(NbtDataUtil.World.IS_MOD, true);
         }
 
         Iterator<UUID> iterator = this.pendingUniqueIds.iterator();

--- a/src/main/java/org/spongepowered/common/network/message/SpongeMessageHandler.java
+++ b/src/main/java/org/spongepowered/common/network/message/SpongeMessageHandler.java
@@ -88,8 +88,8 @@ public final class SpongeMessageHandler {
             Entity entity = sender.worldObj.getEntityByID(message.entityId);
             if (entity != null) {
                 IMixinEntity spongeEntity = (IMixinEntity) entity;
-                owner = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_CREATOR);
-                notifier = spongeEntity.getTrackedPlayer(NbtDataUtil.SPONGE_ENTITY_NOTIFIER);
+                owner = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR);
+                notifier = spongeEntity.getTrackedPlayer(NbtDataUtil.Entity.SPONGE_ENTITY_NOTIFIER);
             }
         }
 

--- a/src/main/java/org/spongepowered/common/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/common/util/SpongeHooks.java
@@ -643,7 +643,7 @@ public class SpongeHooks {
     public static void tryToTrackBlockAndEntity(World world, Object source, Entity entity, BlockPos sourcePos, Block targetBlock, BlockPos targetPos, PlayerTracker.Type type) {
         Optional<User> user = tryToTrackBlock(world, source, sourcePos, targetBlock, targetPos, type);
         if (user.isPresent()) {
-            ((IMixinEntity) entity).trackEntityUniqueId(NbtDataUtil.SPONGE_ENTITY_CREATOR, user.get().getUniqueId());
+            ((IMixinEntity) entity).trackEntityUniqueId(NbtDataUtil.Entity.SPONGE_ENTITY_CREATOR, user.get().getUniqueId());
         }
     }
 


### PR DESCRIPTION
With 1.9's development, it's now apparent that the cleanup of `NbtDataUtil` is required, let alone that anything remaining in the implementation NOT using `NbtDataUtil` constants should be found and refactored to use as such. This is mostly another code cleanup.