### PR TITLE
Update Pagination to not pad if only one page exists.

### DIFF
--- a/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
@@ -188,25 +188,14 @@ abstract class ActivePagination {
         return ret.build();
     }
 
-    protected void padPage(final List<Text> currentPage, final int currentPageLines, final PadBehavior behavior) {
+    protected void padPage(final List<Text> currentPage, final int currentPageLines, final boolean addContinuation) {
         final int maxContentLinesPerPage = getMaxContentLinesPerPage();
         for (int i = currentPageLines; i < maxContentLinesPerPage; i++) {
-            if (i == maxContentLinesPerPage - 1 && behavior != PadBehavior.NO_CONTINUATION) {
+            if (addContinuation && i == maxContentLinesPerPage - 1) {
                 currentPage.add(CONTINUATION_TEXT);
-            } else if (behavior != PadBehavior.NO_PADDING) {
-                // We only want to perform padding if it has been asked for, AND there is another page to
-                // go to.
-                currentPage.add(Text.EMPTY);
             } else {
-                // If no conditions are true, there is no need to continue on this loop.
-                break;
+                currentPage.add(Text.EMPTY);
             }
         }
-    }
-
-    protected enum PadBehavior {
-        NO_CONTINUATION,
-        NO_PADDING,
-        STANDARD
     }
 }

--- a/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ActivePagination.java
@@ -46,6 +46,7 @@ abstract class ActivePagination {
 
     private static final Text SLASH_TEXT = Text.of("/");
     private static final Text DIVIDER_TEXT = Text.of(" ");
+    private static final Text CONTINUATION_TEXT = t("...");
     private final WeakReference<MessageReceiver> src;
     private final UUID id = UUID.randomUUID();
     private final Text nextPageText;
@@ -185,5 +186,27 @@ abstract class ActivePagination {
             ret.style(this.title.getStyle());
         }
         return ret.build();
+    }
+
+    protected void padPage(final List<Text> currentPage, final int currentPageLines, final PadBehavior behavior) {
+        final int maxContentLinesPerPage = getMaxContentLinesPerPage();
+        for (int i = currentPageLines; i < maxContentLinesPerPage; i++) {
+            if (i == maxContentLinesPerPage - 1 && behavior != PadBehavior.NO_CONTINUATION) {
+                currentPage.add(CONTINUATION_TEXT);
+            } else if (behavior != PadBehavior.NO_PADDING) {
+                // We only want to perform padding if it has been asked for, AND there is another page to
+                // go to.
+                currentPage.add(Text.EMPTY);
+            } else {
+                // If no conditions are true, there is no need to continue on this loop.
+                break;
+            }
+        }
+    }
+
+    protected enum PadBehavior {
+        NO_CONTINUATION,
+        NO_PADDING,
+        STANDARD
     }
 }

