### PR TITLE
Ensure empty ListPaginations don't throw

### DIFF
--- a/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.service.pagination;
 
 import static org.spongepowered.common.util.SpongeCommonTranslationHelper.t;
 
+import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageReceiver;
@@ -64,7 +65,9 @@ class ListPagination extends ActivePagination {
 
     @Override
     protected Iterable<Text> getLines(int page) throws CommandException {
-        if (page < 1) {
+        if (this.pages.size() == 0) {
+            return ImmutableList.of();
+        } else if (page < 1) {
             throw new CommandException(t("Page %s does not exist!", page));
         } else if (page > this.pages.size()) {
             throw new CommandException(t("Page %s is too high", page));


### PR DESCRIPTION
Previously, the call to `page > this.pages.size()` would throw a
`CommandException` as soon as you try and fetch the first page of an empty
pagination.

Now, an empty List is returned when there are no items.

Tested it locally on today's freshest SF 1.8.9, works. Not that I expected this to be a breaking change.
