### PR TITLE
[WIP] Implement of Refactoring Block Change API

### DIFF
--- a/src/main/java/org/spongepowered/common/block/BlockUtil.java
+++ b/src/main/java/org/spongepowered/common/block/BlockUtil.java
@@ -48,24 +48,23 @@ public final class BlockUtil {
     public static final Comparator<BlockState> BLOCK_STATE_COMPARATOR = new BlockStateComparator();
     public static final UUID INVALID_WORLD_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
-    public static void setBlockState(World world, int x, int y, int z, BlockState state, boolean notifyNeighbors) {
-        setBlockState(world, new BlockPos(x, y, z), state, notifyNeighbors);
+    public static boolean setBlockState(World world, int x, int y, int z, BlockState state, boolean notifyNeighbors) {
+        return setBlockState(world, new BlockPos(x, y, z), state, notifyNeighbors);
     }
 
-    public static void setBlockState(World world, BlockPos position, BlockState state, boolean notifyNeighbors) {
-        world.setBlockState(position, toNative(state), notifyNeighbors ? 3 : 2);
+    public static boolean setBlockState(World world, BlockPos position, BlockState state, boolean notifyNeighbors) {
+        return world.setBlockState(position, toNative(state), notifyNeighbors ? 3 : 2);
     }
 
-    public static void setBlockState(Chunk chunk, int x, int y, int z, BlockState state, boolean notifyNeighbors) {
-        setBlockState(chunk, new BlockPos(x, y, z), state, notifyNeighbors);
+    public static boolean setBlockState(Chunk chunk, int x, int y, int z, BlockState state, boolean notifyNeighbors) {
+        return setBlockState(chunk, new BlockPos(x, y, z), state, notifyNeighbors);
     }
 
-    public static void setBlockState(Chunk chunk, BlockPos position, BlockState state, boolean notifyNeighbors) {
+    public static boolean setBlockState(Chunk chunk, BlockPos position, BlockState state, boolean notifyNeighbors) {
         if (notifyNeighbors) { // delegate to world
-            setBlockState(chunk.getWorld(), position, state, true);
-            return;
+            return setBlockState(chunk.getWorld(), position, state, true);
         }
-        chunk.setBlockState(position, toNative(state));
+        return chunk.setBlockState(position, toNative(state)) != null;
     }
 
     public static IBlockState toNative(BlockState state) {

--- a/src/main/java/org/spongepowered/common/data/builder/block/tileentity/AbstractTileBuilder.java
+++ b/src/main/java/org/spongepowered/common/data/builder/block/tileentity/AbstractTileBuilder.java
@@ -57,8 +57,10 @@ import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.Queries;
 import org.spongepowered.api.data.persistence.DataBuilder;
 import org.spongepowered.api.data.persistence.InvalidDataException;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.data.persistence.AbstractDataBuilder;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.util.DataQueries;
 
 import java.util.Map;
@@ -107,7 +109,7 @@ public abstract class AbstractTileBuilder<T extends org.spongepowered.api.block.
         final int y = container.getInt(DataQueries.Y_POS).get();
         final int z = container.getInt(DataQueries.Z_POS).get();
 
-        worldOptional.get().getLocation(x, y, z).setBlockType(type);
+        worldOptional.get().getLocation(x, y, z).setBlockType(type, Cause.source(SpongeImpl.getPlugin()).build());
         BlockPos pos = new BlockPos(x, y, z);
         TileEntity tileEntity = ((net.minecraft.world.World) worldOptional.get()).getTileEntity(pos);
         if (tileEntity == null) {

--- a/src/main/java/org/spongepowered/common/data/processor/multi/tileentity/FurnaceDataProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/multi/tileentity/FurnaceDataProcessor.java
@@ -34,7 +34,9 @@ import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.immutable.tileentity.ImmutableFurnaceData;
 import org.spongepowered.api.data.manipulator.mutable.tileentity.FurnaceData;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.manipulator.mutable.tileentity.SpongeFurnaceData;
 import org.spongepowered.common.data.processor.common.AbstractTileEntityDataProcessor;
 
@@ -47,6 +49,8 @@ public class FurnaceDataProcessor extends AbstractTileEntityDataProcessor<TileEn
     public FurnaceDataProcessor() {
         super(TileEntityFurnace.class);
     }
+
+    private final Cause cause = Cause.source(SpongeImpl.getPlugin()).build();
 
     @Override
     protected boolean doesDataExist(TileEntityFurnace tileEntity) {
@@ -76,7 +80,7 @@ public class FurnaceDataProcessor extends AbstractTileEntityDataProcessor<TileEn
         if (needsUpdate) {
             final World world = (World) tileEntity.getWorld();
             world.setBlockType(tileEntity.getPos().getX(), tileEntity.getPos().getY(),
-                    tileEntity.getPos().getZ(), maxBurnTime > 0 ? BlockTypes.LIT_FURNACE : BlockTypes.FURNACE);
+                    tileEntity.getPos().getZ(), maxBurnTime > 0 ? BlockTypes.LIT_FURNACE : BlockTypes.FURNACE, this.cause);
             tileEntity = (TileEntityFurnace) tileEntity.getWorld().getTileEntity(tileEntity.getPos());
         }
 

--- a/src/main/java/org/spongepowered/common/data/processor/value/tileentity/MaxBurnTimeValueProcessor.java
+++ b/src/main/java/org/spongepowered/common/data/processor/value/tileentity/MaxBurnTimeValueProcessor.java
@@ -31,13 +31,17 @@ import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.ValueContainer;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.data.processor.common.AbstractSpongeValueProcessor;
 import org.spongepowered.common.data.value.SpongeValueFactory;
 
 import java.util.Optional;
 
 public class MaxBurnTimeValueProcessor extends AbstractSpongeValueProcessor<TileEntityFurnace, Integer, MutableBoundedValue<Integer>> {
+
+    private final Cause cause = Cause.source(SpongeImpl.getPlugin()).build();
 
     public MaxBurnTimeValueProcessor() {
         super(TileEntityFurnace.class, Keys.MAX_BURN_TIME);
@@ -57,7 +61,7 @@ public class MaxBurnTimeValueProcessor extends AbstractSpongeValueProcessor<Tile
         if (!container.isBurning() && value > 0 || container.isBurning() && value == 0) {
             final World world = (World) container.getWorld();
             world.setBlockType(container.getPos().getX(), container.getPos().getY(),
-                    container.getPos().getZ(), value > 0 ? BlockTypes.LIT_FURNACE : BlockTypes.FURNACE);
+                    container.getPos().getZ(), value > 0 ? BlockTypes.LIT_FURNACE : BlockTypes.FURNACE, this.cause);
             container = (TileEntityFurnace) container.getWorld().getTileEntity(container.getPos());
         }
         container.setField(1, value);

--- a/src/main/java/org/spongepowered/common/event/InternalNamedCauses.java
+++ b/src/main/java/org/spongepowered/common/event/InternalNamedCauses.java
@@ -88,6 +88,7 @@ public final class InternalNamedCauses {
         public static final String BLOCK_BREAK_FORTUNE = "BreakingBlockFortune";
         public static final String BLOCK_BREAK_POSITION = "BreakingBlockPosition";
         public static final String PLUGIN_CAUSE = "PluginCause";
+        public static final String BLOCK_CHANGE = "BlockChangeFlag";
 
         private General() {
         }

--- a/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/TrackingUtil.java
@@ -239,11 +239,11 @@ public final class TrackingUtil {
             PhaseContext phaseContext, IPhaseState phaseState) {
         final WorldServer minecraftWorld = causeTracker.getMinecraftWorld();
         final IBlockState actualState = currentState.getActualState(minecraftWorld, pos);
-        final BlockSnapshot originalBlockSnapshot = causeTracker.getMixinWorld().createSpongeBlockSnapshot(currentState, actualState, pos, flags);
+        final SpongeBlockSnapshot originalBlockSnapshot = causeTracker.getMixinWorld().createSpongeBlockSnapshot(currentState, actualState, pos, flags);
         final List<BlockSnapshot> capturedSnapshots = phaseContext.getCapturedBlocks();
         final Block newBlock = newState.getBlock();
 
-        associateBlockChangeWithSnapshot(phaseState, newBlock, currentState, (SpongeBlockSnapshot) originalBlockSnapshot, capturedSnapshots);
+        associateBlockChangeWithSnapshot(phaseState, newBlock, currentState, originalBlockSnapshot, capturedSnapshots);
         final IMixinChunk mixinChunk = (IMixinChunk) chunk;
         final IBlockState originalBlockState = mixinChunk.setBlockState(pos, newState, currentState, originalBlockSnapshot);
         if (originalBlockState == null) {

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/BlockPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/BlockPhase.java
@@ -103,4 +103,9 @@ public final class BlockPhase extends TrackingPhase {
 
     }
 
+
+    @Override
+    public boolean isRestoring(IPhaseState state, PhaseContext phaseContext, int updateFlag) {
+        return state == State.RESTORING_BLOCKS && (updateFlag & 1) == 0;
+    }
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/GeneralPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/GeneralPhase.java
@@ -46,6 +46,7 @@ import org.spongepowered.api.event.cause.entity.spawn.SpawnCause;
 import org.spongepowered.api.event.entity.SpawnEntityEvent;
 import org.spongepowered.api.event.item.inventory.DropItemEvent;
 import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
@@ -330,7 +331,7 @@ public final class GeneralPhase extends TrackingPhase {
             // NOW we restore the invalid transactions (remember invalid transactions are from either plugins marking them as invalid
             // or the events were cancelled), again in reverse order of which they were received.
             for (Transaction<BlockSnapshot> transaction : Lists.reverse(invalidTransactions)) {
-                transaction.getOriginal().restore(true, false);
+                transaction.getOriginal().restore(true, BlockChangeFlag.NONE);
                 if (unwindingState.tracksBlockSpecificDrops()) {
                     // Cancel any block drops or harvests for the block change.
                     // This prevents unnecessary spawns.
@@ -361,7 +362,7 @@ public final class GeneralPhase extends TrackingPhase {
             }
             // Handle custom replacements
             if (transaction.getCustom().isPresent()) {
-                transaction.getFinal().restore(true, false);
+                transaction.getFinal().restore(true, BlockChangeFlag.ALL);
             }
 
             final SpongeBlockSnapshot oldBlockSnapshot = (SpongeBlockSnapshot) transaction.getOriginal();

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/TrackingPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/TrackingPhase.java
@@ -223,6 +223,11 @@ public abstract class TrackingPhase {
 
     }
 
+
+    public boolean isRestoring(IPhaseState state, PhaseContext context, int updateFlag) {
+        return false;
+    }
+
     public void capturePlayerUsingStackToBreakBlock(@Nullable ItemStack itemStack, EntityPlayerMP playerMP, IPhaseState state, PhaseContext context,
             CauseTracker causeTracker) {
 

--- a/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
+++ b/src/main/java/org/spongepowered/common/extra/fluid/SpongeFluidStack.java
@@ -39,6 +39,7 @@ import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.persistence.InvalidDataException;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.extra.fluid.FluidStack;
 import org.spongepowered.api.extra.fluid.FluidStackSnapshot;
 import org.spongepowered.api.extra.fluid.FluidType;
@@ -134,7 +135,17 @@ public class SpongeFluidStack implements FluidStack {
     }
 
     @Override
+    public <E> DataTransactionResult offer(Key<? extends BaseValue<E>> key, E value, Cause cause) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
     public DataTransactionResult offer(DataManipulator<?, ?> valueContainer, MergeFunction function) {
+        return DataTransactionResult.failNoData();
+    }
+
+    @Override
+    public DataTransactionResult offer(DataManipulator<?, ?> valueContainer, MergeFunction function, Cause cause) {
         return DataTransactionResult.failNoData();
     }
 

--- a/src/main/java/org/spongepowered/common/interfaces/IMixinChunk.java
+++ b/src/main/java/org/spongepowered/common/interfaces/IMixinChunk.java
@@ -31,12 +31,15 @@ import org.spongepowered.api.block.BlockSnapshot;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.Direction;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Chunk;
 import org.spongepowered.common.entity.PlayerTracker;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+
+import javax.annotation.Nullable;
 
 public interface IMixinChunk {
 
@@ -48,7 +51,11 @@ public interface IMixinChunk {
 
     Optional<User> getBlockNotifier(BlockPos pos);
 
-    IBlockState setBlockState(BlockPos pos, IBlockState newState, IBlockState currentState, BlockSnapshot originalBlockSnapshot);
+    @Nullable
+    IBlockState setBlockState(BlockPos pos, IBlockState newState, IBlockState currentState, @Nullable BlockSnapshot originalBlockSnapshot);
+
+    @Nullable
+    IBlockState setBlockState(BlockPos pos, IBlockState newState, IBlockState currentState, @Nullable BlockSnapshot originalBlockSnapshot, BlockChangeFlag flag);
 
     void setBlockNotifier(BlockPos pos, UUID uuid);
 

--- a/src/main/java/org/spongepowered/common/interfaces/world/IMixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/world/IMixinWorldServer.java
@@ -31,6 +31,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.chunk.Chunk;
 import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.common.block.SpongeBlockSnapshot;
 import org.spongepowered.common.config.SpongeConfig;
 import org.spongepowered.common.config.type.WorldConfig;
@@ -58,6 +59,8 @@ public interface IMixinWorldServer extends IMixinWorld {
     void updateRotation(Entity entityIn);
 
     void markAndNotifyNeighbors(BlockPos pos, @Nullable Chunk chunk, IBlockState oldState, IBlockState newState, int flags);
+
+    boolean setBlockState(BlockPos pos, IBlockState state, BlockChangeFlag flag);
 
     boolean forceSpawnEntity(org.spongepowered.api.entity.Entity entity);
 

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/effect/MixinEntityLightningBolt.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/effect/MixinEntityLightningBolt.java
@@ -39,7 +39,6 @@ import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.mutable.entity.ExpirableData;
 import org.spongepowered.api.data.value.mutable.MutableBoundedValue;
 import org.spongepowered.api.entity.Entity;
-import org.spongepowered.api.entity.EntitySnapshot;
 import org.spongepowered.api.entity.weather.Lightning;
 import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.action.LightningEvent;
@@ -55,7 +54,6 @@ import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.block.SpongeBlockSnapshotBuilder;
 import org.spongepowered.common.data.manipulator.mutable.entity.SpongeExpirableData;
 import org.spongepowered.common.data.value.SpongeValueFactory;
-import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 import org.spongepowered.common.interfaces.entity.IMixinEntityLightningBolt;
 import org.spongepowered.common.util.VecHelper;
 
@@ -137,7 +135,7 @@ public abstract class MixinEntityLightningBolt extends MixinEntityWeatherEffect 
             for (Transaction<BlockSnapshot> bt : strike.getTransactions()) {
                 if (bt.isValid()) {
                     BlockSnapshot bs = bt.getFinal();
-                    world.setBlock(bs.getPosition(), bs.getState());
+                    world.setBlock(bs.getPosition(), bs.getState(), cause);
                 }
             }
             for (Entity e : strike.getEntities()) {

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityTNTPrimed.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/item/MixinEntityTNTPrimed.java
@@ -39,6 +39,7 @@ import org.spongepowered.api.entity.explosive.PrimedTNT;
 import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.explosion.Explosion;
@@ -101,7 +102,7 @@ public abstract class MixinEntityTNTPrimed extends MixinEntity implements Primed
         setDead();
         // Place a TNT block at the Entity's position
         getWorld().setBlock((int) this.posX, (int) this.posY, (int) this.posZ,
-                BlockState.builder().blockType(BLOCK_TYPE).build(), true);
+                BlockState.builder().blockType(BLOCK_TYPE).build(), BlockChangeFlag.ALL, Cause.source(this).build());
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorld.java
@@ -57,7 +57,6 @@ import net.minecraft.util.ReportedException;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.GameRules;
@@ -100,6 +99,7 @@ import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.Functional;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.Dimension;
 import org.spongepowered.api.world.Location;
@@ -143,7 +143,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -327,8 +326,8 @@ public abstract class MixinWorld implements World, IMixinWorld {
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
-        setBlock(x, y, z, block, true);
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
+        return setBlock(x, y, z, block, BlockChangeFlag.ALL, cause);
     }
 
 
@@ -627,8 +626,8 @@ public abstract class MixinWorld implements World, IMixinWorld {
     }
 
     @Override
-    public MutableBlockVolumeWorker<? extends World> getBlockWorker() {
-        return new SpongeMutableBlockVolumeWorker<>(this);
+    public MutableBlockVolumeWorker<? extends World> getBlockWorker(Cause cause) {
+        return new SpongeMutableBlockVolumeWorker<>(this, cause);
     }
 
     @Override
@@ -664,14 +663,14 @@ public abstract class MixinWorld implements World, IMixinWorld {
     }
 
     @Override
-    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
-        return snapshot.restore(force, notifyNeighbors);
+    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
+        return snapshot.restore(force, flag);
     }
 
     @Override
-    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
+    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
         snapshot = snapshot.withLocation(new Location<>(this, new Vector3i(x, y, z)));
-        return snapshot.restore(force, notifyNeighbors);
+        return snapshot.restore(force, flag);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinWorldServer.java
@@ -98,6 +98,7 @@ import org.spongepowered.api.event.world.ChangeWorldWeatherEvent;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.GeneratorType;
 import org.spongepowered.api.world.GeneratorTypes;
@@ -118,9 +119,7 @@ import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -143,7 +142,6 @@ import org.spongepowered.common.event.tracking.TrackingUtil;
 import org.spongepowered.common.event.tracking.phase.EntityPhase;
 import org.spongepowered.common.event.tracking.phase.PluginPhase;
 import org.spongepowered.common.event.tracking.phase.WorldPhase;
-import org.spongepowered.common.event.tracking.CauseTracker;
 import org.spongepowered.common.interfaces.IMixinChunk;
 import org.spongepowered.common.interfaces.IMixinNextTickListEntry;
 import org.spongepowered.common.interfaces.block.IMixinBlock;
@@ -609,9 +607,9 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
                                 final PhaseData currentTuple = causeTracker.getStack().peek();
                                 final IPhaseState phaseState = currentTuple.getState();
                                 if (phaseState.getPhase().alreadyCapturingBlockTicks(phaseState, currentTuple.getContext())) {
-                                    block.randomTick((WorldServer) (Object) this, pos, iblockstate, rand);
+                                    block.randomTick((WorldServer) (Object) this, pos, iblockstate, this.rand);
                                 } else {
-                                    TrackingUtil.randomTickBlock(causeTracker, block, pos, iblockstate, rand);
+                                    TrackingUtil.randomTickBlock(causeTracker, block, pos, iblockstate, this.rand);
                                 }
                                 spongeBlock.getTimingsHandler().stopTiming();
                                 // Sponge end
@@ -855,25 +853,22 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
         return Optional.ofNullable((Entity) this.getEntityFromUuid(uuid));
     }
 
-
     @Override
-    public void setBlock(int x, int y, int z, BlockState block, boolean notifyNeighbors) {
-        // TODO this is a dummy workaround fix until we decide on the setblock methods that don't take a cause.
-        setBlock(x, y, z, block, notifyNeighbors, Cause.source(SpongeImpl.getPlugin()).build());
-    }
-
-    @Override
-    public void setBlock(int x, int y, int z, BlockState blockState, boolean notifyNeighbors, Cause cause) {
-        checkArgument(cause != null, "Cause cannot be null!");
-        checkArgument(cause.root() instanceof PluginContainer, "PluginContainer must be at the ROOT of a cause!");
-        final CauseTracker causeTracker = this.getCauseTracker();
+    public boolean setBlock(int x, int y, int z, BlockState blockState, BlockChangeFlag flag, Cause cause) {
         checkBlockBounds(x, y, z);
+        final CauseTracker causeTracker = this.getCauseTracker();
         final PhaseData peek = causeTracker.getStack().peek();
         boolean isWorldGen = peek.getState().getPhase().isWorldGeneration(peek.getState());
+        if (!isWorldGen) {
+            checkArgument(cause != null, "Cause cannot be null!");
+            checkArgument(cause.root() instanceof PluginContainer, "PluginContainer must be at the ROOT of a cause!");
+            checkArgument(flag != null, "BlockChangeFlag cannot be null!");
+        }
         if (!isWorldGen) {
             final PhaseContext context = PhaseContext.start()
                     .add(NamedCause.of(InternalNamedCauses.General.PLUGIN_CAUSE, cause))
                     .addCaptures()
+                    .add(NamedCause.of(InternalNamedCauses.General.BLOCK_CHANGE, flag))
                     .add(NamedCause.source(cause.root()));
             for (Map.Entry<String, Object> entry : cause.getNamedCauses().entrySet()) {
                 context.add(NamedCause.of(entry.getKey(), entry.getValue()));
@@ -881,10 +876,11 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
             context.complete();
             causeTracker.switchToPhase(PluginPhase.State.BLOCK_WORKER, context);
         }
-        setBlockState(new BlockPos(x, y, z), (IBlockState) blockState, notifyNeighbors ? 3 : 2);
+        final boolean state = setBlockState(new BlockPos(x, y, z), (IBlockState) blockState, flag.updateNeighbors() ? 3 : 2);
         if (!isWorldGen) {
             causeTracker.completePhase();
         }
+        return state;
     }
 
     private void checkBlockBounds(int x, int y, int z) {
@@ -969,6 +965,17 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
         }
     }
 
+    @Override
+    public boolean setBlockState(BlockPos pos, IBlockState state, BlockChangeFlag flag) {
+        if (!this.isValid(pos)) {
+            return false;
+        } else if (this.worldInfo.getTerrainType() == WorldType.DEBUG_WORLD) { // isRemote is always false since this is WorldServer
+            return false;
+        } else {
+            // Sponge - reroute to the CauseTracker
+            return this.getCauseTracker().setBlockStateWithFlag(pos, state, flag);
+        }
+    }
 
     /**
      * @author gabizou - March 12th, 2016
@@ -1207,6 +1214,7 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
         return true;
     }
 
+
     @Override
     public SpongeBlockSnapshot createSpongeBlockSnapshot(IBlockState state, IBlockState extended, BlockPos pos, int updateFlag) {
         this.builder.reset();
@@ -1235,7 +1243,7 @@ public abstract class MixinWorldServer extends MixinWorld implements IMixinWorld
                 this.builder.unsafeNbt(nbt);
             }
         }
-        return new SpongeBlockSnapshot(this.builder, updateFlag);
+        return new SpongeBlockSnapshot(this.builder, BlockChangeFlag.ALL.setUpdateNeighbors((updateFlag & 1) != 0), updateFlag);
     }
 
 

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderFlat.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderFlat.java
@@ -33,6 +33,7 @@ import net.minecraft.world.gen.MapGenBase;
 import net.minecraft.world.gen.structure.MapGenStructure;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.biome.BiomeGenerationSettings;
@@ -47,6 +48,7 @@ import org.spongepowered.api.world.gen.populator.Lake;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.interfaces.world.gen.IPopulatorProvider;
 import org.spongepowered.common.world.gen.WorldGenConstants;
 import org.spongepowered.common.world.gen.populators.FilteredPopulator;
@@ -61,6 +63,7 @@ public class MixinChunkProviderFlat implements GenerationPopulator, IPopulatorPr
     @Shadow @Final private boolean hasDecoration;
     @Shadow @Final private boolean hasDungeons;
     @Shadow @Final private FlatGeneratorInfo flatWorldGenInfo;
+    private final Cause providerCause = Cause.source(SpongeImpl.getPlugin()).build();
 
     @Override
     public void addPopulators(WorldGenerator generator) {
@@ -125,7 +128,7 @@ public class MixinChunkProviderFlat implements GenerationPopulator, IPopulatorPr
                 for (x = 0; x < 16; ++x) {
                     int x0 = min.getX() + x;
                     for (z = 0; z < 16; ++z) {
-                        buffer.setBlock(x0, y0, min.getZ() + z, (BlockState) iblockstate);
+                        buffer.setBlock(x0, y0, min.getZ() + z, (BlockState) iblockstate, this.providerCause);
                     }
                 }
             }

--- a/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderOverworld.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/gen/MixinChunkProviderOverworld.java
@@ -43,6 +43,7 @@ import net.minecraft.world.gen.structure.MapGenVillage;
 import net.minecraft.world.gen.structure.StructureOceanMonument;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
@@ -61,6 +62,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.interfaces.world.gen.IChunkProviderOverworld;
 import org.spongepowered.common.interfaces.world.gen.IPopulatorProvider;
 import org.spongepowered.common.util.VecHelper;
@@ -93,6 +95,7 @@ public abstract class MixinChunkProviderOverworld implements IChunkProvider, Gen
 
     @Shadow public abstract void setBlocksInChunk(int p_180518_1_, int p_180518_2_, ChunkPrimer p_180518_3_);
 
+    private Cause cause = Cause.source(SpongeImpl.getPlugin()).build();
     private BiomeGenerator biomegen;
 
     @Inject(method = "<init>", at = @At("RETURN"))
@@ -204,7 +207,7 @@ public abstract class MixinChunkProviderOverworld implements IChunkProvider, Gen
                 for (int y = 0; y < 6; y++) {
                     int y0 = min.getY() + y;
                     if (y <= this.rand.nextInt(5)) {
-                        buffer.setBlock(x0, y0, z0, BlockTypes.BEDROCK.getDefaultState());
+                        buffer.setBlock(x0, y0, z0, BlockTypes.BEDROCK.getDefaultState(), this.cause);
                     }
                 }
             }

--- a/src/main/java/org/spongepowered/common/util/gen/CharArrayImmutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/CharArrayImmutableBlockBuffer.java
@@ -28,6 +28,7 @@ import com.flowpowered.math.vector.Vector3i;
 import net.minecraft.block.Block;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
@@ -83,8 +84,8 @@ public class CharArrayImmutableBlockBuffer extends AbstractBlockBuffer implement
     }
 
     @Override
-    public BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker() {
-        return new SpongeBlockVolumeWorker<>(this);
+    public BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeBlockVolumeWorker<>(this, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/util/gen/CharArrayMutableBlockBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/CharArrayMutableBlockBuffer.java
@@ -29,6 +29,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
@@ -58,9 +59,10 @@ public class CharArrayMutableBlockBuffer extends AbstractBlockBuffer implements 
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
         checkRange(x, y, z);
         this.blocks[getIndex(x, y, z)] = (char) Block.BLOCK_STATE_IDS.get((IBlockState) block);
+        return true;
     }
 
     @Override
@@ -83,8 +85,8 @@ public class CharArrayMutableBlockBuffer extends AbstractBlockBuffer implements 
     }
 
     @Override
-    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker() {
-        return new SpongeMutableBlockVolumeWorker<>(this);
+    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeMutableBlockVolumeWorker<>(this, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/util/gen/ChunkBufferPrimer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ChunkBufferPrimer.java
@@ -29,7 +29,9 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.chunk.ChunkPrimer;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
+import org.spongepowered.common.SpongeImpl;
 
 /**
  * Wraps a {@link MutableBlockVolume} within a ChunkPrimer in order to be able
@@ -40,6 +42,7 @@ public class ChunkBufferPrimer extends ChunkPrimer {
     private static final IBlockState defaultState = Blocks.AIR.getDefaultState();
     private final MutableBlockVolume buffer;
     private final Vector3i min;
+    private final Cause cause = Cause.source(SpongeImpl.getPlugin()).build();
 
     public ChunkBufferPrimer(MutableBlockVolume buffer) {
         this.buffer = buffer;
@@ -53,7 +56,7 @@ public class ChunkBufferPrimer extends ChunkPrimer {
 
     @Override
     public void setBlockState(int x, int y, int z, IBlockState state) {
-        this.buffer.setBlock(this.min.getX() + x, this.min.getY() + y, this.min.getZ() + z, (BlockState) state);
+        this.buffer.setBlock(this.min.getX() + x, this.min.getY() + y, this.min.getZ() + z, (BlockState) state, this.cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/util/gen/ChunkPrimerBuffer.java
+++ b/src/main/java/org/spongepowered/common/util/gen/ChunkPrimerBuffer.java
@@ -30,6 +30,7 @@ import com.flowpowered.math.vector.Vector3i;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.world.chunk.ChunkPrimer;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
@@ -71,9 +72,10 @@ public final class ChunkPrimerBuffer extends AbstractBlockBuffer implements Muta
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
         checkRange(x, y, z);
         this.chunkPrimer.setBlockState(x & 0xf, y, z & 0xF, (IBlockState) block);
+        return true;
     }
 
     @Override
@@ -89,8 +91,8 @@ public final class ChunkPrimerBuffer extends AbstractBlockBuffer implements Muta
     }
 
     @Override
-    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker() {
-        return new SpongeMutableBlockVolumeWorker<>(this);
+    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeMutableBlockVolumeWorker<>(this, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/DefaultedExtent.java
+++ b/src/main/java/org/spongepowered/common/world/extent/DefaultedExtent.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector2i;
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform2;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
@@ -135,8 +136,8 @@ public interface DefaultedExtent extends Extent {
     }
 
     @Override
-    default MutableBlockVolumeWorker<? extends Extent> getBlockWorker() {
-        return new SpongeMutableBlockVolumeWorker<>(this);
+    default MutableBlockVolumeWorker<? extends Extent> getBlockWorker(Cause cause) {
+        return new SpongeMutableBlockVolumeWorker<>(this, cause);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/ExtentViewDownsize.java
@@ -55,6 +55,7 @@ import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.Functional;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.biome.BiomeType;
@@ -183,9 +184,9 @@ public class ExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
         checkRange(x, y, z);
-        this.extent.setBlock(x, y, z, block);
+        return this.extent.setBlock(x, y, z, block, cause);
     }
 
     @Override
@@ -199,15 +200,9 @@ public class ExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block, boolean notifyNeighbors) {
-        checkRange(x, y, z);
-        this.extent.setBlock(x, y, z, block, notifyNeighbors);
-    }
-
-    @Override
-    public void setBlock(int x, int y, int z, BlockState blockState, boolean notifyNeighbors, Cause cause) {
+    public boolean setBlock(int x, int y, int z, BlockState blockState, BlockChangeFlag flag, Cause cause) {
         checkArgument(cause.root() instanceof PluginContainer, "PluginContainer must be at the ROOT of a cause!");
-        this.extent.setBlock(x, y, z, blockState, notifyNeighbors, cause);
+        return this.extent.setBlock(x, y, z, blockState, flag, cause);
     }
 
     @Override
@@ -217,16 +212,16 @@ public class ExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
+    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
         final Vector3i position = snapshot.getPosition();
         checkRange(position.getX(), position.getY(), position.getZ());
-        return this.extent.restoreSnapshot(snapshot, force, notifyNeighbors);
+        return this.extent.restoreSnapshot(snapshot, force, flag, cause);
     }
 
     @Override
-    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
+    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
         checkRange(x, y, z);
-        return this.extent.restoreSnapshot(x, y, z, snapshot, force, notifyNeighbors);
+        return this.extent.restoreSnapshot(x, y, z, snapshot, force, flag, cause);
     }
 
     @Override
@@ -326,9 +321,21 @@ public class ExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
+    public <E> DataTransactionResult offer(int x, int y, int z, Key<? extends BaseValue<E>> key, E value, Cause cause) {
+        checkRange(x, y, z);
+        return this.extent.offer(x, y, z, key, value, cause);
+    }
+
+    @Override
     public DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function) {
         checkRange(x, y, z);
         return this.extent.offer(x, y, z, manipulator, function);
+    }
+
+    @Override
+    public DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function, Cause cause) {
+        checkRange(x, y, z);
+        return this.extent.offer(x, y, z, manipulator, function, cause);
     }
 
     @Override
@@ -422,14 +429,12 @@ public class ExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override public boolean spawnEntities(Iterable<? extends Entity> entities, Cause cause) {
-        // TODO 1.9 gabizou this is for you
-        return false;
+        return this.extent.spawnEntities(entities, cause);
     }
 
     @Override
     public Optional<Entity> getEntity(UUID uuid) {
-        // TODO 1.9 gabizou this is for you
-        return null;
+        return this.extent.getEntity(uuid);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/ExtentViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/ExtentViewTransform.java
@@ -55,6 +55,7 @@ import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.Functional;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.biome.BiomeType;
@@ -180,9 +181,9 @@ public class ExtentViewTransform implements DefaultedExtent {
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
-        this.extent.setBlock(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z), this.inverseTransform
-            .transformZ(x, y, z), block);
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
+        return this.extent.setBlock(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z), this.inverseTransform
+            .transformZ(x, y, z), block, cause);
     }
 
     @Override
@@ -196,15 +197,9 @@ public class ExtentViewTransform implements DefaultedExtent {
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block, boolean notifyNeighbors) {
-        this.extent.setBlock(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z), this.inverseTransform
-            .transformZ(x, y, z), block, notifyNeighbors);
-    }
-
-    @Override
-    public void setBlock(int x, int y, int z, BlockState blockState, boolean notifyNeighbors, Cause cause) {
+    public boolean setBlock(int x, int y, int z, BlockState blockState, BlockChangeFlag flag, Cause cause) {
         checkArgument(cause.root() instanceof PluginContainer, "PluginContainer must be at the ROOT of a cause!");
-        this.extent.setBlock(x, y, z, blockState, notifyNeighbors, cause);
+        return this.extent.setBlock(x, y, z, blockState, flag, cause);
     }
 
     @Override
@@ -215,19 +210,19 @@ public class ExtentViewTransform implements DefaultedExtent {
     }
 
     @Override
-    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
+    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
         final Vector3i position = snapshot.getPosition();
         final int x = position.getX();
         final int y = position.getY();
         final int z = position.getZ();
         return this.extent.restoreSnapshot(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z),
-            this.inverseTransform.transformZ(x, y, z), snapshot, force, notifyNeighbors);
+            this.inverseTransform.transformZ(x, y, z), snapshot, force, flag, cause);
     }
 
     @Override
-    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
+    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
         return this.extent.restoreSnapshot(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z),
-            this.inverseTransform.transformZ(x, y, z), snapshot, force, notifyNeighbors);
+            this.inverseTransform.transformZ(x, y, z), snapshot, force, flag, cause);
     }
 
     @Override
@@ -333,10 +328,24 @@ public class ExtentViewTransform implements DefaultedExtent {
     }
 
     @Override
+    public <E> DataTransactionResult offer(int x, int y, int z, Key<? extends BaseValue<E>> key, E value, Cause cause) {
+        return this.extent
+                .offer(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z), this.inverseTransform.transformZ(x, y, z),
+                        key, value, cause);
+    }
+
+    @Override
     public DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function) {
         return this.extent
             .offer(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z), this.inverseTransform.transformZ(x, y, z),
                 manipulator, function);
+    }
+
+    @Override
+    public DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function, Cause cause) {
+        return this.extent
+                .offer(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z), this.inverseTransform.transformZ(x, y, z),
+                        manipulator, function, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/ImmutableBlockViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/ImmutableBlockViewDownsize.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
 import org.spongepowered.api.world.extent.worker.BlockVolumeWorker;
@@ -49,8 +50,8 @@ public class ImmutableBlockViewDownsize extends AbstractBlockViewDownsize<Immuta
     }
 
     @Override
-    public BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker() {
-        return new SpongeBlockVolumeWorker<>(this);
+    public BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeBlockVolumeWorker<>(this, cause);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/ImmutableBlockViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/ImmutableBlockViewTransform.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
 import org.spongepowered.api.world.extent.worker.BlockVolumeWorker;
@@ -48,8 +49,8 @@ public class ImmutableBlockViewTransform extends AbstractBlockViewTransform<Immu
     }
 
     @Override
-    public BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker() {
-        return new SpongeBlockVolumeWorker<>(this);
+    public BlockVolumeWorker<? extends ImmutableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeBlockVolumeWorker<>(this, cause);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewDownsize.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -41,9 +42,9 @@ public class MutableBlockViewDownsize extends AbstractBlockViewDownsize<MutableB
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
         checkRange(x, y, z);
-        this.volume.setBlock(x, y, z, block);
+        return this.volume.setBlock(x, y, z, block, cause);
     }
 
     @Override
@@ -59,8 +60,8 @@ public class MutableBlockViewDownsize extends AbstractBlockViewDownsize<MutableB
     }
 
     @Override
-    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker() {
-        return new SpongeMutableBlockVolumeWorker<>(this);
+    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeMutableBlockVolumeWorker<>(this, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/MutableBlockViewTransform.java
@@ -26,6 +26,7 @@ package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -41,9 +42,9 @@ public class MutableBlockViewTransform extends AbstractBlockViewTransform<Mutabl
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
-        this.volume.setBlock(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z), this.inverseTransform.transformZ
-            (x, y, z), block);
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
+        return this.volume.setBlock(this.inverseTransform.transformX(x, y, z), this.inverseTransform.transformY(x, y, z),
+                this.inverseTransform.transformZ(x, y, z), block, cause);
     }
 
     @Override
@@ -58,8 +59,8 @@ public class MutableBlockViewTransform extends AbstractBlockViewTransform<Mutabl
     }
 
     @Override
-    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker() {
-        return new SpongeMutableBlockVolumeWorker<>(this);
+    public MutableBlockVolumeWorker<? extends MutableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeMutableBlockVolumeWorker<>(this, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/SoftBufferExtentViewDownsize.java
@@ -55,6 +55,7 @@ import org.spongepowered.api.util.Direction;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.util.Functional;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
+import org.spongepowered.api.world.BlockChangeFlag;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.biome.BiomeType;
@@ -191,9 +192,9 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block) {
+    public boolean setBlock(int x, int y, int z, BlockState block, Cause cause) {
         checkRange(x, y, z);
-        this.extent.setBlock(x, y, z, block);
+        return this.extent.setBlock(x, y, z, block, cause);
     }
 
     @Override
@@ -207,15 +208,9 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public void setBlock(int x, int y, int z, BlockState block, boolean notifyNeighbors) {
-        checkRange(x, y, z);
-        this.extent.setBlock(x, y, z, block, notifyNeighbors);
-    }
-
-    @Override
-    public void setBlock(int x, int y, int z, BlockState blockState, boolean notifyNeighbors, Cause cause) {
+    public boolean setBlock(int x, int y, int z, BlockState blockState, BlockChangeFlag flag, Cause cause) {
         checkArgument(cause.root() instanceof PluginContainer, "PluginContainer must be at the ROOT of a cause!");
-        this.extent.setBlock(x, y, z, blockState, notifyNeighbors, cause);
+        return this.extent.setBlock(x, y, z, blockState, flag, cause);
     }
 
     @Override
@@ -225,16 +220,16 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
-    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
+    public boolean restoreSnapshot(BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
         final Vector3i position = snapshot.getPosition();
         checkRange(position.getX(), position.getY(), position.getZ());
-        return this.extent.restoreSnapshot(snapshot, force, notifyNeighbors);
+        return this.extent.restoreSnapshot(snapshot, force, flag, cause);
     }
 
     @Override
-    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, boolean notifyNeighbors) {
+    public boolean restoreSnapshot(int x, int y, int z, BlockSnapshot snapshot, boolean force, BlockChangeFlag flag, Cause cause) {
         checkRange(x, y, z);
-        return this.extent.restoreSnapshot(x, y, z, snapshot, force, notifyNeighbors);
+        return this.extent.restoreSnapshot(x, y, z, snapshot, force, flag, cause);
     }
 
     @Override
@@ -334,9 +329,21 @@ public class SoftBufferExtentViewDownsize implements DefaultedExtent {
     }
 
     @Override
+    public <E> DataTransactionResult offer(int x, int y, int z, Key<? extends BaseValue<E>> key, E value, Cause cause) {
+        checkRange(x, y, z);
+        return this.extent.offer(x, y, z, key, value, cause);
+    }
+
+    @Override
     public DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function) {
         checkRange(x, y, z);
         return this.extent.offer(x, y, z, manipulator, function);
+    }
+
+    @Override
+    public DataTransactionResult offer(int x, int y, int z, DataManipulator<?, ?> manipulator, MergeFunction function, Cause cause) {
+        checkRange(x, y, z);
+        return this.extent.offer(x, y, z, manipulator, function, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewDownsize.java
+++ b/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewDownsize.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.world.extent.BlockVolume;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
@@ -58,8 +59,8 @@ public class UnmodifiableBlockViewDownsize extends AbstractBlockViewDownsize<Blo
     }
 
     @Override
-    public BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker() {
-        return new SpongeBlockVolumeWorker<>(this);
+    public BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeBlockVolumeWorker<>(this, cause);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewTransform.java
+++ b/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockViewTransform.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.world.extent;
 
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
 import org.spongepowered.api.world.extent.UnmodifiableBlockVolume;
@@ -56,8 +57,8 @@ public class UnmodifiableBlockViewTransform extends AbstractBlockViewTransform<U
     }
 
     @Override
-    public BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker() {
-        return new SpongeBlockVolumeWorker<>(this);
+    public BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeBlockVolumeWorker<>(this, cause);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockVolumeWrapper.java
+++ b/src/main/java/org/spongepowered/common/world/extent/UnmodifiableBlockVolumeWrapper.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.world.extent;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.DiscreteTransform3;
 import org.spongepowered.api.world.extent.ImmutableBlockVolume;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -84,8 +85,8 @@ public class UnmodifiableBlockVolumeWrapper implements UnmodifiableBlockVolume {
     }
 
     @Override
-    public BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker() {
-        return new SpongeBlockVolumeWorker<>(this);
+    public BlockVolumeWorker<? extends UnmodifiableBlockVolume> getBlockWorker(Cause cause) {
+        return new SpongeBlockVolumeWorker<>(this, cause);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/world/extent/worker/SpongeBlockVolumeWorker.java
+++ b/src/main/java/org/spongepowered/common/world/extent/worker/SpongeBlockVolumeWorker.java
@@ -28,6 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.world.Chunk;
 import org.spongepowered.api.world.extent.BlockVolume;
@@ -51,9 +52,11 @@ import java.util.function.BiFunction;
 public class SpongeBlockVolumeWorker<V extends BlockVolume> implements BlockVolumeWorker<V> {
 
     protected final V volume;
+    protected final Cause cause;
 
-    public SpongeBlockVolumeWorker(V volume) {
+    public SpongeBlockVolumeWorker(V volume, Cause cause) {
         this.volume = volume;
+        this.cause = cause;
     }
 
     @Override
@@ -94,7 +97,7 @@ public class SpongeBlockVolumeWorker<V extends BlockVolume> implements BlockVolu
                 for (int x = xMin; x <= xMax; x++) {
                     final BlockState block = mapper.map(unmodifiableVolume, x, y, z);
 
-                    destination.setBlock(x + xOffset, y + yOffset, z + zOffset, block);
+                    destination.setBlock(x + xOffset, y + yOffset, z + zOffset, block, this.cause);
                 }
             }
         }
@@ -135,7 +138,7 @@ public class SpongeBlockVolumeWorker<V extends BlockVolume> implements BlockVolu
                 for (int x = xMin; x <= xMax; x++) {
                     final BlockState block = merger.merge(firstUnmodifiableVolume, x, y, z,
                         secondUnmodifiableVolume, x + xOffsetSecond, y + yOffsetSecond, z + zOffsetSecond);
-                    destination.setBlock(x + xOffsetDestination, y + yOffsetDestination, z + zOffsetDestination, block);
+                    destination.setBlock(x + xOffsetDestination, y + yOffsetDestination, z + zOffsetDestination, block, this.cause);
                 }
             }
         }

--- a/src/main/java/org/spongepowered/common/world/extent/worker/SpongeMutableBlockVolumeWorker.java
+++ b/src/main/java/org/spongepowered/common/world/extent/worker/SpongeMutableBlockVolumeWorker.java
@@ -25,6 +25,7 @@
 package org.spongepowered.common.world.extent.worker;
 
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
 import org.spongepowered.api.world.extent.worker.MutableBlockVolumeWorker;
 import org.spongepowered.api.world.extent.worker.procedure.BlockVolumeFiller;
@@ -34,12 +35,12 @@ import org.spongepowered.api.world.extent.worker.procedure.BlockVolumeFiller;
  */
 public class SpongeMutableBlockVolumeWorker<V extends MutableBlockVolume> extends SpongeBlockVolumeWorker<V> implements MutableBlockVolumeWorker<V> {
 
-    public SpongeMutableBlockVolumeWorker(V volume) {
-        super(volume);
+    public SpongeMutableBlockVolumeWorker(V volume, Cause cause) {
+        super(volume, cause);
     }
 
     @Override
-    public void fill(BlockVolumeFiller filler) {
+    public void fill(BlockVolumeFiller filler, Cause cause) {
         final int xMin = this.volume.getBlockMin().getX();
         final int yMin = this.volume.getBlockMin().getY();
         final int zMin = this.volume.getBlockMin().getZ();
@@ -50,7 +51,7 @@ public class SpongeMutableBlockVolumeWorker<V extends MutableBlockVolume> extend
             for (int y = yMin; y <= yMax; y++) {
                 for (int x = xMin; x <= xMax; x++) {
                     final BlockState block = filler.produce(x, y, z);
-                    this.volume.setBlock(x, y, z, block);
+                    this.volume.setBlock(x, y, z, block, cause);
                 }
             }
         }

--- a/src/main/java/org/spongepowered/common/world/gen/SpongeGenerationPopulator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/SpongeGenerationPopulator.java
@@ -35,6 +35,7 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
 import org.spongepowered.api.world.gen.GenerationPopulator;
@@ -49,6 +50,7 @@ public class SpongeGenerationPopulator implements GenerationPopulator, IGenerati
     private final IChunkGenerator chunkGenerator;
     private final World world;
     private Timing timing;
+    private final Cause populatorCause = Cause.source(this).build();
 
     /**
      * Gets the {@link GenerationPopulator} from the given
@@ -124,7 +126,7 @@ public class SpongeGenerationPopulator implements GenerationPopulator, IGenerati
                 for (int yInChunk = yInChunkStart; yInChunk <= yInChunkEnd; yInChunk++) {
                     for (int zInChunk = zInChunkStart; zInChunk <= zInChunkEnd; zInChunk++) {
                         buffer.setBlock(xOffset + xInChunk, yOffset + yInChunk, zOffset + zInChunk,
-                                (BlockState) miniChunk.get(xInChunk, yInChunk, zInChunk));
+                                (BlockState) miniChunk.get(xInChunk, yInChunk, zInChunk), this.populatorCause);
                     }
                 }
             }

--- a/src/main/java/org/spongepowered/common/world/gen/populators/EndBiomeGenerationPopulator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/populators/EndBiomeGenerationPopulator.java
@@ -27,12 +27,14 @@ package org.spongepowered.common.world.gen.populators;
 import com.flowpowered.math.vector.Vector3i;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
 import org.spongepowered.api.world.gen.GenerationPopulator;
 
 public class EndBiomeGenerationPopulator implements GenerationPopulator {
+    private final Cause populatorCause = Cause.source(this).build();
 
     @Override
     public void populate(World world, MutableBlockVolume buffer, ImmutableBiomeArea biomes) {
@@ -44,7 +46,7 @@ public class EndBiomeGenerationPopulator implements GenerationPopulator {
                 for (int y = max.getY(); y >= min.getY(); --y) {
                     BlockState iblockstate2 = buffer.getBlock(x, y, z);
                     if (iblockstate2.getType() == BlockTypes.STONE) {
-                        buffer.setBlock(x, y, z, iblockstate);
+                        buffer.setBlock(x, y, z, iblockstate, this.populatorCause);
                     }
                 }
             }

--- a/src/main/java/org/spongepowered/common/world/gen/populators/MesaBiomeGenerationPopulator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/populators/MesaBiomeGenerationPopulator.java
@@ -34,6 +34,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.world.gen.NoiseGeneratorPerlin;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -53,6 +54,7 @@ public class MesaBiomeGenerationPopulator implements GenerationPopulator {
     private boolean hasTrees = false;
 
     private double[] stoneNoise;
+    private final Cause populatorCause = Cause.source(this).build();
 
     public MesaBiomeGenerationPopulator(boolean mesa, boolean trees) {
         this.hasHills = mesa;
@@ -128,11 +130,11 @@ public class MesaBiomeGenerationPopulator implements GenerationPopulator {
 
         for (int k1 = 255; k1 >= 0; --k1) {
             if (((IBlockState) p_180622_3_.getBlock(l, k1, k)).getMaterial() == Material.AIR && k1 < (int) d5) {
-                p_180622_3_.setBlock(l, k1, k, (BlockState) Blocks.STONE.getDefaultState());
+                p_180622_3_.setBlock(l, k1, k, (BlockState) Blocks.STONE.getDefaultState(), this.populatorCause);
             }
 
             if (k1 <= p_180622_2_.nextInt(5)) {
-                p_180622_3_.setBlock(l, k1, k, (BlockState) Blocks.BEDROCK.getDefaultState());
+                p_180622_3_.setBlock(l, k1, k, (BlockState) Blocks.BEDROCK.getDefaultState(), this.populatorCause);
             } else {
                 IBlockState iblockstate1 = (IBlockState) p_180622_3_.getBlock(l, k1, k);
 
@@ -163,9 +165,9 @@ public class MesaBiomeGenerationPopulator implements GenerationPopulator {
                                 if (flag1) {
                                     p_180622_3_.setBlock(l, k1, k,
                                             (BlockState) Blocks.DIRT.getDefaultState()
-                                                    .withProperty(BlockDirt.VARIANT, BlockDirt.DirtType.COARSE_DIRT));
+                                                    .withProperty(BlockDirt.VARIANT, BlockDirt.DirtType.COARSE_DIRT), this.populatorCause);
                                 } else {
-                                    p_180622_3_.setBlock(l, k1, k, (BlockState) Blocks.GRASS.getDefaultState());
+                                    p_180622_3_.setBlock(l, k1, k, (BlockState) Blocks.GRASS.getDefaultState(), this.populatorCause);
                                 }
                             } else if (k1 > seaLevel + 3 + i1) {
                                 if (k1 >= 64 && k1 <= 127) {
@@ -179,18 +181,20 @@ public class MesaBiomeGenerationPopulator implements GenerationPopulator {
                                             Blocks.STAINED_HARDENED_CLAY.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.ORANGE);
                                 }
 
-                                p_180622_3_.setBlock(l, k1, k, (BlockState) iblockstate2);
+                                p_180622_3_.setBlock(l, k1, k, (BlockState) iblockstate2, this.populatorCause);
                             } else {
                                 p_180622_3_.setBlock(l, k1, k,
-                                        (BlockState) Blocks.SAND.getDefaultState().withProperty(BlockSand.VARIANT, BlockSand.EnumType.RED_SAND));
+                                        (BlockState) Blocks.SAND.getDefaultState().withProperty(BlockSand.VARIANT, BlockSand.EnumType.RED_SAND),
+                                        this.populatorCause);
                                 flag2 = true;
                             }
                         } else {
-                            p_180622_3_.setBlock(l, k1, k, (BlockState) iblockstate3);
+                            p_180622_3_.setBlock(l, k1, k, (BlockState) iblockstate3, this.populatorCause);
 
                             if (iblockstate3.getBlock() == Blocks.STAINED_HARDENED_CLAY) {
                                 p_180622_3_.setBlock(l, k1, k,
-                                        (BlockState) iblockstate3.getBlock().getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.ORANGE));
+                                        (BlockState) iblockstate3.getBlock().getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.ORANGE),
+                                        this.populatorCause);
                             }
                         }
                     } else if (j1 > 0) {
@@ -198,10 +202,10 @@ public class MesaBiomeGenerationPopulator implements GenerationPopulator {
 
                         if (flag2) {
                             IBlockState clay = Blocks.STAINED_HARDENED_CLAY.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.ORANGE);
-                            p_180622_3_ .setBlock(l, k1, k, (BlockState) clay);
+                            p_180622_3_ .setBlock(l, k1, k, (BlockState) clay, this.populatorCause);
                         } else {
                             iblockstate2 = this.func_180629_a(p_180622_4_, k1, p_180622_5_);
-                            p_180622_3_.setBlock(l, k1, k, (BlockState) iblockstate2);
+                            p_180622_3_.setBlock(l, k1, k, (BlockState) iblockstate2, this.populatorCause);
                         }
                     }
                 }

--- a/src/main/java/org/spongepowered/common/world/gen/populators/RandomBlockPopulator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/populators/RandomBlockPopulator.java
@@ -27,22 +27,18 @@ package org.spongepowered.common.world.gen.populators;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.math.vector.Vector3i;
-import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.world.WorldServer;
 import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.util.weighted.VariableAmount;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.Extent;
-import org.spongepowered.api.world.extent.Extent;
 import org.spongepowered.api.world.gen.PopulatorType;
 import org.spongepowered.api.world.gen.PopulatorTypes;
 import org.spongepowered.api.world.gen.populator.RandomBlock;
-import org.spongepowered.common.block.BlockUtil;
 import org.spongepowered.common.interfaces.world.IMixinLocation;
-import org.spongepowered.common.mixin.core.block.state.MixinStateImplementation;
-import org.spongepowered.common.util.VecHelper;
 
 import java.util.Random;
 import java.util.function.Predicate;
@@ -53,6 +49,7 @@ public class RandomBlockPopulator implements RandomBlock {
     private VariableAmount height;
     private Predicate<Location<World>> check;
     private BlockState state;
+    private final Cause populatorCause = Cause.source(this).build();
 
     public RandomBlockPopulator(BlockState block, VariableAmount count, VariableAmount height) {
         this.count = checkNotNull(count);
@@ -83,7 +80,7 @@ public class RandomBlockPopulator implements RandomBlock {
         for (int i = 0; i < n; i++) {
             Location<World> pos = chunkMin.add(random.nextInt(size.getX()), this.height.getFlooredAmount(random), random.nextInt(size.getZ()));
             if (this.check.test(pos)) {
-                world.setBlock(pos.getBlockPosition(), this.state);
+                world.setBlock(pos.getBlockPosition(), this.state, this.populatorCause);
                 // Liquids force a block update tick so they may flow during world gen
                 try {
                     ((WorldServer) world).immediateBlockTick(((IMixinLocation) (Object) pos).getBlockPos(), (IBlockState) this.state, random);

--- a/src/main/java/org/spongepowered/common/world/gen/populators/SwampLilyPopulator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/populators/SwampLilyPopulator.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.world.gen.populators;
 import com.flowpowered.math.vector.Vector3i;
 import net.minecraft.world.gen.NoiseGeneratorPerlin;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.extent.ImmutableBiomeArea;
 import org.spongepowered.api.world.extent.MutableBlockVolume;
@@ -37,6 +38,7 @@ import java.util.Random;
 public class SwampLilyPopulator implements GenerationPopulator {
 
     private NoiseGeneratorPerlin noise = new NoiseGeneratorPerlin(new Random(2345L), 1);
+    private final Cause populatorCause = Cause.source(this).build();
 
     public SwampLilyPopulator() {
 
@@ -55,10 +57,10 @@ public class SwampLilyPopulator implements GenerationPopulator {
                     for (int i1 = 255; i1 >= 0; --i1) {
                         if (buffer.getBlock(x, i1, z).getType() != BlockTypes.AIR) {
                             if (i1 == 62 && buffer.getBlock(x, i1, z).getType() != BlockTypes.WATER) {
-                                buffer.setBlock(x, i1, z, BlockTypes.WATER.getDefaultState());
+                                buffer.setBlock(x, i1, z, BlockTypes.WATER.getDefaultState(), this.populatorCause);
 
                                 if (d1 < 0.12D) {
-                                    buffer.setBlock(x, i1 + 1, z, BlockTypes.WATERLILY.getDefaultState());
+                                    buffer.setBlock(x, i1 + 1, z, BlockTypes.WATERLILY.getDefaultState(), this.populatorCause);
                                 }
                             }
                             break;

--- a/src/main/java/org/spongepowered/common/world/gen/populators/package-info.java
+++ b/src/main/java/org/spongepowered/common/world/gen/populators/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.world.gen.populators;


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1315) | **SpongeCommon** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/770)

This is a more focused PR at dealing with several issues at once, but for the sake of having not had a decent PR description in a while, I'll rehash the conversational description that we used to have a while back.

#### So what's changing?

In short, if a plugin developer is calling any API method that changes something, an event should be thrown. Traditionally, we used to have the inability to throw events for virtually everything, however, at this point in time, it's well within our means to throw events for all `setBlock`, `createEntity`, `spawnEntity`, etc. 

#### But why force plugin developers to supply a `Cause`? Don't developers know to throw events to check for things before they make a change?

Yes and no. It's been useful for developers to throw "dummy" events to check for permissions or block modifications before finalizing a change, and for other cases, to throw dummy spawn events before an entity is indeed spawned into the world. The problem with all of this is that it's entirely up to the developer whether to throw the events, or not throw the events, and other plugins are none the wiser. This is especially complicated by the fact that Sponge has a very complex tracking system that performs various actions based on pre-defined expectations. The change resolves a great many event cause tracking determining aspects, such as a synchronous task set up by plugin X to make a tree due to player Y. 

#### Could you explain why this wasn't an issue in API 4.X?

The issue lies in the API and the implementation. Originally planned, the CauseTracker in 1.8.9 does a very good job at determining what is causing X, Y, and Z happening, when it's *expected*. Plugins that call our methods to spawn entities are bypassing the CauseTracker, but only to a limited extent, there's no `Cause` required or provided, and other plugins have no knowledge of why an entity was being spawned. Or for that matter, the CauseTracker can flip out if a multitude of block changes take place in a synchronized task, but this isn't the fault of the CauseTracker, more so our contracts we set forth in the API. If I had to pinpoint why the change is necessary, it's that the CauseTracker is more of a mechanism to determine causes for which things happen.

#### So what actually is changing API wise?

In short, any method that changes a block in a `World` (or `Extent`) will require a `Cause`. Virtually anything that touches changing blocks will now provide a `Cause` to the system, and the system will be able to apply that provided `Cause` to the ensuing `ChangeBlockEvent` (unless this is a populator, which can simply provide a recycled `Cause` as shown in the skylands populators and generators). Data API has gained an overloaded method that will provide a `Cause` for the cases that the `#offer(Key,Object,Cause)` will change a block in a `World`, however, normal offers that simply change data on a `TileEntity` can still use the traditional `#offer(Key,Object)` method. It is understandable at this point as well that the other `DataHolder` implementations may throw Data related events with the provided `Cause`.

#### What else? What's this `BlockChangeFlag`?

Ah, so that is a brainchild of the various `boolean` flags that we used to require plugin developers to provide, namely to show that there are various *options* to perform a block change. The reasoning for it is that previously, we could only allow developers to *NOT* notify neighboring blocks on a block change, but we didn't allow it to *NOT* perform block physics on placement. This caused issues with some `BlockSnapshot#restore`s, since the restore process would always perform block physics due to the nature of the implementation. At this point, instead of adding yet another `boolean` flag and set of overloads, it was simpler to use an object to determine whether neighbor notifications should take place, and if block physics should take place. In the future, more flags may be added as necessary, and this time without breaking the API ;).

#### With all of the `Cause` usage, why does this look like the implementation is leaking into the API?

It is and isn't. Due to the nature of our tracking system, this is the best way that we can achieve a proper API contract of "all your changes throw events". Likewise, this eliminates the issues of being able to deterministically resolve what is performing changes to the world, without some obscure `Cause` containing a `Task` and or a `PluginContainer`. This also eliminates any sort of tracking required on our part to *determine* what caused those changes. This ends up with the API being more contractually sound with the end result that plugins no longer have to throw dummy events and the implementation has no requirement to track and determine what is going on throughout different phases.

Any further questions can be asked below.