### PR TITLE
Add message events for when server sends message to players

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandExecuteAtSender.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinCommandExecuteAtSender.java
@@ -56,7 +56,7 @@ public abstract class MixinCommandExecuteAtSender implements ProxySource, IMixin
 
     @Override
     public void sendMessage(Text message) {
-        getOriginalSource().sendMessages(message);
+        getOriginalSource().sendMessage(message);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -156,6 +156,7 @@ import org.spongepowered.common.interfaces.text.IMixinTitle;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 import org.spongepowered.common.text.SpongeTexts;
+import org.spongepowered.common.text.chat.ChatUtil;
 import org.spongepowered.common.text.chat.SpongeChatType;
 import org.spongepowered.common.util.BookFaker;
 import org.spongepowered.common.util.LocaleCache;
@@ -200,7 +201,6 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
     @Shadow public abstract void openGuiHorseInventory(AbstractHorse horse, IInventory horseInventory);
 
     // Inventory
-    @Shadow public abstract void sendMessage(ITextComponent component);
     @Shadow public abstract void closeScreen();
     @Shadow public int currentWindowId;
     @Shadow private void getNextWindowId() { }
@@ -414,6 +414,20 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
         }
 
         this.connection.sendPacket(new SPacketChat(component, ((SpongeChatType) type).getByteId()));
+    }
+
+    /**
+     * @author simon816 - 14th November, 2016
+     *
+     * @reason Redirect messages sent to the player to fire a message event. Once the
+     * event is handled, it will send the message to
+     * {@link #sendMessage(ChatType, Text)}.
+     *
+     * @param component The message
+     */
+    @Overwrite
+    public void sendMessage(ITextComponent component) {
+        ChatUtil.sendMessage(component, MessageChannel.fixed(this), (CommandSource) this.mcServer, true);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/server/MixinPlayerList.java
@@ -73,6 +73,7 @@ import net.minecraft.world.storage.WorldInfo;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.SpongeEventFactory;
@@ -119,7 +120,6 @@ import org.spongepowered.common.interfaces.entity.IMixinEntity;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayer;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayerMP;
 import org.spongepowered.common.interfaces.network.play.server.IMixinSPacketWorldBorder;
-import org.spongepowered.common.interfaces.world.IMixinWorldProvider;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 import org.spongepowered.common.mixin.core.entity.player.MixinEntityPlayer;
 import org.spongepowered.common.service.ban.SpongeIPBanList;
@@ -127,6 +127,7 @@ import org.spongepowered.common.service.ban.SpongeUserListBans;
 import org.spongepowered.common.service.permission.SpongePermissionService;
 import org.spongepowered.common.service.whitelist.SpongeUserListWhitelist;
 import org.spongepowered.common.text.SpongeTexts;
+import org.spongepowered.common.text.chat.ChatUtil;
 import org.spongepowered.common.util.VecHelper;
 import org.spongepowered.common.world.WorldManager;
 import org.spongepowered.common.world.storage.SpongePlayerDataHandler;
@@ -158,7 +159,6 @@ public abstract class MixinPlayerList implements IMixinPlayerList {
     @Shadow public abstract NBTTagCompound readPlayerDataFromFile(EntityPlayerMP playerIn);
     @Shadow public abstract MinecraftServer getServerInstance();
     @Shadow public abstract int getMaxPlayers();
-    @Shadow public abstract void sendMessage(ITextComponent component);
     @Shadow public abstract void sendPacketToAllPlayers(Packet<?> packetIn);
     @Shadow public abstract void preparePlayer(EntityPlayerMP playerIn, @Nullable WorldServer worldIn);
     @Shadow public abstract void playerLoggedIn(EntityPlayerMP playerIn);
@@ -876,4 +876,19 @@ public abstract class MixinPlayerList implements IMixinPlayerList {
         // Check the world info of the current world instead of overworld world info
         return player.world.getWorldInfo();
     }
+
+    /**
+     * @author simon816 - 14th November, 2016
+     *
+     * @reason Redirect chat broadcasts to fire an event for the message. Each receiver
+     * (typically a player) will handle the actual sending of the message.
+     *
+     * @param component The message
+     * @param isSystem Whether this is a system message
+     */
+    @Overwrite
+    public void sendMessage(ITextComponent component, boolean isSystem) {
+        ChatUtil.sendMessage(component, MessageChannel.TO_ALL, (CommandSource) this.mcServer, !isSystem);
+    }
+
 }

--- a/src/main/java/org/spongepowered/common/text/chat/ChatUtil.java
+++ b/src/main/java/org/spongepowered/common/text/chat/ChatUtil.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.text.chat;
+
+import net.minecraft.util.text.ITextComponent;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.message.MessageChannelEvent;
+import org.spongepowered.api.event.message.MessageEvent;
+import org.spongepowered.api.event.message.MessageEvent.MessageFormatter;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.chat.ChatTypes;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.text.SpongeTexts;
+
+import java.util.Optional;
+
+public final class ChatUtil {
+
+    private ChatUtil() {
+    }
+
+    public static void sendMessage(ITextComponent component, MessageChannel channel, CommandSource source, boolean isChat) {
+        Text raw = SpongeTexts.toText(component);
+        MessageFormatter formatter = new MessageEvent.MessageFormatter(raw);
+        Cause cause = Cause.source(source).build();
+        MessageChannelEvent event;
+        if (isChat) {
+            event = SpongeEventFactory.createMessageChannelEventChat(cause, channel, Optional.of(channel), formatter, raw, false);
+        } else {
+            event = SpongeEventFactory.createMessageChannelEvent(cause, channel, Optional.of(channel), formatter, false);
+        }
+        if (!SpongeImpl.postEvent(event) && !event.isMessageCancelled() && event.getChannel().isPresent()) {
+            event.getChannel().get().send(source, event.getMessage(), isChat ? ChatTypes.CHAT : ChatTypes.SYSTEM);
+        }
+    }
+
+}


### PR DESCRIPTION
When a call is made to send a message to a player, a `MessageChannelEvent` is fired with a fixed `MessageChannel`.
This allows customizing the output messages sent to players.
Closes SpongePowered/SpongeAPI#1292
