### PR TITLE
Make the difficulty cataloguetype ID not include the resource location. Fixes SpongeAPI-#1254

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/data/types/MixinEnumDifficulty.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/data/types/MixinEnumDifficulty.java
@@ -49,7 +49,7 @@ public class MixinEnumDifficulty implements Difficulty {
 
     @Inject(method = "<init>", at = @At(value = "RETURN"))
     public void onConstruction(CallbackInfo callbackInfo) {
-        this.id = this.difficultyResourceKey.replace("options.difficulty.", "");
+        this.id = this.difficultyResourceKey.replace("options.difficulty.", "minecraft:");
     }
     
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/data/types/MixinEnumDifficulty.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/data/types/MixinEnumDifficulty.java
@@ -31,6 +31,9 @@ import org.spongepowered.api.world.difficulty.Difficulty;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.common.text.translation.SpongeTranslation;
 
 @NonnullByDefault
@@ -39,17 +42,24 @@ public class MixinEnumDifficulty implements Difficulty {
 
     @Shadow @Final private int difficultyId;
     @Shadow @Final private String difficultyResourceKey;
+    
+    private String id;
 
     private Translation translation;
 
+    @Inject(method = "<init>", at = @At(value = "RETURN"))
+    public void onConstruction(CallbackInfo callbackInfo) {
+        this.id = this.difficultyResourceKey.replace("options.difficulty.", "");
+    }
+    
     @Override
     public String getId() {
-        return this.difficultyResourceKey;
+        return this.id;
     }
 
     @Override
     public String getName() {
-        return this.difficultyResourceKey.replace("options.difficulty.", "");
+        return this.id;
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/registry/type/world/DifficultyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/DifficultyRegistryModule.java
@@ -47,6 +47,10 @@ public final class DifficultyRegistryModule implements CatalogRegistryModule<Dif
 
     @Override
     public Optional<Difficulty> getById(String id) {
+        checkNotNull(id);
+        if (!id.contains(":") && !id.equals("none")) {
+            id = "minecraft:" + id; // assume vanilla
+        }
         return Optional.ofNullable(this.difficultyMappings.get(checkNotNull(id).toLowerCase(Locale.ENGLISH)));
     }
 
@@ -57,10 +61,10 @@ public final class DifficultyRegistryModule implements CatalogRegistryModule<Dif
 
     @Override
     public void registerDefaults() {
-        this.difficultyMappings.put("peaceful", (Difficulty) (Object) EnumDifficulty.PEACEFUL);
-        this.difficultyMappings.put("easy", (Difficulty) (Object) EnumDifficulty.EASY);
-        this.difficultyMappings.put("normal", (Difficulty) (Object) EnumDifficulty.NORMAL);
-        this.difficultyMappings.put("hard", (Difficulty) (Object) EnumDifficulty.HARD);
+        this.difficultyMappings.put("minecraft:peaceful", (Difficulty) (Object) EnumDifficulty.PEACEFUL);
+        this.difficultyMappings.put("minecraft:easy", (Difficulty) (Object) EnumDifficulty.EASY);
+        this.difficultyMappings.put("minecraft:normal", (Difficulty) (Object) EnumDifficulty.NORMAL);
+        this.difficultyMappings.put("minecraft:hard", (Difficulty) (Object) EnumDifficulty.HARD);
     }
 
     @AdditionalRegistration

--- a/src/main/java/org/spongepowered/common/registry/type/world/DifficultyRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/world/DifficultyRegistryModule.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.world.EnumDifficulty;
-import org.spongepowered.api.registry.CatalogRegistryModule;
+import org.spongepowered.api.registry.AlternateCatalogRegistryModule;
 import org.spongepowered.api.registry.util.AdditionalRegistration;
 import org.spongepowered.api.registry.util.RegisterCatalog;
 import org.spongepowered.api.world.difficulty.Difficulties;
@@ -40,7 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-public final class DifficultyRegistryModule implements CatalogRegistryModule<Difficulty> {
+public final class DifficultyRegistryModule implements AlternateCatalogRegistryModule<Difficulty> {
 
     @RegisterCatalog(Difficulties.class)
     private final Map<String, Difficulty> difficultyMappings = new HashMap<>();
@@ -57,6 +57,15 @@ public final class DifficultyRegistryModule implements CatalogRegistryModule<Dif
     @Override
     public Collection<Difficulty> getAll() {
         return ImmutableList.copyOf(this.difficultyMappings.values());
+    }
+
+    @Override
+    public Map<String, Difficulty> provideCatalogMap() {
+        Map<String, Difficulty> newMap = new HashMap<>();
+        for (Map.Entry<String, Difficulty> entry : this.difficultyMappings.entrySet()) {
+            newMap.put(entry.getKey().replace("minecraft:", ""), entry.getValue());
+        }
+        return newMap;
     }
 
     @Override


### PR DESCRIPTION
In reference to https://github.com/SpongePowered/SpongeAPI/issues/1254

This uses just the name for the ID of Difficulty, rather than the resource location. 

It makes more sense to use just the name, as it firstly fixes the issue above, and the ID should be something easily identifiable, which options.difficulty.etc isn't,

Edit:
This was tested by running 
> System.out.println(Sponge.getGame().getRegistry().getType(Difficulty.class, "easy"));
The output was 
> Optional[EASY]