### PR TITLE
Implement GravityData

### DIFF
--- a/src/main/java/org/spongepowered/common/data/DataRegistrar.java
+++ b/src/main/java/org/spongepowered/common/data/DataRegistrar.java
@@ -392,6 +392,9 @@ public class DataRegistrar {
 
         dataManager.registerDualProcessor(GlowingData.class, SpongeGlowingData.class, ImmutableGlowingData.class, ImmutableSpongeGlowingData.class,
                 new GlowingDataProcessor());
+        
+        dataManager.registerDualProcessor(GravityData.class, SpongeGravityData.class, ImmutableGravityData.class, ImmutableSpongeGravityData.class,
+                new GravityDataProcessor());
 
         dataManager.registerDualProcessor(PickupRuleData.class, SpongePickupRuleData.class, ImmutablePickupRuleData.class,
                 ImmutableSpongePickupRuleData.class, new PickupRuleDataProcessor());
@@ -727,7 +730,6 @@ public class DataRegistrar {
         dataManager.registerValueProcessor(Keys.BEACON_PRIMARY_EFFECT, new BeaconPrimaryEffectValueProcessor());
         dataManager.registerValueProcessor(Keys.BEACON_SECONDARY_EFFECT, new BeaconSecondaryEffectValueProcessor());
         dataManager.registerValueProcessor(Keys.ARMOR_STAND_HAS_BASE_PLATE, new ArmorStandBasePlateValueProcessor());
-        dataManager.registerValueProcessor(Keys.ARMOR_STAND_HAS_GRAVITY, new ArmorStandGravityValueProcessor());
         dataManager.registerValueProcessor(Keys.ARMOR_STAND_MARKER, new ArmorStandMarkerValueProcessor());
         dataManager.registerValueProcessor(Keys.ARMOR_STAND_IS_SMALL, new ArmorStandSmallValueProcessor());
         dataManager.registerValueProcessor(Keys.ARMOR_STAND_HAS_ARMS, new ArmorStandArmsValueProcessor());

--- a/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
+++ b/src/main/java/org/spongepowered/common/data/key/KeyRegistry.java
@@ -317,12 +317,12 @@ public class KeyRegistry {
         keyMap.put("explosion_radius", makeSingleKey(Integer.class, Value.class, of("ExplosionRadius")));
         keyMap.put("armor_stand_has_arms", makeSingleKey(Boolean.class, Value.class, of("HasArms")));
         keyMap.put("armor_stand_has_base_plate", makeSingleKey(Boolean.class, Value.class, of("HasBasePlate")));
-        keyMap.put("armor_stand_has_gravity", makeSingleKey(Boolean.class, Value.class, of("HasGravity")));
         keyMap.put("armor_stand_marker", makeSingleKey(Boolean.class, Value.class, of("IsMarker")));
         keyMap.put("armor_stand_is_small", makeSingleKey(Boolean.class, Value.class, of("IsSmall")));
         keyMap.put("invulnerability_ticks", makeSingleKey(Integer.class, MutableBoundedValue.class, of("HurtTime")));
         keyMap.put("glowing", makeSingleKey(Boolean.class, Value.class, of("Glowing")));
         keyMap.put("pickup_rule", makeSingleKey(PickupRule.class, Value.class, of("PickupRule")));
+        keyMap.put("has_gravity", makeSingleKey(Boolean.class, Value.class, of("HasGravity")));
     }
 
     @SuppressWarnings("unused") // Used in DataTestUtil.generateKeyMap

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeArmorStandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeArmorStandData.java
@@ -38,29 +38,25 @@ public class ImmutableSpongeArmorStandData extends AbstractImmutableData<Immutab
 
     private final boolean marker;
     private final boolean small;
-    private final boolean gravity;
     private final boolean arms;
     private final boolean basePlate;
     private final ImmutableValue<Boolean> markerValue;
     private final ImmutableValue<Boolean> smallValue;
-    private final ImmutableValue<Boolean> gravityValue;
     private final ImmutableValue<Boolean> armsValue;
     private final ImmutableValue<Boolean> basePlateValue;
 
     public ImmutableSpongeArmorStandData() {
-        this(false, false, true, false, true);
+        this(false, false, false, true);
     }
 
-    public ImmutableSpongeArmorStandData(boolean marker, boolean small, boolean gravity, boolean arms, boolean basePlate) {
+    public ImmutableSpongeArmorStandData(boolean marker, boolean small, boolean arms, boolean basePlate) {
         super(ImmutableArmorStandData.class);
         this.marker = marker;
         this.small = small;
-        this.gravity = gravity;
         this.arms = arms;
         this.basePlate = basePlate;
         this.markerValue = ImmutableSpongeValue.cachedOf(Keys.ARMOR_STAND_MARKER, false, this.marker);
         this.smallValue = ImmutableSpongeValue.cachedOf(Keys.ARMOR_STAND_IS_SMALL, false, this.small);
-        this.gravityValue = ImmutableSpongeValue.cachedOf(Keys.ARMOR_STAND_HAS_GRAVITY, true, this.gravity);
         this.armsValue = ImmutableSpongeValue.cachedOf(Keys.ARMOR_STAND_HAS_ARMS, false, this.arms);
         this.basePlateValue = ImmutableSpongeValue.cachedOf(Keys.ARMOR_STAND_HAS_BASE_PLATE, true, this.basePlate);
         registerGetters();
@@ -76,9 +72,6 @@ public class ImmutableSpongeArmorStandData extends AbstractImmutableData<Immutab
 
         registerFieldGetter(Keys.ARMOR_STAND_HAS_BASE_PLATE, () -> this.basePlate);
         registerKeyValue(Keys.ARMOR_STAND_HAS_BASE_PLATE, () -> this.basePlateValue);
-
-        registerFieldGetter(Keys.ARMOR_STAND_HAS_GRAVITY, () -> this.gravity);
-        registerKeyValue(Keys.ARMOR_STAND_HAS_GRAVITY, () -> this.gravityValue);
 
         registerFieldGetter(Keys.ARMOR_STAND_MARKER, () -> this.marker);
         registerKeyValue(Keys.ARMOR_STAND_MARKER, () -> this.markerValue);
@@ -96,11 +89,6 @@ public class ImmutableSpongeArmorStandData extends AbstractImmutableData<Immutab
     }
 
     @Override
-    public ImmutableValue<Boolean> gravity() {
-        return this.gravityValue;
-    }
-
-    @Override
     public ImmutableValue<Boolean> arms() {
         return this.armsValue;
     }
@@ -112,7 +100,7 @@ public class ImmutableSpongeArmorStandData extends AbstractImmutableData<Immutab
 
     @Override
     public ArmorStandData asMutable() {
-        return new SpongeArmorStandData(this.marker, this.small, this.gravity, this.arms, this.basePlate);
+        return new SpongeArmorStandData(this.marker, this.small, this.arms, this.basePlate);
     }
 
     @Override
@@ -121,7 +109,6 @@ public class ImmutableSpongeArmorStandData extends AbstractImmutableData<Immutab
                 .compare(o.arms().get(), this.arms)
                 .compare(o.marker().get(), this.marker)
                 .compare(o.basePlate().get(), this.basePlate)
-                .compare(o.gravity().get(), this.gravity)
                 .compare(o.small().get(), this.small)
                 .result();
     }
@@ -131,7 +118,6 @@ public class ImmutableSpongeArmorStandData extends AbstractImmutableData<Immutab
         return super.toContainer()
                 .set(Keys.ARMOR_STAND_HAS_ARMS, this.arms)
                 .set(Keys.ARMOR_STAND_HAS_BASE_PLATE, this.basePlate)
-                .set(Keys.ARMOR_STAND_HAS_GRAVITY, this.gravity)
                 .set(Keys.ARMOR_STAND_IS_SMALL, this.small)
                 .set(Keys.ARMOR_STAND_MARKER, this.marker);
     }

--- a/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeGravityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/immutable/entity/ImmutableSpongeGravityData.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.immutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableGravityData;
+import org.spongepowered.api.data.manipulator.mutable.entity.GravityData;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.common.data.manipulator.immutable.common.AbstractImmutableBooleanData;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeGravityData;
+import org.spongepowered.common.data.util.DataConstants;
+
+public class ImmutableSpongeGravityData extends AbstractImmutableBooleanData<ImmutableGravityData, GravityData> implements ImmutableGravityData {
+
+    public ImmutableSpongeGravityData(boolean value) {
+        super(ImmutableGravityData.class, value, Keys.HAS_GRAVITY, SpongeGravityData.class, DataConstants.DEFAULT_HAS_GRAVITY);
+    }
+
+    @Override
+    public ImmutableValue<Boolean> gravity() {
+        return getValueGetter();
+    }
+
+}

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeArmorStandData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeArmorStandData.java
@@ -39,19 +39,17 @@ public class SpongeArmorStandData extends AbstractData<ArmorStandData, Immutable
 
     private boolean marker;
     private boolean small;
-    private boolean gravity;
     private boolean arms;
     private boolean basePlate;
 
     public SpongeArmorStandData() {
-        this(false, false, true, false, true);
+        this(false, false, false, true);
     }
 
-    public SpongeArmorStandData(boolean marker, boolean small, boolean gravity, boolean arms, boolean basePlate) {
+    public SpongeArmorStandData(boolean marker, boolean small, boolean arms, boolean basePlate) {
         super(ArmorStandData.class);
         this.marker = marker;
         this.small = small;
-        this.gravity = gravity;
         this.arms = arms;
         this.basePlate = basePlate;
         registerGettersAndSetters();
@@ -72,10 +70,6 @@ public class SpongeArmorStandData extends AbstractData<ArmorStandData, Immutable
         registerFieldSetter(Keys.ARMOR_STAND_HAS_BASE_PLATE, (basePlate) -> this.basePlate = basePlate);
         registerKeyValue(Keys.ARMOR_STAND_HAS_BASE_PLATE, this::basePlate);
 
-        registerFieldGetter(Keys.ARMOR_STAND_HAS_GRAVITY, () -> this.gravity);
-        registerFieldSetter(Keys.ARMOR_STAND_HAS_GRAVITY, (gravity) -> this.gravity = gravity);
-        registerKeyValue(Keys.ARMOR_STAND_HAS_GRAVITY, this::gravity);
-
         registerFieldGetter(Keys.ARMOR_STAND_MARKER, () -> this.marker);
         registerFieldSetter(Keys.ARMOR_STAND_MARKER, (marker) -> this.marker = marker);
         registerKeyValue(Keys.ARMOR_STAND_MARKER, this::marker);
@@ -92,11 +86,6 @@ public class SpongeArmorStandData extends AbstractData<ArmorStandData, Immutable
     }
 
     @Override
-    public Value<Boolean> gravity() {
-        return new SpongeValue<>(Keys.ARMOR_STAND_HAS_GRAVITY, true, this.gravity);
-    }
-
-    @Override
     public Value<Boolean> arms() {
         return new SpongeValue<>(Keys.ARMOR_STAND_HAS_ARMS, false, this.arms);
     }
@@ -109,12 +98,12 @@ public class SpongeArmorStandData extends AbstractData<ArmorStandData, Immutable
 
     @Override
     public ArmorStandData copy() {
-        return new SpongeArmorStandData(this.marker, this.small, this.gravity, this.arms, this.basePlate);
+        return new SpongeArmorStandData(this.marker, this.small, this.arms, this.basePlate);
     }
 
     @Override
     public ImmutableArmorStandData asImmutable() {
-        return ImmutableDataCachingUtil.getManipulator(ImmutableSpongeArmorStandData.class, this.marker, this.small, this.gravity, this.arms, this.basePlate);
+        return ImmutableDataCachingUtil.getManipulator(ImmutableSpongeArmorStandData.class, this.marker, this.small, this.arms, this.basePlate);
     }
 
     @Override
@@ -123,7 +112,6 @@ public class SpongeArmorStandData extends AbstractData<ArmorStandData, Immutable
                 .compare(o.arms().get(), this.arms)
                 .compare(o.marker().get(), this.marker)
                 .compare(o.basePlate().get(), this.basePlate)
-                .compare(o.gravity().get(), this.gravity)
                 .compare(o.small().get(), this.small)
                 .result();
     }
@@ -133,7 +121,6 @@ public class SpongeArmorStandData extends AbstractData<ArmorStandData, Immutable
         return super.toContainer()
                 .set(Keys.ARMOR_STAND_HAS_ARMS, this.arms)
                 .set(Keys.ARMOR_STAND_HAS_BASE_PLATE, this.basePlate)
-                .set(Keys.ARMOR_STAND_HAS_GRAVITY, this.gravity)
                 .set(Keys.ARMOR_STAND_IS_SMALL, this.small)
                 .set(Keys.ARMOR_STAND_MARKER, this.marker);
     }