--- a/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
@@ -82,11 +82,15 @@ class IterablePagination extends ActivePagination {
         int addedLines = 0;
         while (addedLines <= getMaxContentLinesPerPage()) {
             if (!this.countIterator.hasNext()) {
-                padPage(ret,addedLines, Text.EMPTY);
+                // Pad the last page, but only if it isn't the first.
+                if (page > 1) {
+                    padPage(ret, addedLines, PadBehavior.NO_CONTINUATION);
+                }
                 break;
             }
             if (addedLines + this.countIterator.peek().getValue() > getMaxContentLinesPerPage()) {
-                padPage(ret,addedLines, t("..."));
+                // Add the continuation marker, pad if required
+                padPage(ret, addedLines, PadBehavior.STANDARD);
                 break;
             }
             Map.Entry<Text, Integer> ent = this.countIterator.next();
@@ -94,17 +98,6 @@ class IterablePagination extends ActivePagination {
             addedLines += ent.getValue();
         }
         return ret;
-    }
-
-    private void padPage(final List<Text> currentPage, final int currentPageLines, final Text continuation) {
-        final int maxContentLinesPerPage = getMaxContentLinesPerPage();
-        for (int i = currentPageLines; i< maxContentLinesPerPage; i++){
-            if (i == (maxContentLinesPerPage - 1)) {
-                currentPage.add(continuation);
-            } else {
-                currentPage.add(Text.EMPTY);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/IterablePagination.java
@@ -84,13 +84,13 @@ class IterablePagination extends ActivePagination {
             if (!this.countIterator.hasNext()) {
                 // Pad the last page, but only if it isn't the first.
                 if (page > 1) {
-                    padPage(ret, addedLines, PadBehavior.NO_CONTINUATION);
+                    padPage(ret, addedLines, false);
                 }
                 break;
             }
             if (addedLines + this.countIterator.peek().getValue() > getMaxContentLinesPerPage()) {
                 // Add the continuation marker, pad if required
-                padPage(ret, addedLines, PadBehavior.STANDARD);
+                padPage(ret, addedLines, true);
                 break;
             }
             Map.Entry<Text, Integer> ent = this.countIterator.next();

--- a/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
@@ -50,7 +50,7 @@ class ListPagination extends ActivePagination {
 
         for (Map.Entry<Text, Integer> ent : lines) {
             if (getMaxContentLinesPerPage() > 0 && ent.getValue() + currentPageLines > getMaxContentLinesPerPage() && currentPageLines != 0) {
-                padPage(currentPage, currentPageLines, t("..."));
+                padPage(currentPage, currentPageLines, PadBehavior.STANDARD);
                 currentPageLines = 0;
                 pages.add(currentPage);
                 currentPage = new ArrayList<>();
@@ -59,21 +59,13 @@ class ListPagination extends ActivePagination {
             currentPage.add(ent.getKey());
         }
         if (currentPageLines > 0) {
-            padPage(currentPage, currentPageLines, Text.EMPTY);
+            if (!pages.isEmpty()) {
+                // Only pad if we have a previous page
+                padPage(currentPage, currentPageLines, PadBehavior.NO_CONTINUATION);
+            }
             pages.add(currentPage);
         }
         this.pages = pages;
-    }
-
-    private void padPage(final List<Text> currentPage, final int currentPageLines, final Text continuation) {
-        final int maxContentLinesPerPage = getMaxContentLinesPerPage();
-        for (int i = currentPageLines; i< maxContentLinesPerPage; i++){
-            if (i == maxContentLinesPerPage - 1) {
-                currentPage.add(continuation);
-            } else {
-                currentPage.add(Text.EMPTY);
-            }
-        }
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
+++ b/src/main/java/org/spongepowered/common/service/pagination/ListPagination.java
@@ -50,7 +50,7 @@ class ListPagination extends ActivePagination {
 
         for (Map.Entry<Text, Integer> ent : lines) {
             if (getMaxContentLinesPerPage() > 0 && ent.getValue() + currentPageLines > getMaxContentLinesPerPage() && currentPageLines != 0) {
-                padPage(currentPage, currentPageLines, PadBehavior.STANDARD);
+                padPage(currentPage, currentPageLines, true);
                 currentPageLines = 0;
                 pages.add(currentPage);
                 currentPage = new ArrayList<>();
@@ -61,7 +61,7 @@ class ListPagination extends ActivePagination {
         if (currentPageLines > 0) {
             if (!pages.isEmpty()) {
                 // Only pad if we have a previous page
-                padPage(currentPage, currentPageLines, PadBehavior.NO_CONTINUATION);
+                padPage(currentPage, currentPageLines, false);
             }
             pages.add(currentPage);
         }


### PR DESCRIPTION
When #639 was merged, some of my pagination broke - see https://github.com/NucleusPowered/Nucleus/issues/158. In this particular case:

* A one page MOTD which has the potential to have more than one page now fills the entire chat box, which is a waste of chat space when there is only one page to display.
* I have code that sets the number of lines to display to the console to `Integer.MAX_VALUE`, so that the console can just see the entire MOTD. However, since merging #639, this causes an out of memory error because it's trying to create a _huge_ list. (While I accept I could lower this value, I still want to use the styling that the Pagination service provides without any padding when I do not know how many lines I have.)

I think the change provided in #639 is a real usability win, but only when there is more than one page, and this breaks what plugins were expecting before. This PR returns the previous behaviour to one page items, while retaining the new behaviour when there is more than one page.

I have a test plugin that will demonstrate the behaviour: https://gist.github.com/dualspiral/067000c4b1fc80407e79bd51cce151d8

The commands are:

* `/pg <numberoflines>`, put the word "text" into the pagination list the specified number of times, displaying 20 lines per page.
* `/pglg <numberoflines>`, put the phrase "long text text text text text text text text text text text text text text text text text text text text text text text" into the pagination list the specified number of times, 20 lines per page.
* `/pgmax <numberoflines>` is the same as `/pg`, but can have `Integer.MAX_VALUE` number of lines.

I tested with `/pg 1`, `/pg 21`, `/pglg 10` and `/pgmax 25`.