### PR TITLE
Add LaunchWrapperTestRunner that allows unit tests to use Mixins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,14 @@ dependencies {
     forgeGradleMcDeps('net.minecraft:launchwrapper:1.11') {
         transitive = false
     }
+
+    testCompile 'org.spongepowered:launchwrappertestsuite:1.0-SNAPSHOT'
 }
 
 // Include API dependencies in our POM
 ext.shadedDevProject = api
+
+test {
+    systemProperty 'lwts.tweaker', 'org.spongepowered.common.launch.TestTweaker'
+    workingDir = {test.temporaryDir}
+}

--- a/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
+++ b/src/main/java/org/spongepowered/common/data/SpongeDataManager.java
@@ -148,7 +148,7 @@ public final class SpongeDataManager implements DataManager {
             }
             this.builders.put(clazz, builder);
         } else {
-            SpongeImpl.getLogger().warn("A DataBuilder has already been registered for %s. Attempted to register %s instead.%n", clazz,
+            SpongeImpl.getLogger().warn("A DataBuilder has already been registered for {}. Attempted to register {} instead.", clazz,
                     builder.getClass());
         }
     }
@@ -528,12 +528,12 @@ public final class SpongeDataManager implements DataManager {
     }
 
     @SuppressWarnings("rawtypes")
