### PR TITLE
Replace usages of Trove with fastutil

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ minecraft {
     version = '1.9.4'
 }
 
+configurations {
+    fastutil
+    compile {
+        extendsFrom fastutil
+    }
+}
+
 dependencies {
     compile api
     compile('org.spongepowered:mixin:0.5.5-SNAPSHOT') {
@@ -55,7 +62,7 @@ dependencies {
         exclude module: 'guava'
     }
 
-    compile 'net.sf.trove4j:trove4j:3.0.3'
+    fastutil 'it.unimi.dsi:fastutil:7.0.12'
 
     // log4j2 slf4j implementation
     runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.0-beta9'

--- a/gradle/implementation.gradle
+++ b/gradle/implementation.gradle
@@ -89,6 +89,43 @@ shadowJar {
 
     // Prevent other dependencies replacing our license file
     exclude 'LICENSE', 'NOTICE'
+
+    from(zipTree(common.configurations.fastutil.first())) {
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectFunction.class'
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByte2ObjectMap.class'
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByteBidirectionalIterator.class'
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByteCollection.class'
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByteIterator.class'
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByteList.class'
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByteListIterator.class'
+        include 'it/unimi/dsi/fastutil/bytes/AbstractByteSet.class'
+        include 'it/unimi/dsi/fastutil/bytes/Byte2ObjectFunction.class'
+        include 'it/unimi/dsi/fastutil/bytes/Byte2ObjectMap.class'
+        include 'it/unimi/dsi/fastutil/bytes/Byte2ObjectOpenHashMap.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteArrayList.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteArrays.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteBidirectionalIterator.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteCollection.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteComparator.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteIterable.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteIterator.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteIterators.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteList.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteListIterator.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteSet.class'
+        include 'it/unimi/dsi/fastutil/bytes/ByteStack.class'
+        include 'it/unimi/dsi/fastutil/ints/IntOpenHashSet.class'
+        include 'it/unimi/dsi/fastutil/objects/AbstractObject2IntFunction.class'
+        include 'it/unimi/dsi/fastutil/objects/AbstractObject2IntMap.class'
+        include 'it/unimi/dsi/fastutil/objects/AbstractObject2LongFunction.class'
+        include 'it/unimi/dsi/fastutil/objects/AbstractObject2LongMap.class'
+        include 'it/unimi/dsi/fastutil/objects/Object2IntFunction.class'
+        include 'it/unimi/dsi/fastutil/objects/Object2IntMap.class'
+        include 'it/unimi/dsi/fastutil/objects/Object2IntOpenHashMap.class'
+        include 'it/unimi/dsi/fastutil/objects/Object2LongFunction.class'
+        include 'it/unimi/dsi/fastutil/objects/Object2LongMap.class'
+        include 'it/unimi/dsi/fastutil/objects/Object2LongOpenHashMap.class'
+    }
 }
 
 artifacts {

--- a/src/main/java/co/aikar/timings/TimingHandler.java
+++ b/src/main/java/co/aikar/timings/TimingHandler.java
@@ -25,7 +25,7 @@
 package co.aikar.timings;
 
 import co.aikar.util.LoadingIntMap;
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.spongepowered.common.SpongeImpl;
 
 class TimingHandler implements Timing {
@@ -36,7 +36,7 @@ class TimingHandler implements Timing {
     final String name;
     private final boolean verbose;
 
-    final TIntObjectHashMap<TimingData> children = new LoadingIntMap<>(TimingData.LOADER);
+    final Int2ObjectMap<TimingData> children = new LoadingIntMap<>(TimingData.LOADER);
 
     final TimingData record;
     private final TimingHandler groupHandler;
@@ -76,7 +76,7 @@ class TimingHandler implements Timing {
         }
 
         this.record.processTick(violated);
-        for (TimingData handler : this.children.valueCollection()) {
+        for (TimingData handler : this.children.values()) {
             handler.processTick(violated);
         }
     }

--- a/src/main/java/co/aikar/timings/TimingHistoryEntry.java
+++ b/src/main/java/co/aikar/timings/TimingHistoryEntry.java
@@ -36,7 +36,7 @@ class TimingHistoryEntry {
         this.data = handler.record.clone();
         this.children = new TimingData[handler.children.size()];
         int i = 0;
-        for (TimingData child : handler.children.valueCollection()) {
+        for (TimingData child : handler.children.values()) {
             this.children[i++] = child.clone();
         }
     }

--- a/src/main/java/co/aikar/util/LoadingIntMap.java
+++ b/src/main/java/co/aikar/util/LoadingIntMap.java
@@ -24,7 +24,7 @@
  */
 package co.aikar.util;
 
-import gnu.trove.map.hash.TIntObjectHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.util.function.Function;
 
@@ -44,7 +44,7 @@ import java.util.function.Function;
  *
  * @param <V> Value
  */
-public class LoadingIntMap<V> extends TIntObjectHashMap<V> {
+public class LoadingIntMap<V> extends Int2ObjectOpenHashMap<V> {
 
     private static final long serialVersionUID = 4788110182547553543L;
     private final Function<Integer, V> loader;

--- a/src/main/java/org/spongepowered/common/item/inventory/lens/Lens.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/lens/Lens.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.common.item.inventory.lens;
 
-import gnu.trove.set.TIntSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.text.translation.Translation;
 import org.spongepowered.common.item.inventory.adapter.InventoryAdapter;
@@ -93,7 +93,7 @@ public interface Lens<TInventory, TStack> extends LensCollection<TInventory, TSt
     public abstract boolean hasSlot(int index); //TInventory inv, int index);
     
 //    @Deprecated // TODO deprecate
-    public abstract TIntSet getSlots(); //TInventory inv);
+    public abstract IntSet getSlots(); //TInventory inv);
     
     /**
      * Returns the "real" underlying slot index in the target inventory for the

--- a/src/main/java/org/spongepowered/common/item/inventory/lens/impl/AbstractLens.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/lens/impl/AbstractLens.java
@@ -28,9 +28,9 @@ import static com.google.common.base.Preconditions.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
-import gnu.trove.impl.unmodifiable.TUnmodifiableIntSet;
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.InventoryProperty;
 import org.spongepowered.api.text.translation.Translation;
@@ -64,7 +64,7 @@ public abstract class AbstractLens<TInventory, TStack> extends ObservableLens<TI
     
     protected final int base;
     
-    protected final TIntSet availableSlots = new TIntHashSet();
+    protected final IntSet availableSlots = new IntOpenHashSet();
     
     protected Lens<TInventory, TStack> parent; 
     
@@ -173,8 +173,8 @@ public abstract class AbstractLens<TInventory, TStack> extends ObservableLens<TI
     }
     
     @Override
-    public TIntSet getSlots() {
-        return new TUnmodifiableIntSet(this.availableSlots);
+    public IntSet getSlots() {
+        return IntSets.unmodifiable(this.availableSlots);
     }
     
     @Override

--- a/src/main/java/org/spongepowered/common/item/inventory/lens/impl/DefaultEmptyLens.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/lens/impl/DefaultEmptyLens.java
@@ -24,9 +24,8 @@
  */
 package org.spongepowered.common.item.inventory.lens.impl;
 
-import gnu.trove.impl.unmodifiable.TUnmodifiableIntSet;
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.api.item.inventory.Inventory;
@@ -43,7 +42,7 @@ import java.util.List;
 
 public class DefaultEmptyLens extends ObservableLens<IInventory, ItemStack> {
 
-    private static final TIntSet EMPTY_SLOT_SET = new TUnmodifiableIntSet(new TIntHashSet());
+    private static final IntSet EMPTY_SLOT_SET = IntSets.EMPTY_SET;
     
     protected final InventoryAdapter<IInventory, ItemStack> adapter;
     
@@ -131,7 +130,7 @@ public class DefaultEmptyLens extends ObservableLens<IInventory, ItemStack> {
     }
     
     @Override
-    public TIntSet getSlots() {
+    public IntSet getSlots() {
         return DefaultEmptyLens.EMPTY_SLOT_SET;
     }
     

--- a/src/main/java/org/spongepowered/common/item/inventory/query/Query.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/query/Query.java
@@ -27,8 +27,8 @@ package org.spongepowered.common.item.inventory.query;
 import static com.google.common.base.Preconditions.*;
 
 import com.google.common.collect.Maps;
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.InventoryProperty;
@@ -197,8 +197,8 @@ public class Query<TInventory, TStack> {
 //        return true;
 //    }
 
-    private TIntSet getSlots(Collection<Lens<TInventory, TStack>> lenses) {
-        TIntSet slots = new TIntHashSet();
+    private IntSet getSlots(Collection<Lens<TInventory, TStack>> lenses) {
+        IntSet slots = new IntOpenHashSet();
         for (Lens<TInventory, TStack> lens : lenses) {
             slots.addAll(lens.getSlots());
         }

--- a/src/main/java/org/spongepowered/common/item/inventory/query/result/MinecraftResultAdapterProvider.java
+++ b/src/main/java/org/spongepowered/common/item/inventory/query/result/MinecraftResultAdapterProvider.java
@@ -24,8 +24,8 @@
  */
 package org.spongepowered.common.item.inventory.query.result;
 
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.api.item.inventory.Inventory;
@@ -97,7 +97,7 @@ public class MinecraftResultAdapterProvider implements ResultAdapterProvider<IIn
     }
 
     protected int getResultSize() {
-        TIntSet slots = new TIntHashSet();
+        IntSet slots = new IntOpenHashSet();
         
         for (Lens<IInventory, ItemStack> lens : this.getResultSet()) {
             slots.addAll(lens.getSlots());

--- a/src/main/java/org/spongepowered/common/util/SpongeHooks.java
+++ b/src/main/java/org/spongepowered/common/util/SpongeHooks.java
@@ -25,7 +25,8 @@
 package org.spongepowered.common.util;
 
 import com.flowpowered.math.vector.Vector3i;
-import gnu.trove.map.hash.TObjectLongHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -76,7 +77,7 @@ import javax.management.MBeanServer;
 
 public class SpongeHooks {
 
-    private static TObjectLongHashMap<CollisionWarning> recentWarnings = new TObjectLongHashMap<>();
+    private static Object2LongMap<CollisionWarning> recentWarnings = new Object2LongOpenHashMap<>();
 
     public static void logInfo(String msg, Object... args) {
         SpongeImpl.getLogger().info(MessageFormat.format(msg, args));
@@ -361,7 +362,7 @@ public class SpongeHooks {
 
         if (collisionWarnSize > 0 && (entity.getEntityWorld().getMinecraftServer().getTickCounter() % 10) == 0 && list.size() >= collisionWarnSize) {
             SpongeHooks.CollisionWarning warning = new SpongeHooks.CollisionWarning(entity.worldObj, entity);
-            if (SpongeHooks.recentWarnings.contains(warning)) {
+            if (SpongeHooks.recentWarnings.containsKey(warning)) {
                 long lastWarned = SpongeHooks.recentWarnings.get(warning);
                 if ((MinecraftServer.getCurrentTimeMillis() - lastWarned) < 30000) {
                     return;


### PR DESCRIPTION
As discussed in #586 this replaces all usages of Trove with fastutil. A subset of the fastutil classes is already bundled with Minecraft in 1.9.3+, however for Sponge we need some additional classes.

For now I've added the additional classes to a separate sourceset on SpongeCommon, so at the end only the additional classes will be shaded. There are quite a few, so I'm not sure whether we should rather move that to a separate repo or just upload it to the Maven repository directly (the classes are all unmodified).

This saves about ~2MB of the final SpongeVanilla JAR because only ~200KB of fastutil is additionally shaded in Sponge.

**Additional SpongeVanilla branch:** [feature/fastutil](https://github.com/SpongePowered/SpongeVanilla/tree/feature/fastutil)