### PR TITLE
Incorrect name of world

### DIFF
--- a/src/main/java/org/spongepowered/common/world/WorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/WorldManager.java
@@ -573,6 +573,10 @@ public final class WorldManager {
             if (((IMixinWorldInfo) properties).getDimensionId() == null || ((IMixinWorldInfo) properties).getDimensionId() == Integer.MIN_VALUE) {
                 ((IMixinWorldInfo) properties).setDimensionId(getNextFreeDimensionId());
             }
+            
+            if(!properties.getWorldName().equals(worldName)) {
+            	((IMixinWorldInfo) properties).setWorldName(worldName);
+            }
 
             registerWorldProperties(properties);
 

--- a/src/main/java/org/spongepowered/common/world/WorldManager.java
+++ b/src/main/java/org/spongepowered/common/world/WorldManager.java
@@ -574,7 +574,7 @@ public final class WorldManager {
                 ((IMixinWorldInfo) properties).setDimensionId(getNextFreeDimensionId());
             }
             
-            if(!properties.getWorldName().equals(worldName)) {
+            if (!properties.getWorldName().equals(worldName)) {
             	((IMixinWorldInfo) properties).setWorldName(worldName);
             }
 


### PR DESCRIPTION
The folder name can be different from the name of the world. This causes many problems for other functions WorldManager.

I 'm not the only one to notice the problem. ProjectWorlds directly changes the name of the world in level.dat file : https://github.com/trentech/ProjectWorlds/blob/79ef1142c180beaea39efbc42dd798a01770bd22/src/main/java/com/gmail/trentech/pjw/io/WorldData.java