### PR TITLE
Add Item entity merge configuration.

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/WorldCategory.java
@@ -75,6 +75,15 @@ public class WorldCategory extends ConfigCategory {
     @Setting(value = "chunk-gc-load-threshold", comment = "The number of newly loaded chunks before triggering a forced cleanup. \nNote: When triggered, the loaded chunk threshold will reset and start incrementing. \nDisabled by default.")
     private int chunkGCLoadThreshold = 0;
 
+    @Setting(value = "item-merge-radius", comment = "This defines the Item entity merge radius such that two Item entities"
+                                                    + "\nwithin the defined radius of each other will attempt to merge. Usually,"
+                                                    + "\nthe default radius is set to 0.5 in Vanilla, however, for performance reasons"
+                                                    + "\n2.5 is generally acceptable. "
+                                                    + "\nNote: Increasing the radius higher will likely cause performance degredation"
+                                                    + "\nwith larger amount of items as they attempt to merge and search nearby"
+                                                    + "\nareas for more items. Setting to a negative value is not supported!")
+    private double itemMergeRadius = 2.5D;
+
     public WorldCategory() {
         this.portalAgents.put("minecraft:default_nether", "DIM-1");
         this.portalAgents.put("minecraft:default_the_end", "DIM1");
@@ -162,5 +171,9 @@ public class WorldCategory extends ConfigCategory {
 
     public int getChunkLoadThreadhold() {
         return this.chunkGCLoadThreshold;
+    }
+
+    public double getItemMergeRadius() {
+        return itemMergeRadius;
     }
 }


### PR DESCRIPTION
This is a really simple configuration addition, but I just want it to be looked over as to whether the configuration area is the best place. This works really well to the point where the method now looks like so:
```java
    private void searchForOtherItemsNearby() {
        Iterator var1 = this.worldObj.getEntitiesWithinAABB(EntityItem.class, this.getEntityBoundingBox().expand(this.getSearchRadius(0.5D), 0.0D, this.getSearchRadius(0.5D))).iterator();

        while(var1.hasNext()) {
            EntityItem entityitem = (EntityItem)var1.next();
            this.combineItems(entityitem);
        }

    }
    private double getSearchRadius(double originalRadius) {
        if(this.worldObj.isRemote) {
            return originalRadius;
        } else {
            double configRadius = ((IMixinWorld)this.worldObj).getActiveConfig().getConfig().getWorld().getItemMergeRadius();
            return configRadius < 0.0D?0.0D:configRadius;
        }
    }
```

The configuration is probably the best place residing in world so that per world options can be set. It does do some rudimentary checking on the configuration option being set to less than `0` where basically little to no item merging can take place, unless items are dropped at the same exact place that two items reside in.

The configuration looks like so:
![config](http://puu.sh/pvOgb/86de38056a.png)

Just wanting to get some look over from @bloodmc and possibly others for feedback.