--- a/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeGravityData.java
+++ b/src/main/java/org/spongepowered/common/data/manipulator/mutable/entity/SpongeGravityData.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.manipulator.mutable.entity;
+
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableGravityData;
+import org.spongepowered.api.data.manipulator.mutable.entity.GravityData;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.common.data.manipulator.immutable.entity.ImmutableSpongeGravityData;
+import org.spongepowered.common.data.manipulator.mutable.common.AbstractBooleanData;
+import org.spongepowered.common.data.util.DataConstants;
+
+public class SpongeGravityData extends AbstractBooleanData<GravityData, ImmutableGravityData> implements GravityData {
+
+    public SpongeGravityData(boolean value) {
+        super(GravityData.class, value, Keys.HAS_GRAVITY, ImmutableSpongeGravityData.class, DataConstants.DEFAULT_HAS_GRAVITY);
+    }
+
+    public SpongeGravityData() {
+        this(DataConstants.DEFAULT_HAS_GRAVITY);
+    }
+
+    @Override
+    public Value<Boolean> gravity() {
+        return getValueGetter();
+    }
+}
+

--- a/src/main/java/org/spongepowered/common/data/processor/data/entity/GravityDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/data/entity/GravityDataProcessor.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.data.processor.data.entity;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.immutable.entity.ImmutableGravityData;
+import org.spongepowered.api.data.manipulator.mutable.entity.GravityData;
+import org.spongepowered.api.data.value.ValueContainer;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.util.OptBool;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeGravityData;
+import org.spongepowered.common.data.processor.common.AbstractEntitySingleDataProcessor;
+import org.spongepowered.common.data.util.DataConstants;
+import org.spongepowered.common.data.value.immutable.ImmutableSpongeValue;
+import org.spongepowered.common.data.value.mutable.SpongeValue;
+
+import java.util.Optional;
+
+public class GravityDataProcessor extends AbstractEntitySingleDataProcessor<Entity, Boolean, Value<Boolean>, GravityData, ImmutableGravityData> {
+
+    public GravityDataProcessor() {
+        super(Entity.class, Keys.HAS_GRAVITY);
+    }
+
+    @Override
+    protected Value<Boolean> constructValue(Boolean actualValue) {
+        return new SpongeValue<>(this.key, DataConstants.DEFAULT_HAS_GRAVITY, actualValue);
+    }
+
+    @Override
+    protected GravityData createManipulator() {
+        return new SpongeGravityData();
+    }
+
+    @Override
+    protected boolean set(Entity entity, Boolean value) {
+        entity.setNoGravity(!value);
+        return true;
+    }
+
+    @Override
+    protected Optional<Boolean> getVal(Entity entity) {
+        return OptBool.of(!entity.hasNoGravity());
+    }
+
+    @Override
+    protected ImmutableValue<Boolean> constructImmutableValue(Boolean value) {
+        return ImmutableSpongeValue.cachedOf(this.key, DataConstants.DEFAULT_HAS_GRAVITY, value);
+    }
+
+    @Override
+    public DataTransactionResult removeFrom(ValueContainer<?> container) {
+        return DataTransactionResult.failNoData();
+    }
+}

