### PR TITLE
[1.9] Implement EnderDragon.getHealingCrystal().

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/boss/MixinEntityDragon.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/boss/MixinEntityDragon.java
@@ -28,7 +28,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import net.minecraft.entity.boss.EntityDragon;
 import net.minecraft.entity.boss.EntityDragonPart;
+import net.minecraft.entity.item.EntityEnderCrystal;
 import net.minecraft.world.GameRules;
+import org.spongepowered.api.entity.EnderCrystal;
 import org.spongepowered.api.entity.living.complex.EnderDragon;
 import org.spongepowered.api.entity.living.complex.EnderDragonPart;
 import org.spongepowered.asm.mixin.Mixin;
@@ -38,12 +40,16 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.common.interfaces.entity.IMixinGriefer;
 import org.spongepowered.common.mixin.core.entity.MixinEntityLiving;
 
+import java.util.Optional;
 import java.util.Set;
+
+import javax.annotation.Nullable;
 
 @Mixin(EntityDragon.class)
 public abstract class MixinEntityDragon extends MixinEntityLiving implements EnderDragon {
 
     @Shadow public EntityDragonPart[] dragonPartArray;
+    @Shadow public EntityEnderCrystal healingEnderCrystal;
 
     @Override
     public Set<EnderDragonPart> getParts() {
@@ -59,5 +65,10 @@ public abstract class MixinEntityDragon extends MixinEntityLiving implements End
     @Redirect(method = "destroyBlocksInAABB", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameRules;getBoolean(Ljava/lang/String;)Z"))
     private boolean onCanGrief(GameRules gameRules, String rule) {
         return gameRules.getBoolean(rule) && ((IMixinGriefer) this).canGrief();
+    }
+    
+    @Override
+    public Optional<EnderCrystal> getHealingCrystal() {
+        return Optional.ofNullable((EnderCrystal) this.healingEnderCrystal);
     }
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1260) | **SpongeCommon**
I heard @gabizou say some time ago that `DataManipulator`s are no longer allowed to store `Entity`s. So instead of implementing `HealingSourceData`, I just moved it into `EnderDragon` and implemented it there.