### PR TITLE
New event. CommandProcessEvent

### DIFF
--- a/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
@@ -257,7 +257,7 @@ public class SpongeCommandManager implements CommandManager {
 
         try {
             try {
-                final CommandProcessEvent.Before eventBefore = SpongeEventFactory.creatCommandProcessEventBefore(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0]);
+                final CommandProcessEvent.Pre eventBefore = SpongeEventFactory.createCommandProcessEventPre(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0]);
                 Sponge.getGame().getEventManager().post(eventBefore);
                 if (eventBefore.isCancelled()) {
                     return commandResult;
@@ -307,7 +307,7 @@ public class SpongeCommandManager implements CommandManager {
                     .valueOf(thr.getMessage()))), thr);
         }
 
-        final CommandProcessEvent.After eventAfter = SpongeEventFactory.creatCommandProcessEventAfter(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0], commandResult);
+        final CommandProcessEvent.Post eventAfter = SpongeEventFactory.createCommandProcessEventPost(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0], commandResult);
         Sponge.getGame().getEventManager().post(eventAfter);
 
         return commandResult;

--- a/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
@@ -24,13 +24,24 @@
  */
 package org.spongepowered.common.command;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.spongepowered.api.command.CommandMessageFormatting.error;
+import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
+
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.command.*;
+import org.spongepowered.api.command.CommandCallable;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandManager;
+import org.spongepowered.api.command.CommandMapping;
+import org.spongepowered.api.command.CommandPermissionException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.InvocationCommandException;
 import org.spongepowered.api.command.dispatcher.Disambiguator;
 import org.spongepowered.api.command.dispatcher.SimpleDispatcher;
 import org.spongepowered.api.event.SpongeEventFactory;
@@ -47,17 +58,22 @@ import org.spongepowered.api.util.TextMessageException;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spongepowered.api.command.CommandMessageFormatting.error;
-import static org.spongepowered.api.util.SpongeApiTranslationHelper.t;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 /**
  * A simple implementation of {@link CommandManager}.
@@ -257,7 +273,7 @@ public class SpongeCommandManager implements CommandManager {
 
         try {
             try {
-                final CommandProcessEvent.Pre eventBefore = SpongeEventFactory.createCommandProcessEventPre(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0]);
+                final org.spongepowered.api.event.command.CommandProcessEvent.Pre eventBefore = SpongeEventFactory.createCommandProcessEventPre(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0]);
                 Sponge.getGame().getEventManager().post(eventBefore);
                 if (eventBefore.isCancelled()) {
                     return commandResult;

--- a/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
+++ b/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java
@@ -254,7 +254,7 @@ public class SpongeCommandManager implements CommandManager {
     public CommandResult process(CommandSource source, String commandLine) {
         CommandResult commandResult = CommandResult.empty();
         final String[] argSplit = commandLine.split(" ", 2);
-        final org.spongepowered.api.event.command.CommandProcessEvent.Pre eventPre = SpongeEventFactory.createCommandProcessEventPre(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0]);
+        final CommandProcessEvent.Pre eventPre = SpongeEventFactory.createCommandProcessEventPre(Cause.of(NamedCause.source(source)), argSplit.length > 1 ? argSplit[1] : "", argSplit[0]);
         Sponge.getGame().getEventManager().post(eventPre);
         if (eventPre.isCancelled()) {
             return commandResult;


### PR DESCRIPTION
I needed an event to handle the process of a command before and after that happen in the same tick. So I created this new event to handle that.

When some commands are fired by some players, I need to disable some functionalities. /help is one of them.

Currently there is only one event for when a command is send and it is SendCommandEvent. The commandResult isn't good.

https://github.com/SpongePowered/SpongeCommon/blob/bleeding/src/main/java/org/spongepowered/common/command/SpongeCommandManager.java#L258

SpongeAPI: https://github.com/SpongePowered/SpongeAPI/pull/1333