### PR TITLE
Fix SolidCubeProperty being only accessible from Location<World>

### DIFF
--- a/src/main/java/org/spongepowered/common/data/property/store/block/SolidCubePropertyStore.java
+++ b/src/main/java/org/spongepowered/common/data/property/store/block/SolidCubePropertyStore.java
@@ -27,32 +27,30 @@ package org.spongepowered.common.data.property.store.block;
 import net.minecraft.block.Block;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
 import org.spongepowered.api.data.property.block.SolidCubeProperty;
-import org.spongepowered.api.util.Direction;
-import org.spongepowered.api.world.Location;
-import org.spongepowered.api.world.World;
-import org.spongepowered.common.data.property.store.common.AbstractSpongePropertyStore;
-import org.spongepowered.common.util.VecHelper;
+import org.spongepowered.common.data.property.store.common.AbstractBlockPropertyStore;
 
 import java.util.Optional;
 
-public class SolidCubePropertyStore extends AbstractSpongePropertyStore<SolidCubeProperty> {
+public class SolidCubePropertyStore extends AbstractBlockPropertyStore<SolidCubeProperty> {
 
     protected static final SolidCubeProperty TRUE = new SolidCubeProperty(true);
     protected static final SolidCubeProperty FALSE = new SolidCubeProperty(false);
 
+    public SolidCubePropertyStore() {
+        super(true);
+    }
+
     @Override
-    public Optional<SolidCubeProperty> getFor(Location<World> location) {
-        final Block block = (Block) location.getBlockType();
+    protected Optional<SolidCubeProperty> getForBlock(Block block) {
         return Optional.of(block.getMaterial().isSolid() ? TRUE : FALSE);
     }
 
     @Override
-    public Optional<SolidCubeProperty> getFor(Location<World> location, Direction direction) {
-        final net.minecraft.world.World world = (net.minecraft.world.World) location.getExtent();
-        final Block block = (Block) location.getBlockType();
-        final BlockPos pos = VecHelper.toBlockPos(location);
-        final EnumFacing facing = toEnumFacing(direction);
+    protected Optional<SolidCubeProperty> getForDirection(World world, int x, int y, int z, EnumFacing facing) {
+        BlockPos pos = new BlockPos(x, y, z);
+        Block block = world.getBlockState(pos).getBlock();
         return Optional.of(block.isBlockSolid(world, pos, facing) ? TRUE : FALSE);
     }
 


### PR DESCRIPTION
See https://forums.spongepowered.org/t/getting-properties-of-a-block-type-fails/12859/

This fixes SolidCube property so that it uses the correct Abstract class. Before this change it would only be able to be fetched from a block in the world, not via an `ItemStack`. This change fixes this to be in line with the rest of the item-capable properties.