### PR TITLE
[1.10] Refactor the SpongeTeleportHelper.

### DIFF
--- a/src/main/java/org/spongepowered/common/world/SpongeTeleportHelper.java
+++ b/src/main/java/org/spongepowered/common/world/SpongeTeleportHelper.java
@@ -24,20 +24,23 @@
  */
 package org.spongepowered.common.world;
 
+import com.flowpowered.math.GenericMath;
 import com.flowpowered.math.vector.Vector3i;
-import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
-import org.spongepowered.api.block.BlockState;
-import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.block.BlockTypes;
+import net.minecraft.world.border.WorldBorder;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.api.world.World;
 import org.spongepowered.common.block.BlockUtil;
-import org.spongepowered.common.util.VecHelper;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 public class SpongeTeleportHelper implements TeleportHelper {
 
@@ -47,205 +50,131 @@ public class SpongeTeleportHelper implements TeleportHelper {
     }
 
     @Override
-    public Optional<Location<World>> getSafeLocation(Location<World> location, final int height, final int width) {
-        // TODO - mixin to ChunkProviderServer to allow for returning EmptyChunks
-//        ChunkProviderServer chunkProvider = ((WorldServer) location.getExtent()).theChunkProviderServer;
-//        boolean chunkOverride = chunkProvider.chunkLoadOverride;
-//        chunkProvider.chunkLoadOverride = true;
+    public Optional<Location<World>> getSafeLocation(Location<World> location, int height, int width) {
+        final World world = location.getExtent();
 
-        // Check around the player first in a configurable radius:
-        final Optional<Location<World>> safe = checkAboveAndBelowLocation(location, height, width);
+        // Get the vectors to check, and get the block types with them.
+        // The vectors should be sorted by distance from the centre of the checking region, so
+        // this makes it easier to try to get close, because we can just iterate and get progressively further out.
+        final List<Vector3i> sortedList = getBlockLocations(location, height, width);
 
-//        chunkProvider.chunkLoadOverride = chunkOverride;
-        if (safe.isPresent()) {
-            // Add 0.5 to X and Z of block position so always in centre of block
-            return Optional.of(new Location<>(safe.get().getExtent(), safe.get().getBlockPosition().toDouble().add(0.5, 0, 0.5)));
-        }
-        return safe;
-    }
+        // We cache the various block lookup results so we don't check a block twice.
+        final Map<Vector3i, BlockData> blockCache = new HashMap<>();
 
-    private Optional<Location<World>> checkAboveAndBelowLocation(Location<World> location, final int height, final int width) {
-        // For now this will just do a straight up block.
-        // Check the main level
-        Optional<Location<World>> safe = checkAroundLocation(location, width);
+        for (Vector3i currentTarget : sortedList) {
 
-        if (safe.isPresent()) {
-            return safe;
-        }
+            // Get the block, add it to the cache.
+            BlockData block = getBlockData(currentTarget, world, blockCache);
 
-        // We've already checked zero right above this.
-        for (int currentLevel = 1; currentLevel <= height; currentLevel++) {
-            // Check above
-            safe = checkAroundLocation(location.add(0, currentLevel, 0), width);
-            if (safe.isPresent()) {
-                return safe;
-            }
+            // If the block isn't safe, no point in continuing on this run.
+            if (block.isSafeBody) {
 
-            // Check below
-            safe = checkAroundLocation(location.add(0, -currentLevel, 0), width);
-            if (safe.isPresent()) {
-                return safe;
+                // Check the block ABOVE is safe for the body, and the two BELOW are safe too.
+                if (getBlockData(currentTarget.add(0, 1, 0), world, blockCache).isSafeBody
+                        && isFloorSafe(currentTarget, world, blockCache)) {
+
+                    // This position should be safe. Get the center of the block to spawn into.
+                    return Optional.of(new Location<>(world, currentTarget.toDouble().add(0.5, 0, 0.5)));
+                }
             }
         }
 
+        // No vectors matched, so return an empty optional.
         return Optional.empty();
     }
 
-    private Optional<Location<World>> checkAroundLocation(Location<World> location, final int radius) {
-        if (isSafeLocation(location.getExtent(), location.getBlockPosition())) {
-            return Optional.of(location);
+    private boolean isFloorSafe(Vector3i currentTarget, World world, Map<Vector3i, BlockData> blockCache) {
+        BlockData data = getBlockData(currentTarget.sub(0, 1, 0), world, blockCache);
+
+        // If it's a safe floor, we can just say yes now.
+        if (data.isSafeFloor) {
+            return true;
         }
 
-        // Now we're going to search in expanding concentric circles...
-        for (int currentRadius = 0; currentRadius <= radius; currentRadius++) {
-            Optional<Vector3i> safePosition = checkAroundSpecificDiameter(location, currentRadius);
-            if (safePosition.isPresent()) {
-                // If a safe area was found: Return the checkLoc, it is the safe
-                // location.
-                return Optional.of(new Location<>(location.getExtent(), safePosition.get()));
-            }
-        }
-
-        return Optional.empty();
-    }
-
-    private Optional<Vector3i> checkAroundSpecificDiameter(Location<World> checkLoc, final int radius) {
-        World world = checkLoc.getExtent();
-        Vector3i blockPos = checkLoc.getBlockPosition();
-        //example at radius 2
-        //..c..
-        //.....
-        //..o..
-        //.....
-        //.....
-        // Check out at the radius provided.
-        blockPos = blockPos.add(radius, 0, 0);
-        if (isSafeLocation(world, blockPos)) {
-            return Optional.of(blockPos);
-        }
-        //example at radius 2
-        //..c01
-        //.....
-        //..o..
-        //.....
-        //.....
-        // Move up to the first corner..
-        for (int i = 0; i < radius; i++) {
-            blockPos = blockPos.add(0, 0, i);
-            if (isSafeLocation(world, blockPos)) {
-                return Optional.of(blockPos);
-            }
-        }
-        //example at radius 2
-        //....c
-        //....0
-        //..o.1
-        //....2
-        //....3
-        // Move to the second corner..
-        for (int i = 0; i < radius * 2; i++) {
-            blockPos = blockPos.add(-i, 0, 0);
-            if (isSafeLocation(world, blockPos)) {
-                return Optional.of(blockPos);
-            }
-        }
-        //example at radius 2
-        //.....
-        //.....
-        //..o..
-        //.....
-        //3210c
-        // Move to the third corner..
-        for (int i = 0; i < radius * 2; i++) {
-            blockPos = blockPos.add(0, 0, -i);
-            if (isSafeLocation(world, blockPos)) {
-                return Optional.of(blockPos);
-            }
-        }
-        //example at radius 2
-        //3....
-        //2....
-        //1.o..
-        //0....
-        //c....
-        // Move to the last corner..
-        for (int i = 0; i < radius * 2; i++) {
-            blockPos = blockPos.add(i, 0, 0);
-            if (isSafeLocation(world, blockPos)) {
-                return Optional.of(blockPos);
-            }
-        }
-        //example at radius 2
-        //c0...
-        //.....
-        //..o..
-        //.....
-        //.....
-        // Move back to just before the starting point.
-        for (int i = 0; i < radius - 1; i++) {
-            blockPos = blockPos.add(0, 0, i);
-            if (isSafeLocation(world, blockPos)) {
-                return Optional.of(blockPos);
-            }
-        }
-        return Optional.empty();
-    }
-
-    public boolean isSafeLocation(World world, Vector3i blockPos) {
-        final Vector3i up = blockPos.add(Vector3i.UP);
-        final Vector3i down = blockPos.sub(Vector3i.UP);
-
-        return !(!isBlockSafe(world, blockPos, false) || !isBlockSafe(world, up, false) || !isBlockSafe(world, down, true));
-
-    }
-
-    private boolean isBlockSafe(World world, Vector3i blockPos, boolean floorBlock) {
-        if (blockPos.getY() <= 0) {
+        // If it's not safe for the body, then we don't want to go through it anyway.
+        if (!data.isSafeBody) {
             return false;
         }
 
-        if (blockPos.getY() > world.getDimension().getHeight()) {
-            return false;
-        }
+        // Check the next block down, if it's a floor, then we're good to go, otherwise we'd fall too far for our liking.
+        return getBlockData(currentTarget.sub(0, 2, 0), world, blockCache).isSafeFloor;
+    }
 
-        final IBlockState blockState = BlockUtil.getBlockState(world, blockPos);
+    private List<Vector3i> getBlockLocations(Location<World> worldLocation, int height, int width) {
+        // We don't want to warp outside of the world border, so we want to check that we're within it.
+        WorldBorder worldBorder = (WorldBorder) worldLocation.getExtent().getWorldBorder();
+        int worldBorderMinX = GenericMath.floor(worldBorder.minX());
+        int worldBorderMinZ = GenericMath.floor(worldBorder.minZ());
+        int worldBorderMaxX = GenericMath.floor(worldBorder.maxX());
+        int worldBorderMaxZ = GenericMath.floor(worldBorder.maxZ());
 
-        if (floorBlock) {
-            // Floor is air so we'll fall, need to make sure we fall safely.
-            if (blockState.getBlock() == BlockTypes.AIR) {
-                final BlockState typeBelowPos = world.getBlock(blockPos.sub(0, 1, 0));
-                final BlockState typeBelowPos2 = world.getBlock(blockPos.sub(0, 2, 0));
+        // Get the World and get the maximum Y value.
+        int worldMaxY = worldLocation.getExtent().getBlockMax().getY();
 
-                // We'll fall too far, not safe
-                if (typeBelowPos.getType() == BlockTypes.AIR && typeBelowPos2.getType() == BlockTypes.AIR) {
-                    return false;
+        Vector3i vectorLocation = worldLocation.getBlockPosition();
+
+        // We use clamp to remain within the world confines, so we don't waste time checking blocks outside of the
+        // world border and the world height.
+        int minY = GenericMath.clamp(vectorLocation.getY() - height, 0, worldMaxY);
+        int maxY = GenericMath.clamp(vectorLocation.getY() + height, 0, worldMaxY);
+
+        int minX = GenericMath.clamp(vectorLocation.getX() - width, worldBorderMinX, worldBorderMaxX);
+        int maxX = GenericMath.clamp(vectorLocation.getX() + width, worldBorderMinX, worldBorderMaxX);
+
+        int minZ = GenericMath.clamp(vectorLocation.getZ() - width, worldBorderMinZ, worldBorderMaxZ);
+        int maxZ = GenericMath.clamp(vectorLocation.getZ() + width, worldBorderMinZ, worldBorderMaxZ);
+
+        // We now iterate over all possible x, y and z positions to get all possible vectors.
+        List<Vector3i> vectors = new ArrayList<>();
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    vectors.add(new Vector3i(x, y, z));
                 }
-
-                // We'll fall onto a block, need to make sure its safe
-                if (typeBelowPos.getType() != BlockTypes.AIR && !isSafeFloorMaterial(BlockUtil.toNative(typeBelowPos).getMaterial())) {
-                    return false;
-                }
-
-                // We'll fall through an air block to another, need to make sure
-                // its safe
-                return isSafeFloorMaterial(BlockUtil.toNative(typeBelowPos2).getMaterial());
             }
-
-            // We have a non-air floor, need to ensure its safe
-            return isSafeFloorMaterial(blockState.getMaterial());
         }
 
-        // We need to make sure the block at our torso or head is safe
-        return isSafeBodyMaterial(blockState.getMaterial());
+        // Sort them according to the distance to the provided worldLocation.
+        return vectors.stream()
+                .sorted((first, second) -> Integer.compare(vectorLocation.distanceSquared(first), vectorLocation.distanceSquared(second)))
+                .collect(Collectors.toList());
     }
 
-    private boolean isSafeFloorMaterial(Material material) {
-        return !(material == Material.CACTUS || material == Material.FIRE || material == Material.LAVA);
+    private BlockData getBlockData(Vector3i vector3i, World world, Map<Vector3i, BlockData> cache) {
+        if (vector3i.getY() < 0) {
+            // Anything below this isn't safe, no point going further.
+            return new BlockData(null);
+        }
+
+        if (cache.containsKey(vector3i)) {
+            return cache.get(vector3i);
+        }
+
+        BlockData data = new BlockData(BlockUtil.toNative(world.getBlock(vector3i)).getMaterial());
+        cache.put(vector3i, data);
+        return data;
     }
 
-    private boolean isSafeBodyMaterial(Material material) {
-        return (material == Material.AIR || material == Material.GRASS || material == Material.PLANTS
-                || material == Material.WATER || material == Material.REDSTONE_LIGHT || material == Material.CIRCUITS
-                || material == Material.SNOW || material == Material.PORTAL || material == Material.WEB || material == Material.VINE);
+    private class BlockData {
+
+        private final boolean isSafeBody;
+        private final boolean isSafeFloor;
+
+        // A null material just indicates that we want nothing to be marked as safe.
+        private BlockData(@Nullable Material material) {
+            this.isSafeBody = isSafeBodyMaterial(material);
+            this.isSafeFloor = isSafeFloorMaterial(material);
+        }
+
+        private boolean isSafeFloorMaterial(@Nullable Material material) {
+            return material != null && !(material == Material.AIR || material == Material.CACTUS || material == Material.FIRE
+                    || material == Material.LAVA);
+        }
+
+        private boolean isSafeBodyMaterial(@Nullable Material material) {
+            return material != null && (material == Material.AIR || material == Material.PLANTS
+                    || material == Material.WATER || material == Material.REDSTONE_LIGHT || material == Material.CIRCUITS
+                    || material == Material.SNOW || material == Material.PORTAL || material == Material.WEB || material == Material.VINE);
+        }
     }
 }


### PR DESCRIPTION
The safe teleport code has been rewritten in response to SpongePowered/SpongeForge#863, as @Zidane suggested this needed a rewrite! The code now:

* Collects all the possible locations for teleport and sorts them by distance from the original target. This will strip out any targets outside of the world border.
* Iterates over all possible locations from the closest to the furthest. For each block:
 * Checks to see if the block is safe for a player's body
 * Checks if the block above is safe for the body
 * Checks if the block below is a safe floor OR safe for the body
 * If the above is safe for the body but not a floor, checks to see if the block below is floor-worthy
 * If this is all satisfactory, then the location is returned.
 * If no block satifies these constraints, return an empty optional.

To try to improve performance, blocks that have been checked get their locations cached, along with whether the block is safe for the body or as a floor. These safety checks are currently using the previous methods with minor updates, that is, using the Material enum in Minecraft.

In theory, this could be backported to 4.x too.

A quick test plugin for teleporting using the safe teleport routine can be found at https://gist.github.com/dualspiral/e505bd4ce912355252de249644e71543 - just put co-ordinates of obviously invalid blocks for teleporting!