### PR TITLE
DamageTypes not initialized

### DIFF
--- a/src/main/java/org/spongepowered/common/registry/type/event/DamageSourceRegistryModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/event/DamageSourceRegistryModule.java
@@ -32,13 +32,14 @@ import org.spongepowered.api.registry.util.RegistrationDependency;
 @RegistrationDependency(DamageTypeRegistryModule.class)
 public final class DamageSourceRegistryModule implements RegistryModule {
 
-    public static final net.minecraft.util.DamageSource IGNORED_DAMAGE_SOURCE = new net.minecraft.util.DamageSource("spongespecific").setDamageBypassesArmor().setDamageAllowedInCreativeMode();
+    public static net.minecraft.util.DamageSource IGNORED_DAMAGE_SOURCE;
     public static net.minecraft.util.DamageSource DAMAGESOURCE_POISON;
     public static net.minecraft.util.DamageSource DAMAGESOURCE_MELTING;
 
     @Override
     public void registerDefaults() {
         try {
+            IGNORED_DAMAGE_SOURCE = (new net.minecraft.util.DamageSource("spongespecific")).setDamageBypassesArmor().setDamageAllowedInCreativeMode();
             DAMAGESOURCE_POISON = (new net.minecraft.util.DamageSource("poison")).setDamageBypassesArmor().setMagicDamage();
             DAMAGESOURCE_MELTING = (new net.minecraft.util.DamageSource("melting")).setDamageBypassesArmor().setFireDamage();
             DamageSources.class.getDeclaredField("DROWNING").set(null, (DamageSource) net.minecraft.util.DamageSource.drown);


### PR DESCRIPTION
The creation of a "DamageSource" create a "Map" from "DamageTypes" in "DamageSourceToTypeProvider" though they are not yet initialized.

Fixe : https://github.com/SpongePowered/SpongeCommon/issues/902