--- a/src/main/java/org/spongepowered/common/data/processor/multi/entity/ArmorStandDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/entity/ArmorStandDataProcessor.java
@@ -54,13 +54,11 @@ public class ArmorStandDataProcessor extends AbstractEntityDataProcessor<EntityA
     protected boolean set(EntityArmorStand dataHolder, Map<Key<?>, Object> keyValues) {
         final boolean hasArms = (boolean) keyValues.get(Keys.ARMOR_STAND_HAS_ARMS);
         final boolean hasBasePlate = (boolean) keyValues.get(Keys.ARMOR_STAND_HAS_BASE_PLATE);
-        final boolean hasGravity = (boolean) keyValues.get(Keys.ARMOR_STAND_HAS_GRAVITY);
         final boolean isSmall = (boolean) keyValues.get(Keys.ARMOR_STAND_IS_SMALL);
         final boolean isMarker = (boolean) keyValues.get(Keys.ARMOR_STAND_MARKER);
         dataHolder.setSmall(isSmall);
         dataHolder.setMarker(isMarker);
         dataHolder.setNoBasePlate(!hasBasePlate);
-        dataHolder.setNoGravity(!hasGravity);
         dataHolder.setShowArms(hasArms);
         return true;
     }
@@ -70,7 +68,6 @@ public class ArmorStandDataProcessor extends AbstractEntityDataProcessor<EntityA
         return ImmutableMap.<Key<?>, Object>builder()
                 .put(Keys.ARMOR_STAND_HAS_ARMS, dataHolder.getShowArms())
                 .put(Keys.ARMOR_STAND_HAS_BASE_PLATE, !dataHolder.hasNoBasePlate())