-	public Optional<NbtDataProcessor> getRawNbtProcessor(NbtDataType dataType, Class<? extends DataManipulator> aClass) {
+    public Optional<NbtDataProcessor> getRawNbtProcessor(NbtDataType dataType, Class<? extends DataManipulator> aClass) {
         return Optional.ofNullable(this.nbtProcessorTable.get(checkNotNull(aClass, "Manipulator class cannot be null!"), dataType));
     }
 
     @SuppressWarnings("rawtypes")
-	public Optional<NbtValueProcessor> getRawNbtProcessor(NbtDataType dataType, Key<?> key) {
+    public Optional<NbtValueProcessor> getRawNbtProcessor(NbtDataType dataType, Key<?> key) {
         return Optional.ofNullable(this.nbtValueTable.get(key, dataType));
     }
 

--- a/src/main/java/org/spongepowered/common/registry/type/entity/AITaskTypeModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/entity/AITaskTypeModule.java
@@ -96,25 +96,28 @@ public class AITaskTypeModule implements AlternateCatalogRegistryModule<AITaskTy
 
     @Override
     public void registerDefaults() {
-        createAITaskType(SpongeImpl.getMinecraftPlugin(), "wander", "Wander", WanderAITask.class);
-        createAITaskType(SpongeImpl.getMinecraftPlugin(), "avoid_entity", "Avoid Entity", AvoidEntityAITask.class);
-        createAITaskType(SpongeImpl.getMinecraftPlugin(), "run_around_like_crazy", "Run Around Like Crazy", RunAroundLikeCrazyAITask.class);
-        createAITaskType(SpongeImpl.getMinecraftPlugin(), "swimming", "Swimming", SwimmingAITask.class);
-        createAITaskType(SpongeImpl.getMinecraftPlugin(), "watch_closest", "Watch Closest", WatchClosestAITask.class);
-        createAITaskType(SpongeImpl.getMinecraftPlugin(), "find_nearest_attackable_target", "Find Nearest Attackable Target",
-                FindNearestAttackableTargetAITask.class);
-        createAITaskType(SpongeImpl.getMinecraftPlugin(), "attack_living", "Attack Living", AttackLivingAITask.class);
+        createAITaskType("minecraft:wander", "Wander", WanderAITask.class);
+        createAITaskType("minecraft:avoid_entity", "Avoid Entity", AvoidEntityAITask.class);
+        createAITaskType("minecraft:run_around_like_crazy", "Run Around Like Crazy", RunAroundLikeCrazyAITask.class);
+        createAITaskType("minecraft:swimming", "Swimming", SwimmingAITask.class);
+        createAITaskType("minecraft:watch_closest", "Watch Closest", WatchClosestAITask.class);
+        createAITaskType("minecraft:find_nearest_attackable_target", "Find Nearest Attackable Target", FindNearestAttackableTargetAITask.class);
+        createAITaskType("minecraft:attack_living", "Attack Living", AttackLivingAITask.class);
+    }
+
+    private AITaskType createAITaskType(String combinedId, String name, Class<? extends AITask<? extends Agent>> aiClass) {
+        final SpongeAITaskType newType = new SpongeAITaskType(combinedId, name, aiClass);
+        this.aiTaskTypes.put(combinedId, newType);
+        return newType;
     }
 
     public AITaskType createAITaskType(Object plugin, String id, String name, Class<? extends AITask<? extends Agent>> aiClass) {
         final Optional<PluginContainer> optPluginContainer = SpongeImpl.getGame().getPluginManager().fromInstance(plugin);
         Preconditions.checkArgument(optPluginContainer.isPresent());
         final PluginContainer pluginContainer = optPluginContainer.get();
-        final String combinedId = pluginContainer.getId().toLowerCase(Locale.ENGLISH) + ":" + id;
+        final String combinedId = pluginContainer.getId().toLowerCase(Locale.ENGLISH) + ':' + id;
 
-        final SpongeAITaskType newType = new SpongeAITaskType(combinedId, name, aiClass);
-        this.aiTaskTypes.put(combinedId, newType);
-        return newType;
+        return createAITaskType(combinedId, name, aiClass);
     }
 
     AITaskTypeModule() {}

--- a/src/main/java/org/spongepowered/common/registry/type/entity/GoalTypeModule.java
+++ b/src/main/java/org/spongepowered/common/registry/type/entity/GoalTypeModule.java
@@ -78,8 +78,15 @@ public class GoalTypeModule implements AlternateCatalogRegistryModule<GoalType> 
 
     @Override
     public void registerDefaults() {
-        createGoalType(SpongeImpl.getMinecraftPlugin(), "normal", "Normal");
-        createGoalType(SpongeImpl.getMinecraftPlugin(), "target", "Target");
+        createGoalType("minecraft:normal", "Normal");
+        createGoalType("minecraft:target", "Target");
+    }
+
+    private GoalType createGoalType(String combinedId, String name) {
+        @SuppressWarnings("unchecked")
+        final SpongeGoalType newType = new SpongeGoalType(combinedId, name, (Class<Goal<?>>) (Class<?>) EntityAITasks.class);
+        this.goalTypes.put(combinedId, newType);
+        return newType;
     }
 
     public GoalType createGoalType(Object plugin, String id, String name) {
@@ -88,10 +95,7 @@ public class GoalTypeModule implements AlternateCatalogRegistryModule<GoalType> 
         final PluginContainer pluginContainer = optPluginContainer.get();
         final String combinedId = pluginContainer.getId().toLowerCase(Locale.ENGLISH) + ":" + id;
 
-        @SuppressWarnings("unchecked")
-        final SpongeGoalType newType = new SpongeGoalType(combinedId, name, (Class<Goal<?>>) (Class<?>) EntityAITasks.class);
-        this.goalTypes.put(combinedId, newType);
-        return newType;
+        return createGoalType(combinedId, name);
     }
 
     GoalTypeModule() {

--- a/src/test/java/org/spongepowered/common/data/manipulator/DataTestUtil.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/DataTestUtil.java
@@ -24,72 +24,80 @@
  */
 package org.spongepowered.common.data.manipulator;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.spongepowered.api.data.key.Key;
-import org.spongepowered.api.data.key.Keys;
+import com.google.inject.Injector;
+import net.minecraft.init.Bootstrap;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.Platform;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.manipulator.DataManipulator;
 import org.spongepowered.api.data.manipulator.DataManipulatorBuilder;
-import org.spongepowered.api.extra.fluid.FluidTypes;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.common.SpongeGame;
 import org.spongepowered.common.SpongeImpl;
-import org.spongepowered.common.data.DataRegistrar;
+import org.spongepowered.common.SpongePlatform;
 import org.spongepowered.common.data.SpongeDataManager;
-import org.spongepowered.common.data.type.SpongeCommonFluidType;
 import org.spongepowered.common.data.util.DataProcessorDelegate;
-import org.spongepowered.common.data.util.ImplementationRequiredForTest;
-import org.spongepowered.common.registry.type.data.KeyRegistryModule;
-import org.spongepowered.common.registry.util.RegistryModuleLoader;
+import org.spongepowered.common.registry.RegistryHelper;
+import org.spongepowered.common.registry.SpongeGameRegistry;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 final class DataTestUtil {
 
     private DataTestUtil() {}
 
+    private static void initializeEnvironment() {
+        Bootstrap.register();
+
+        Game game = mock(SpongeGame.class);
+        RegistryHelper.setFinalStatic(Sponge.class, "game", game);
+
+        SpongeGameRegistry registry = new SpongeGameRegistry();
+        when(game.getRegistry()).thenReturn(registry);
+        when(game.getDataManager()).thenCallRealMethod();
+
+        // Initialize plugin manager
+        PluginManager manager = mock(PluginManager.class);
+        when(manager.getPlugin(anyString())).thenReturn(Optional.of(mock(PluginContainer.class)));
+        when(game.getPluginManager()).thenReturn(manager);
+
+        // Initialize platform
+        Platform platform = new SpongePlatform(manager, SpongeImpl.MINECRAFT_VERSION);
+        when(game.getPlatform()).thenReturn(platform);
+
+        new SpongeImpl(mock(Injector.class), game, manager);
+
+        registry.preRegistryInit();
+        registry.preInit();
+        registry.init();
+        //registry.postInit();
+    }
+
     @SuppressWarnings("unchecked")
     static List<Object[]> generateManipulatorTestObjects() throws Exception {
-        KeyRegistryModule.getInstance().registerDefaults();
-        generateKeyMap();
-        setupCatalogTypes();
-        SpongeGame mockGame = mock(SpongeGame.class);
-
-        when(mockGame.getDataManager()).thenReturn(SpongeDataManager.getInstance());
-        DataRegistrar.setupSerialization(mockGame);
-        final List<Object[]> list = new ArrayList<>();
+        initializeEnvironment();
 
         final Map<Class<? extends DataManipulator<?, ?>>, DataManipulatorBuilder<?, ?>> manipulatorBuilderMap = getBuilderMap();
         final Map<Class<? extends DataManipulator<?, ?>>, DataProcessorDelegate<?, ?>> delegateMap = getDelegateMap();
-        delegateMap.entrySet().stream().filter(entry -> isValidForTesting(entry.getKey())).forEach(entry -> {
-            list.add(new Object[]{entry.getKey().getSimpleName(), entry.getKey(), manipulatorBuilderMap.get(entry.getKey())});
-        });
-        return list;
+        return delegateMap.entrySet().stream()
+                .filter(entry -> isValidForTesting(entry.getKey()))
+                .map(entry -> new Object[]{entry.getKey().getSimpleName(), entry.getKey(), manipulatorBuilderMap.get(entry.getKey())})
+                .collect(Collectors.toList());
     }
 
     private static boolean isValidForTesting(Class<?> clazz) {
         return !Modifier.isInterface(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers())
-               && clazz.getAnnotation(ImplementationRequiredForTest.class) == null;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void generateKeyMap() throws Exception {
-        Field mapGetter = KeyRegistryModule.class.getDeclaredField("fieldMap");
-        mapGetter.setAccessible(true);
-        final Map<String, Key<?>> mapping = (Map<String, Key<?>>) mapGetter.get(KeyRegistryModule.getInstance());
-        for (Field field : Keys.class.getDeclaredFields()) {
-            if (!mapping.containsKey(field.getName().toLowerCase())) {
-                continue;
-            }
-            Field modifierField = Field.class.getDeclaredField("modifiers");
-            modifierField.setAccessible(true);
-            modifierField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-            field.set(null, mapping.get(field.getName().toLowerCase()));
-        }
+               /*&& clazz.getAnnotation(ImplementationRequiredForTest.class) == null*/;
     }
 
     @SuppressWarnings("unchecked")
@@ -107,26 +115,4 @@ final class DataTestUtil {
         return (Map<Class<? extends DataManipulator<?, ?>>, DataManipulatorBuilder<?, ?>>) builderMap.get(SpongeDataManager.getInstance());
     }
 
-
-    public static void setStaticFinalField(Field field, Object value) throws ReflectiveOperationException {
-        field.setAccessible(true);
-
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
-        field.set(null, value);
-    }
-
-    private static void setupCatalogTypes() {
-        for (Field field : FluidTypes.class.getDeclaredFields()) {
-            try {
-                setStaticFinalField(field, new SpongeCommonFluidType(field.getName().toLowerCase()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
-
-    }
 }

--- a/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
+++ b/src/test/java/org/spongepowered/common/data/manipulator/ManipulatorTest.java
@@ -38,13 +38,14 @@ import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import org.spongepowered.api.util.PEBKACException;
+import org.spongepowered.lwts.runner.LaunchWrapperParameterized;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.Set;
 
-@RunWith(Parameterized.class)
+@RunWith(LaunchWrapperParameterized.class)
 public class ManipulatorTest {
 
     @Parameterized.Parameters(name = "{index} Data: {0}")
@@ -55,7 +56,6 @@ public class ManipulatorTest {
     private String dataName;
     private Class<? extends DataManipulator<?, ?>> manipulatorClass;
     private DataManipulatorBuilder<?, ?> builder;
-
 
     public ManipulatorTest(String simpleName, Class<? extends DataManipulator<?, ?>> manipulatorClass, DataManipulatorBuilder<?, ?> builder) {
         this.manipulatorClass = manipulatorClass;

--- a/src/test/java/org/spongepowered/common/launch/TestTweaker.java
+++ b/src/test/java/org/spongepowered/common/launch/TestTweaker.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.launch;
+
+import static org.spongepowered.asm.mixin.MixinEnvironment.Side.SERVER;
+
+import net.minecraft.launchwrapper.LaunchClassLoader;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.test.launchwrapper.AbstractTestTweaker;
+
+public class TestTweaker extends AbstractTestTweaker {
+
+    @Override
+    public void injectIntoClassLoader(LaunchClassLoader loader) {
+        super.injectIntoClassLoader(loader);
+
+        registerAccessTransformer("META-INF/common_at.cfg");
+
+        SpongeLaunch.setupMixinEnvironment();
+        MixinEnvironment.getDefaultEnvironment().setSide(SERVER);
+    }
+
+}

--- a/src/test/java/org/spongepowered/common/launch/mixin/MixinItem.java
+++ b/src/test/java/org/spongepowered/common/launch/mixin/MixinItem.java
@@ -22,30 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.spongepowered.common.launch;
+package org.spongepowered.common.launch.mixin;
 
-import static org.spongepowered.asm.mixin.MixinEnvironment.Side.SERVER;
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.registry.type.ItemTypeRegistryModule;
 
-import net.minecraft.launchwrapper.LaunchClassLoader;
-import org.spongepowered.asm.mixin.MixinEnvironment;
-import org.spongepowered.asm.mixin.Mixins;
-import org.spongepowered.lwts.AbstractTestTweaker;
+@Mixin(value = Item.class, remap = false)
+public abstract class MixinItem {
 
-import java.io.File;
-
-public class TestTweaker extends AbstractTestTweaker {
-
-    @Override
-    public void injectIntoClassLoader(LaunchClassLoader loader) {
-        super.injectIntoClassLoader(loader);
-
-        registerAccessTransformer("META-INF/common_at.cfg");
-
-        SpongeLaunch.initPaths(new File("."));
-
-        SpongeLaunch.setupMixinEnvironment();
-        Mixins.addConfiguration("mixins.common.test.json");
-        MixinEnvironment.getDefaultEnvironment().setSide(SERVER);
+    // Register items
+    @Inject(method = "registerItem(ILnet/minecraft/util/ResourceLocation;Lnet/minecraft/item/Item;)V", at = @At("RETURN"))
+    private static void registerMinecraftItem(int id, ResourceLocation name, Item item, CallbackInfo ci) {
+        ItemTypeRegistryModule.getInstance().registerAdditionalCatalog((ItemType) item);
     }
 
 }

--- a/src/test/java/org/spongepowered/common/text/LegacySerializerTest.java
+++ b/src/test/java/org/spongepowered/common/text/LegacySerializerTest.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.text;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.spongepowered.common.text.SpongeTexts.COLOR_CHAR;
+
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.spongepowered.lwts.runner.LaunchWrapperTestRunner;
+
+@RunWith(LaunchWrapperTestRunner.class)
+public class LegacySerializerTest {
+
+    @Test
+    public void testPlainText() {
+        assertThat(SpongeTexts.toLegacy(new TextComponentString("test")), is("test"));
+    }
+
+    @Test
+    public void testTranslatableText() {
+        assertThat(SpongeTexts.toLegacy(new TextComponentTranslation("test")), is("test"));
+    }
+
+    @Test
+    public void testColoredText() {
+        ITextComponent component = new TextComponentString("test");
+        component.getStyle().setColor(TextFormatting.RED);
+        assertThat(SpongeTexts.toLegacy(component), is(COLOR_CHAR + "ctest"));
+    }
+
+    @Test
+    public void testNestedText() {
+        ITextComponent component = new TextComponentString("first");
+        component.getStyle().setColor(TextFormatting.RED);
+
+        component.appendSibling(new TextComponentString("second"));
+
+        TextComponentString component2 = new TextComponentString("third");
+        component2.getStyle().setColor(TextFormatting.BLUE);
+        component.appendSibling(component2);
+
+        assertThat(SpongeTexts.toLegacy(component), is(COLOR_CHAR + "cfirstsecond" + COLOR_CHAR + "9third"));
+    }
+
+    @Test
+    public void testEmptyTranslatableText() {
+        assertThat(SpongeTexts.toLegacy(new TextComponentString("blah").appendSibling(new TextComponentTranslation(""))), is("blah"));
+    }
+
+}

--- a/src/test/resources/mixins.common.test.json
+++ b/src/test/resources/mixins.common.test.json
@@ -1,0 +1,12 @@
+{
+    "required": true,
+    "package": "org.spongepowered.common.launch.mixin",
+    "target": "@env(DEFAULT)",
+    "compatibilityLevel": "JAVA_8",
+    "mixins": [
+        "MixinItem"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    }
+}


### PR DESCRIPTION
Adds a new `LaunchWrapperTestRunner` that will load the test classes using an initialized LaunchWrapper environment including the Mixin transformer. That allows the tests to use methods that are only available after the Mixins have been applied.

Basically, it works like this:
- You define a test class with the `@RunWith` annotation:
  
  ``` java
  @RunWith(LaunchWrapperTestRunner.class)
  public class ExampleTest {
  
  }
  ```
- The first time a test class with the annotation is loaded `LaunchWrapperTestRunner` will initialize a dummy LaunchWrapper environment together with the Mixin transformer.
- The test class is loaded using the `LaunchClassLoader` which will apply the Mixins to all referenced classes.

This could be also extended to call Minecraft's `Bootstrap.init()` if that is needed in a specific test.

I've added an example test for the legacy text serializer that requires the mixins to `ITextComponent` to be applied.
