### PR TITLE
[WIP] Bugfixes and improvements for selectors

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/type/text/ArgumentRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/text/ArgumentRegistryModule.java
@@ -64,7 +64,7 @@ public final class ArgumentRegistryModule implements RegistryModule {
         this.argumentTypeMap.put("radius", radius);
 
         // GAME_MODE
-        this.argumentTypeMap.put("game_mode", factory.createArgumentType("m", GameMode.class));
+        this.argumentTypeMap.put("game_mode", factory.createInvertibleArgumentType("m", GameMode.class));
 
         // COUNT
         this.argumentTypeMap.put("count", factory.createArgumentType("c", Integer.class));

--- a/src/main/java/org/spongepowered/common/text/selector/SelectorResolver.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SelectorResolver.java
@@ -29,15 +29,13 @@ import static org.spongepowered.common.util.OptionalUtils.asSet;
 
 import com.flowpowered.math.vector.Vector3d;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.data.manipulator.mutable.DisplayNameData;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExperienceHolderData;
 import org.spongepowered.api.data.manipulator.mutable.entity.GameModeData;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityType;
-import org.spongepowered.api.entity.EntityTypes;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.living.player.gamemode.GameModes;
@@ -47,28 +45,30 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.selector.Argument;
 import org.spongepowered.api.text.selector.Argument.Invertible;
 import org.spongepowered.api.text.selector.ArgumentHolder;
-import org.spongepowered.api.text.selector.ArgumentType;
 import org.spongepowered.api.text.selector.ArgumentTypes;
 import org.spongepowered.api.text.selector.Selector;
 import org.spongepowered.api.text.selector.SelectorType;
 import org.spongepowered.api.text.selector.SelectorTypes;
 import org.spongepowered.api.util.Functional;
-import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.util.GuavaCollectors;
 import org.spongepowered.api.world.Locatable;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
-import org.spongepowered.common.SpongeImpl;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
 
 /**
  * A resolver that acts like Vanilla Minecraft in many regards.
@@ -78,19 +78,8 @@ public class SelectorResolver {
 
     private static final Function<CommandSource, String> GET_NAME = CommandSource::getName;
     private static final Vector3d ORIGIN = new Vector3d(0, 0, 0);
-    private static final Set<ArgumentType<?>> LOCATION_BASED_ARGUMENTS;
     private static final Function<Number, Double> TO_DOUBLE = Number::doubleValue;
     private static final Collection<SelectorType> INFINITE_TYPES = ImmutableSet.of(SelectorTypes.ALL_ENTITIES, SelectorTypes.ALL_PLAYERS);
-
-    static {
-        ImmutableSet.Builder<ArgumentType<?>> builder = ImmutableSet.builder();
-        builder.addAll(ArgumentTypes.POSITION.getTypes());
-        builder.addAll(ArgumentTypes.DIMENSION.getTypes());
-        builder.addAll(ArgumentTypes.RADIUS.getTypes());
-        // Left commented because Vanilla doesn't include it (see field_179666_d)
-        // builder.addAll(ArgumentTypes.ROTATION.getTypes());
-        LOCATION_BASED_ARGUMENTS = builder.build();
-    }
 
     private static Extent extentFromSource(CommandSource origin) {
         if (origin instanceof Locatable) {
@@ -106,7 +95,7 @@ public class SelectorResolver {
         return null;
     }
 
-    private static <I, R> Predicate<I> requireTypePredicate(Class<I> inputType, final Class<R> requiredType) {
+    private static <I, R extends I> Predicate<I> requireTypePredicate(Class<I> inputType, final Class<R> requiredType) {
         return requiredType::isInstance;
     }
 
@@ -115,35 +104,32 @@ public class SelectorResolver {
     private final Optional<CommandSource> original;
     private final Selector selector;
     private final Predicate<Entity> selectorFilter;
-    private final boolean alwaysUsePosition;
 
-    public SelectorResolver(Collection<? extends Extent> extents, Selector selector, boolean force) {
-        this(extents, null, null, selector, force);
+    public SelectorResolver(Collection<? extends Extent> extents, Selector selector) {
+        this(extents, null, null, selector);
     }
 
-    public SelectorResolver(Location<World> location, Selector selector, boolean force) {
-        this(ImmutableSet.of(location.getExtent()), location.getPosition(), null, selector, force);
+    public SelectorResolver(Location<World> location, Selector selector) {
+        this(ImmutableSet.of(location.getExtent()), location.getPosition(), null, selector);
     }
 
-    public SelectorResolver(CommandSource origin, Selector selector, boolean force) {
-        this(asSet(Optional.ofNullable(extentFromSource(origin))), positionFromSource(origin), origin, selector, force);
+    public SelectorResolver(CommandSource origin, Selector selector) {
+        this(asSet(Optional.ofNullable(extentFromSource(origin))), positionFromSource(origin), origin, selector);
     }
 
-    private SelectorResolver(Collection<? extends Extent> extents, Vector3d position,
-        CommandSource original, Selector selector, boolean force) {
+    private SelectorResolver(Collection<? extends Extent> extents, @Nullable Vector3d position, @Nullable CommandSource original, Selector selector) {
         this.extents = ImmutableSet.copyOf(extents);
         this.position = position == null ? ORIGIN : position;
         this.original = Optional.ofNullable(original);
         this.selector = checkNotNull(selector);
         this.selectorFilter = makeFilter();
-        this.alwaysUsePosition = force;
     }
 
     private Predicate<Entity> makeFilter() {
-        // for easier reading
         final Selector sel = this.selector;
         Vector3d position = getPositionOrDefault(this.position, ArgumentTypes.POSITION);
-        List<Predicate<Entity>> filters = Lists.newArrayList();
+        ArrayList<Predicate<Entity>> filters = new ArrayList<>(sel.getArguments().size());
+
         addTypeFilters(filters);
         addDimensionFilters(position, filters);
         addRadiusFilters(position, filters);
@@ -153,18 +139,18 @@ public class SelectorResolver {
         addRotationFilters(filters);
         addTeamFilters(filters);
         addScoreFilters(filters);
-        SelectorType selectorType = sel.getType();
-        Optional<Invertible<EntityType>> type = sel.getArgument(ArgumentTypes.ENTITY_TYPE);
-        // isn't an ALL_ENTITIES selector or it is a RANDOM selector for only players
-        boolean isPlayerOnlySelector =
-            selectorType == SelectorTypes.ALL_PLAYERS || selectorType == SelectorTypes.NEAREST_PLAYER
-                || (selectorType == SelectorTypes.RANDOM && type.isPresent() && !type.get().isInverted()
-                && type.get().getValue() != EntityTypes.PLAYER);
-        if (isPlayerOnlySelector) {
+
+        if (isPlayerOnlySelector(sel.getType())) {
             // insert at the start so it applies first
             filters.add(0, requireTypePredicate(Entity.class, Player.class));
         }
+        // Pack the list before returning it to improve space efficiency
+        filters.trimToSize();
         return Functional.predicateAnd(filters);
+    }
+
+    private boolean isPlayerOnlySelector(SelectorType selectorType) {
+        return selectorType == SelectorTypes.ALL_PLAYERS || selectorType == SelectorTypes.NEAREST_PLAYER;
     }
 
     private void addDimensionFilters(final Vector3d position, List<Predicate<Entity>> filters) {
@@ -259,8 +245,10 @@ public class SelectorResolver {
     private void addRotationFilters(List<Predicate<Entity>> filters) {
         Selector sel = this.selector;
         // If the Z's are uncommented, don't forget to implement them
-        // Optional<Double> rotMinZ = sel.get(ArgumentTypes.ROTATION.minimum().z());
-        // Optional<Double> rotMaxZ = sel.get(ArgumentTypes.ROTATION.maximum().z());
+        // Optional<Double> rotMinZ =
+        // sel.get(ArgumentTypes.ROTATION.minimum().z());
+        // Optional<Double> rotMaxZ =
+        // sel.get(ArgumentTypes.ROTATION.maximum().z());
         Optional<Double> rotMinX = sel.get(ArgumentTypes.ROTATION.minimum().x());
         if (rotMinX.isPresent()) {
             final double rmx = rotMinX.get();
@@ -294,13 +282,13 @@ public class SelectorResolver {
         if (teamOpt.isPresent()) {
             Invertible<String> teamArg = teamOpt.get();
             final boolean inverted = teamArg.isInverted();
-            final Collection<Team> teams = Sponge.getGame().getServer().getServerScoreboard().get().getTeams();
             filters.add(new Predicate<Entity>() {
 
                 @Override
                 public boolean test(Entity input) {
+                    Collection<Team> teams = Sponge.getGame().getServer().getServerScoreboard().get().getTeams();
                     if (input instanceof TeamMember) {
-                        return inverted ^ collectMembers(teams).contains(((TeamMember) input).getTeamRepresentation());
+                        return inverted != collectMembers(teams).contains(((TeamMember) input).getTeamRepresentation());
                     }
                     return false;
                 }
@@ -324,7 +312,7 @@ public class SelectorResolver {
             Argument.Invertible<EntityType> typeArg = typeOpt.get();
             final boolean inverted = typeArg.isInverted();
             final EntityType type = typeArg.getValue();
-            filters.add(input -> inverted ^ input.getType() == type);
+            filters.add(input -> inverted != (input.getType() == type));
         }
     }
 
@@ -332,56 +320,49 @@ public class SelectorResolver {
         Optional<Double> x = this.selector.get(vecTypes.x()).map(TO_DOUBLE);
         Optional<Double> y = this.selector.get(vecTypes.y()).map(TO_DOUBLE);
         Optional<Double> z = this.selector.get(vecTypes.z()).map(TO_DOUBLE);
-        return new Vector3d(x.orElse(Double.valueOf(pos.getX())), y.orElse(Double.valueOf(pos.getY())), z.orElse(Double.valueOf(pos.getZ())));
+        return new Vector3d(x.orElse(pos.getX()), y.orElse(pos.getY()), z.orElse(pos.getZ()));
     }
 
     public String getName() {
         return this.original.map(GET_NAME).orElse("SelectorResolver");
     }
 
-    public Set<Entity> resolve() {
+    public List<Entity> resolve() {
         SelectorType selectorType = this.selector.getType();
         int defaultCount = 1;
         if (INFINITE_TYPES.contains(selectorType)) {
             defaultCount = 0;
         }
         int maxToSelect = this.selector.get(ArgumentTypes.COUNT).orElse(defaultCount);
+        boolean isReversed = maxToSelect < 0;
+        maxToSelect = Math.abs(maxToSelect);
         Set<? extends Extent> extents = getExtentSet();
-        int count = 0;
-        ImmutableSet.Builder<Entity> entities = ImmutableSet.builder();
-        for (Extent extent : extents) {
-            Collection<Entity> allEntities = extent.getEntities();
+        Stream<Entity> entityStream = extents.stream()
+                .flatMap(ext -> ext.getEntities().stream())
+                .filter(this.selectorFilter);
+        if (maxToSelect != 0) {
             if (selectorType == SelectorTypes.RANDOM) {
-                List<Entity> entityList = new ArrayList<>(allEntities);
-                Collections.shuffle(entityList);
-                allEntities = entityList;
+                List<Entity> holder = entityStream.collect(Collectors.toList());
+                Collections.shuffle(holder);
+                entityStream = holder.stream();
             }
-
-            for (Entity e : allEntities) {
-                if (!this.selectorFilter.test(e)) {
-                    continue;
-                }
-                entities.add(e);
-                count++;
-                if (maxToSelect != 0 && count > maxToSelect) {
-                    break;
-                }
-            }
+            entityStream = entityStream.limit(maxToSelect);
         }
-        return entities.build();
+        return entityStream.sorted(distanceSort(isReversed)).collect(GuavaCollectors.toImmutableList());
+    }
+
+    private Comparator<? super Entity> distanceSort(boolean isReversed) {
+        Vector3d position = getPositionOrDefault(this.position, ArgumentTypes.POSITION);
+        int multiplier = isReversed ? -1 : 1;
+        return (a, b) -> {
+            double distToPosA = a.getLocation().getPosition().distanceSquared(position);
+            double distToPosB = b.getLocation().getPosition().distanceSquared(position);
+            return Double.compare(distToPosA, distToPosB) * multiplier;
+        };
     }
 
     private Set<? extends Extent> getExtentSet() {
-        if (!this.alwaysUsePosition && Collections.disjoint(getArgumentTypes(this.selector.getArguments()), LOCATION_BASED_ARGUMENTS)) {
-            return ImmutableSet.copyOf(SpongeImpl.getGame().getServer().getWorlds());
-        }
         return ImmutableSet.copyOf(this.extents);
-    }
-
-    private Collection<ArgumentType<?>> getArgumentTypes(Collection<Argument<?>> arguments) {
-        Collection<ArgumentType<?>> types = Sets.newHashSet();
-        types.addAll(arguments.stream().map(Argument::getType).collect(Collectors.toList()));
-        return types;
     }
 
 }

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeArgumentType.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeArgumentType.java
@@ -28,7 +28,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Maps;
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.living.player.gamemode.GameModes;
 import org.spongepowered.api.text.selector.ArgumentType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.common.SpongeImpl;
@@ -47,6 +50,26 @@ public class SpongeArgumentType<T> extends SpongeArgumentHolder<ArgumentType<T>>
         converters.put(String.class.getName(), Function.<String>identity());
         converters.put(EntityType.class.getName(),
                        (Function<String, EntityType>) input -> EntityTypeRegistryModule.getInstance().getById(input.toLowerCase()).orElse(null));
+        converters.put(GameMode.class.getName(), input -> {
+            try {
+                int mode = Integer.parseInt(input);
+                switch (mode) {
+                    case -1:
+                        return GameModes.NOT_SET;
+                    case 0:
+                        return GameModes.SURVIVAL;
+                    case 1:
+                        return GameModes.CREATIVE;
+                    case 2:
+                        return GameModes.ADVENTURE;
+                    case 3:
+                        return GameModes.SPECTATOR;
+                }
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+            return Sponge.getRegistry().getType(GameMode.class, input);
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeSelector.java
@@ -26,25 +26,23 @@ package org.spongepowered.common.text.selector;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.text.selector.Argument;
 import org.spongepowered.api.text.selector.ArgumentType;
 import org.spongepowered.api.text.selector.Selector;
 import org.spongepowered.api.text.selector.SelectorType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
-import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 @NonnullByDefault
 public class SpongeSelector implements Selector {
@@ -103,43 +101,23 @@ public class SpongeSelector implements Selector {
     }
 
     @Override
-    public Set<Entity> resolve(CommandSource origin) {
-        return new SelectorResolver(origin, this, false).resolve();
+    public List<Entity> resolve(CommandSource origin) {
+        return new SelectorResolver(origin, this).resolve();
     }
 
     @Override
-    public Set<Entity> resolve(Extent... extents) {
+    public List<Entity> resolve(Extent... extents) {
         return resolve(ImmutableSet.copyOf(extents));
     }
 
     @Override
-    public Set<Entity> resolve(Collection<? extends Extent> extents) {
-        return new SelectorResolver(extents, this, false).resolve();
+    public List<Entity> resolve(Collection<? extends Extent> extents) {
+        return new SelectorResolver(extents, this).resolve();
     }
 
     @Override
-    public Set<Entity> resolve(Location<World> location) {
-        return new SelectorResolver(location, this, false).resolve();
-    }
-
-    @Override
-    public Set<Entity> resolveForce(CommandSource origin) {
-        return new SelectorResolver(origin, this, true).resolve();
-    }
-
-    @Override
-    public Set<Entity> resolveForce(Extent... extents) {
-        return resolveForce(ImmutableSet.copyOf(extents));
-    }
-
-    @Override
-    public Set<Entity> resolveForce(Collection<? extends Extent> extents) {
-        return new SelectorResolver(extents, this, true).resolve();
-    }
-
-    @Override
-    public Set<Entity> resolveForce(Location<World> location) {
-        return new SelectorResolver(location, this, true).resolve();
+    public List<Entity> resolve(Location<World> location) {
+        return new SelectorResolver(location, this).resolve();
     }
 
     @Override
@@ -158,16 +136,8 @@ public class SpongeSelector implements Selector {
         result.append('@').append(this.type.getId());
 
         if (!this.arguments.isEmpty()) {
-            result.append('[');
             Collection<Argument<?>> args = this.arguments.values();
-            for (Iterator<Argument<?>> iter = args.iterator(); iter.hasNext();) {
-                Argument<?> arg = iter.next();
-                result.append(arg.toPlain());
-                if (iter.hasNext()) {
-                    result.append(',');
-                }
-            }
-            result.append(']');
+            result.append(args.stream().map(Argument::toPlain).collect(Collectors.joining(",", "[", "]")));
         }
 
         return result.toString();

--- a/src/main/java/org/spongepowered/common/text/selector/SpongeSelectorFactory.java
+++ b/src/main/java/org/spongepowered/common/text/selector/SpongeSelectorFactory.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.text.selector;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -222,6 +223,8 @@ public class SpongeSelectorFactory implements SelectorFactory {
     public <T> SpongeArgumentType.Invertible<T> createInvertibleArgumentType(
             String key, Class<T> type, String converterKey) {
         if (!this.argumentLookupMap.containsKey(key)) {
+            checkNotNull(converterKey, "converter key cannot be null");
+            checkNotNull(converterKey, "converter key cannot be null");
             this.argumentLookupMap.put(key,
                                        new SpongeArgumentType.Invertible<>(key, type,
                                                                            converterKey));

--- a/src/main/java/org/spongepowered/common/util/OptionalUtils.java
+++ b/src/main/java/org/spongepowered/common/util/OptionalUtils.java
@@ -24,17 +24,15 @@
  */
 package org.spongepowered.common.util;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
 
 public class OptionalUtils {
 
-    public static <E> Collection<E> asSet(Optional<E> opt) {
-        if (opt.isPresent()) {
-            return Collections.singleton(opt.get());
-        }
-        return Collections.emptySet();
+    public static <E> Set<E> asSet(Optional<E> opt) {
+        return opt.map(v -> ImmutableSet.of(v)).orElseGet(() -> ImmutableSet.of());
     }
 
 }


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1270) | SpongeCommon (You're here!)

Improvements and fixes for selectors based on 1.9 and my own review of the code.

Selectors now use a `List`, the resolver returns the elements ordered properly as well as the right number of elements. Removed the `force` argument as I don't remember what it was really useful for.
