### PR TITLE
Add MountEntityEvent and DismountEntityEvent implementations. (Continues #765)

### DIFF
--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -51,7 +51,7 @@ public class ShouldFire {
     public static boolean DROP_ITEM_EVENT_DESTRUCT = false;
     public static boolean DROP_ITEM_EVENT_DISPENSE = false;
 
-    public static boolean MOUNT_ENTITY_EVENT = false;
-    public static boolean DISMOUNT_ENTITY_EVENT = false;
+    public static boolean RIDE_ENTITY_EVENT_MOUNT = false;
+    public static boolean RIDE_ENTITY_EVENT_DISMOUNT = false;
 
 }

--- a/src/main/java/org/spongepowered/common/event/ShouldFire.java
+++ b/src/main/java/org/spongepowered/common/event/ShouldFire.java
@@ -51,4 +51,7 @@ public class ShouldFire {
     public static boolean DROP_ITEM_EVENT_DESTRUCT = false;
     public static boolean DROP_ITEM_EVENT_DISPENSE = false;
 
+    public static boolean MOUNT_ENTITY_EVENT = false;
+    public static boolean DISMOUNT_ENTITY_EVENT = false;
+
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntity.java
@@ -75,7 +75,9 @@ import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.entity.MoveEntityEvent;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
@@ -110,6 +112,7 @@ import org.spongepowered.common.entity.EntityUtil;
 import org.spongepowered.common.entity.SpongeEntityArchetypeBuilder;
 import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 import org.spongepowered.common.entity.SpongeEntityType;
+import org.spongepowered.common.event.ShouldFire;
 import org.spongepowered.common.event.SpongeCommonEventFactory;
 import org.spongepowered.common.event.damage.DamageEventHandler;
 import org.spongepowered.common.event.damage.MinecraftBlockDamageSource;
@@ -274,6 +277,22 @@ public abstract class MixinEntity implements IMixinEntity {
     @Override
     public void firePostConstructEvents() {
         this.isConstructing = false;
+    }
+
+    @Inject(method = "addPassenger(Lnet/minecraft/entity/Entity;)V", at = @At("HEAD"), cancellable = true)
+    public void onAddPassenger(net.minecraft.entity.Entity passenger, CallbackInfo ci) {
+        if (!this.worldObj.isRemote && ShouldFire.MOUNT_ENTITY_EVENT) {
+            if (SpongeImpl.postEvent(SpongeEventFactory.createMountEntityEvent(Cause.of(NamedCause.source(passenger)), this))) {
+                ci.cancel();
+            }
+        }
+    }
+
+    @Inject(method = "removePassenger(Lnet/minecraft/entity/Entity;)V", at = @At("HEAD"))
+    public void onRemovePassenger(net.minecraft.entity.Entity passenger, CallbackInfo ci) {
+        if (!this.worldObj.isRemote && ShouldFire.DISMOUNT_ENTITY_EVENT) {
+            SpongeImpl.postEvent(SpongeEventFactory.createDismountEntityEvent(Cause.of(NamedCause.source(passenger)), this));
+        }
     }
 
     @Inject(method = "setSize", at = @At("RETURN"))


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1340)

Continuation of https://github.com/SpongePowered/SpongeCommon/pull/765, that moves the injected methods to allow for smoother cancellation of the events.

It was tested with the following

`
    @Listener
    public void onMount(MountEntityEvent event) {
        Sponge.getServer().getBroadcastChannel().send(Text.of(event.getTargetEntity().getType().getName() + " was mounted with dat cause " + event
                .getCause().toString()));
    }

    @Listener
    public void onDismount(DismountEntityEvent event) {
        Sponge.getServer().getBroadcastChannel().send(Text.of(event.getTargetEntity().getType().getName() + " was dismounted with dat cause " +
                event.getCause().toString()));
    }

`

Currently waiting on https://github.com/SpongePowered/SpongeAPI/pull/1340