### PR TITLE
Prevent replaceBiomeBlocks method from running when using other generators

### DIFF
--- a/src/main/java/org/spongepowered/common/world/gen/SpongeChunkGenerator.java
+++ b/src/main/java/org/spongepowered/common/world/gen/SpongeChunkGenerator.java
@@ -231,7 +231,9 @@ public class SpongeChunkGenerator implements WorldGenerator, IChunkGenerator {
         ImmutableBiomeArea biomeBuffer = this.cachedBiomes.getImmutableBiomeCopy();
         this.baseGenerator.populate((org.spongepowered.api.world.World) this.world, blockBuffer, biomeBuffer);
 
-        replaceBiomeBlocks(this.world, this.rand, chunkX, chunkZ, chunkprimer, biomeBuffer);
+        if (!(this.baseGenerator instanceof SpongeGenerationPopulator)) {
+            replaceBiomeBlocks(this.world, this.rand, chunkX, chunkZ, chunkprimer, biomeBuffer);
+        }
 
         // Apply the generator populators to complete the blockBuffer
         for (GenerationPopulator populator : this.genpop) {


### PR DESCRIPTION
Such as TerrainControl.

This PR fixes the surface generation conflict between TerrainControl and Sponge.

Signed-off-by: Mike Howe - Dockter <mike@mcsnetworks.com>