### PR TITLE
Fix MinecraftCommandWrapper to allow for custom command sources

### DIFF
--- a/src/main/java/org/spongepowered/common/command/WrapperICommandSender.java
+++ b/src/main/java/org/spongepowered/common/command/WrapperICommandSender.java
@@ -35,6 +35,7 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.world.Locatable;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.interfaces.IMixinCommandSource;
 import org.spongepowered.common.text.SpongeTexts;
 import org.spongepowered.common.util.VecHelper;
@@ -92,7 +93,7 @@ public class WrapperICommandSender implements ICommandSender {
         if (this.source instanceof Locatable) {
             return (World) ((Locatable) this.source).getWorld();
         }
-        return null;
+        return SpongeImpl.getServer().getEntityWorld(); // Use overworld as default
     }
 
     @Override
@@ -115,11 +116,7 @@ public class WrapperICommandSender implements ICommandSender {
 
     @Override
     public MinecraftServer getServer() {
-        final World world = getEntityWorld();
-        if (world != null) {
-            return world.getMinecraftServer();
-        }
-        return null;
+        return getEntityWorld().getMinecraftServer();
     }
 
     public static ICommandSender of(CommandSource source) {


### PR DESCRIPTION
Based on @JBYoshi's comment [here](https://github.com/SpongePowered/SpongeCommon/commit/2a2f8184d67b64e562e6d2eb11335d2f3e0df764#commitcomment-17244727) and due to this issue cropping up [here](https://forums.spongepowered.org/t/error-with-custom-commandsource/13787).

I have changed `MinecraftCommandWrapper` so that it allows plugins to implement and pass their own sources to vanilla minecraft commands.

Test:
```java
@Plugin(id = "test-plugin", name = "Test Plugin", version = "1.0.0")
public class TestPlugin {

    @Inject
    private Logger log;

    @Inject
    private PluginContainer container;

    @Listener
    public void onStarted(GameStartedServerEvent event) {
        CommandSource custom = new CustomSource();

        Sponge.getCommandManager().process(custom, "time set night");
    }

    class CustomSource implements CommandSource {

        @Override public String getIdentifier() {
            return "custom-source";
        }

        @Override public void sendMessage(Text message) {
            log.info("[" + getName() + "] " + message.toPlain());
        }

        @Override public String getName() {
            return "CustomSource";
        }

        @Override public Set<Context> getActiveContexts() {
            return ImmutableSet.of();
        }

        @Override public Optional<CommandSource> getCommandSource() {
            return Optional.empty();
        }

        @Override public SubjectCollection getContainingCollection() {
            return null;
        }

        @Override public MessageChannel getMessageChannel() {
            return MessageChannel.TO_ALL;
        }

        @Override public SubjectData getSubjectData() {
            return null;
        }

        @Override public void setMessageChannel(MessageChannel channel) {

        }

        @Override public SubjectData getTransientSubjectData() {
            return null;
        }

        @Override public boolean hasPermission(Set<Context> contexts, String permission) {
            return true;
        }

        @Override public Tristate getPermissionValue(Set<Context> contexts, String permission) {
            return Tristate.TRUE;
        }

        @Override public boolean isChildOf(Set<Context> contexts, Subject parent) {
            return false;
        }

        @Override public List<Subject> getParents(Set<Context> contexts) {
            return ImmutableList.of();
        }

        @Override public Optional<String> getOption(Set<Context> contexts, String key) {
            return Optional.empty();
        }
    }
}
```
Result: 
```
[14:51:40] [Server thread/INFO]: [CustomSource: Set the time to 13000]
[14:51:40] [Server thread/INFO] [test-plugin]: [CustomSource] Set the time to 13000
```