### PR TITLE
Implemented Player chat simulation method. Adds SpongeAPI-#733

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -69,6 +69,7 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.GameType;
 import net.minecraft.world.IInteractionObject;
@@ -95,6 +96,8 @@ import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.entity.MoveEntityEvent;
 import org.spongepowered.api.event.entity.living.humanoid.ChangeGameModeEvent;
 import org.spongepowered.api.event.entity.living.humanoid.player.PlayerChangeClientSettingsEvent;
+import org.spongepowered.api.event.message.MessageChannelEvent;
+import org.spongepowered.api.event.message.MessageEvent;
 import org.spongepowered.api.item.inventory.Carrier;
 import org.spongepowered.api.item.inventory.Container;
 import org.spongepowered.api.item.inventory.Inventory;
@@ -836,5 +839,24 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
             SpongeImpl.getLogger().warn("Opening fallback ContainerChest for inventory '{}'. Most API inventory methods will not be supported", chestInventory);
             ((IMixinContainer) this.openContainer).setSpectatorChest(true);
         }
+    }
+
+    @Override
+    public MessageChannelEvent.Chat simulateChat(Text message, Cause cause) {
+        checkNotNull(message, "message");
+
+        TextComponentTranslation component = new TextComponentTranslation("chat.type.text", SpongeTexts.toComponent(this.getDisplayNameText()),
+                SpongeTexts.toComponent(message));
+        final Text[] messages = SpongeTexts.splitChatMessage(component);
+
+        final MessageChannel originalChannel = this.getMessageChannel();
+        final MessageChannelEvent.Chat event = SpongeEventFactory.createMessageChannelEventChat(
+                cause, originalChannel, Optional.of(originalChannel),
+                new MessageEvent.MessageFormatter(messages[0], messages[1]), message, false
+        );
+        if (!SpongeImpl.postEvent(event) && !event.isMessageCancelled()) {
+            event.getChannel().ifPresent(channel -> channel.send(this, event.getMessage(), ChatTypes.CHAT));
+        }
+        return event;
     }
 }


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1283) | [Common](https://github.com/SpongePowered/SpongeCommon/pull/895)

This PR adds a method to Player, that allows for the simulation of chat.

The exact reasoning of it can be seen in the corresponding issue, https://github.com/SpongePowered/SpongeAPI/issues/733

This method returns the event so that the plugin can see what modifications have been made by other plugins, and to see if it has been cancelled.

Test code,

``` java
    @Listener
    public void onInteract(InteractBlockEvent.Secondary event, @First Player player) {
        player.simulateChat(Text.of("Hello there"));
    }

    @Listener
    public void onMessage(MessageChannelEvent.Chat chat, @First Player player) {
        Sponge.getServer().getBroadcastChannel().send(Text.of("Hello, " + player.getName() + '!'));
    }
```