-                .put(Keys.ARMOR_STAND_HAS_GRAVITY, !dataHolder.hasNoGravity())
                 .put(Keys.ARMOR_STAND_MARKER, dataHolder.hasMarker())
                 .put(Keys.ARMOR_STAND_IS_SMALL, dataHolder.isSmall())
                 .build();
@@ -88,9 +85,6 @@ public class ArmorStandDataProcessor extends AbstractEntityDataProcessor<EntityA
         }
         if (container.contains(Keys.ARMOR_STAND_MARKER)) {
             armorStandData.set(Keys.ARMOR_STAND_MARKER, container.getBoolean(Keys.ARMOR_STAND_MARKER.getQuery()).get());
-        }
-        if (container.contains(Keys.ARMOR_STAND_HAS_GRAVITY)) {
-            armorStandData.set(Keys.ARMOR_STAND_HAS_GRAVITY, container.getBoolean(Keys.ARMOR_STAND_HAS_GRAVITY.getQuery()).get());
         }
         if (container.contains(Keys.ARMOR_STAND_HAS_BASE_PLATE)) {
             armorStandData.set(Keys.ARMOR_STAND_HAS_BASE_PLATE, container.getBoolean(Keys.ARMOR_STAND_HAS_BASE_PLATE.getQuery()).get());

--- a/src/main/java/org/spongepowered/common/data/util/DataConstants.java
+++ b/src/main/java/org/spongepowered/common/data/util/DataConstants.java
@@ -99,6 +99,7 @@ public final class DataConstants {
     public static final boolean IS_WET_DEFAULT = false;
     public static final boolean DEFAULT_ATTACHED = false;
     public static final boolean DEFAULT_GLOWING = false;
+    public static final boolean DEFAULT_HAS_GRAVITY = true;
 
     public static final int DEFAULT_FIRE_TICKS = 10;
     public static final int MINIMUM_FIRE_TICKS = 1;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -68,6 +68,7 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.IgniteableData;
 import org.spongepowered.api.data.manipulator.mutable.entity.VehicleData;
 import org.spongepowered.api.data.persistence.InvalidDataException;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityArchetype;
 import org.spongepowered.api.entity.EntitySnapshot;
@@ -101,6 +102,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeGravityData;
 import org.spongepowered.common.data.persistence.NbtTranslator;
 import org.spongepowered.common.data.util.DataQueries;
 import org.spongepowered.common.data.util.DataUtil;
@@ -370,6 +372,7 @@ public abstract class MixinEntity implements IMixinEntity {
         if (this.fire > 0) {
             manipulators.add(get(IgniteableData.class).get());
         }
+        manipulators.add(new SpongeGravityData(!this.hasNoGravity()));
     }
 
     @Override
@@ -1260,4 +1263,8 @@ public abstract class MixinEntity implements IMixinEntity {
         return new SpongeEntityArchetypeBuilder().from(this).build();
     }
 
+    @Override
+    public Value<Boolean> gravity() {
+        return this.getValue(Keys.HAS_GRAVITY).get();
+    }
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityArmorStand.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityArmorStand.java
@@ -138,13 +138,8 @@ public abstract class MixinEntityArmorStand extends MixinEntityLivingBase implem
     }
 
     @Override
-    public Value<Boolean> gravity() {
-        return new SpongeValue<>(Keys.ARMOR_STAND_HAS_GRAVITY, true, !this.hasNoGravity());
-    }
-
-    @Override
     public ArmorStandData getArmorStandData() {
-        return new SpongeArmorStandData(this.hasMarker(), this.shadow$isSmall(), !this.hasNoGravity(), this.getShowArms(), !this.hasNoBasePlate());
+        return new SpongeArmorStandData(this.hasMarker(), this.shadow$isSmall(), this.getShowArms(), !this.hasNoBasePlate());
     }
 
     @Override


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1301) | [**Common**](https://github.com/SpongePowered/SpongeCommon/pull/828)

Implements`GravityData` and removes gravity from `ArmorStandData`. This is due to a change in Minecraft  1.10 that allows all entities, not just armor stands, to be affected by the `NoGravity` tag.