### PR TITLE
Add Structure Saving Whitelist/Blacklist

### DIFF
--- a/src/main/java/org/spongepowered/common/config/category/OptimizationCategory.java
+++ b/src/main/java/org/spongepowered/common/config/category/OptimizationCategory.java
@@ -32,6 +32,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.common.SpongeImplHooks;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @ConfigSerializable
 public class OptimizationCategory extends ConfigCategory {
@@ -61,6 +63,20 @@ public class OptimizationCategory extends ConfigCategory {
                                                                + "for such a simple check. This may however break mods that alter\n"
                                                                + "world heights and can thus be disabled in those cases.")
     private boolean inlineBlockPositionChecks = true;
+
+    @Setting(value = "structure-saving", comment = "Toggles structures that should be saved to disk. Certain structures\n"
+                                                   + "are not neccessarily required to be saved to perform their proper\n"
+                                                   + "function. As such, saving these structures may take unnecessary \n"
+                                                   + "storage space, and/or time during world saves. By default, \n"
+                                                   + "\"Mineshaft\" is \"false\".")
+    public Map<String, Boolean> structureMap = generateMap();
+
+    private static Map<String, Boolean> generateMap() {
+        final Map<String, Boolean> map = new HashMap<>();
+        map.put("Mineshaft", false); // Let everything else be true
+        return map;
+    }
+
 
     public OptimizationCategory() {
         try {

--- a/src/main/java/org/spongepowered/common/mixin/optimization/world/gen/structure/MixinMapGenStructure_Structure_Saving.java
+++ b/src/main/java/org/spongepowered/common/mixin/optimization/world/gen/structure/MixinMapGenStructure_Structure_Saving.java
@@ -1,0 +1,38 @@
+package org.spongepowered.common.mixin.optimization.world.gen.structure;
+
+import it.unimi.dsi.fastutil.objects.Object2BooleanArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldSavedData;
+import net.minecraft.world.gen.MapGenBase;
+import net.minecraft.world.gen.structure.MapGenStructure;
+import net.minecraft.world.gen.structure.MapGenStructureData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.interfaces.world.IMixinWorldServer;
+
+@Mixin(MapGenStructure.class)
+public abstract class MixinMapGenStructure_Structure_Saving extends MapGenBase {
+
+
+    @Redirect(method = "initializeStructureData", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;loadItemData(Ljava/lang/Class;Ljava/lang/String;)Lnet/minecraft/world/WorldSavedData;"))
+    private WorldSavedData checkLoadOrDefault(World world, Class<? extends WorldSavedData> structureClass, String structureName) {
+        if (world instanceof IMixinWorldServer) {
+            Boolean saveStructure = SpongeImpl.getGlobalConfig().getConfig().getOptimizations().structureMap.get(structureName);
+            if (saveStructure == null) {
+                SpongeImpl.getGlobalConfig().getConfig().getOptimizations().structureMap.put(structureName, true);
+                saveStructure = true;
+            }
+            if (saveStructure) {
+                return world.loadItemData(structureClass, structureName);
+            } else {
+                return new MapGenStructureData(structureName);
+            }
+        } else {
+            return world.loadItemData(structureClass, structureName);
+        }
+    }
+
+}

--- a/src/main/resources/mixins.common.optimization.json
+++ b/src/main/resources/mixins.common.optimization.json
@@ -16,7 +16,8 @@
         "world.MixinWorldServer_Lighting_Inline_Valid_BlockPos",
         "MixinSpongeImplHooks_Item_Pre_Merge",
         "MixinWorldServer_Explosion",
-        "MixinExplosion_Explosion"
+        "MixinExplosion_Explosion",
+        "world.gen.structure.MixinMapGenStructure_Structure_Saving"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
It is possible to prevent some various structures from getting saved to file on extremely large worlds, wasting space. This was a feature initially requested by @bloodmc and to match Paper's patch.

Yes, I know this needs to be rebased and cleaned up since it hasn't been touched in several months now.
