### PR TITLE
Check for command block and selector permissions in MixinICommandSender and WrapperCommandSender.

### DIFF
--- a/src/main/java/org/spongepowered/common/command/CommandPermissions.java
+++ b/src/main/java/org/spongepowered/common/command/CommandPermissions.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.command;
+
+import org.spongepowered.api.command.CommandCallable;
+import org.spongepowered.api.command.CommandMapping;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.service.permission.SubjectData;
+import org.spongepowered.api.util.Tristate;
+import org.spongepowered.common.SpongeImpl;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public final class CommandPermissions {
+
+    private static final String COMMAND_BLOCK_COMMAND = "";
+    private static final String COMMAND_BLOCK_PERMISSION = "minecraft.commandblock";
+    private static final int COMMAND_BLOCK_LEVEL = 2;
+    private static final String SELECTOR_COMMAND = "@";
+    private static final String SELECTOR_PERMISSION = "minecraft.selector";
+    private static final int SELECTOR_LEVEL = 2;
+
+    private CommandPermissions() {
+    }
+
+    public static boolean testPermission(CommandSource source, String commandName) {
+        if (commandName.equals(CommandPermissions.SELECTOR_COMMAND)) {
+            return source.hasPermission(CommandPermissions.SELECTOR_PERMISSION);
+        }
+        if (commandName.equals(CommandPermissions.COMMAND_BLOCK_COMMAND)) {
+            return source.hasPermission(CommandPermissions.COMMAND_BLOCK_PERMISSION);
+        }
+        Optional<? extends CommandMapping> mapping = SpongeImpl.getGame().getCommandManager().get(commandName);
+        if (mapping.isPresent()) {
+            CommandCallable callable = mapping.get().getCallable();
+            if (callable instanceof MinecraftCommandWrapper) {
+                return source.hasPermission(((MinecraftCommandWrapper) callable).getCommandPermission());
+            } else {
+                return callable.testPermission(source);
+            }
+        }
+        return source.hasPermission(commandName);
+    }
+
+    public static void populateNonCommandPermissions(SubjectData data, BiFunction<Integer, String, Boolean> testPermission) {
+        if (testPermission.apply(CommandPermissions.COMMAND_BLOCK_LEVEL, CommandPermissions.COMMAND_BLOCK_COMMAND)) {
+            data.setPermission(SubjectData.GLOBAL_CONTEXT, SELECTOR_PERMISSION, Tristate.TRUE);
+        }
+        if (testPermission.apply(CommandPermissions.SELECTOR_LEVEL, CommandPermissions.SELECTOR_COMMAND)) {
+            data.setPermission(SubjectData.GLOBAL_CONTEXT, COMMAND_BLOCK_COMMAND, Tristate.TRUE);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/common/command/WrapperCommandSource.java
+++ b/src/main/java/org/spongepowered/common/command/WrapperCommandSource.java
@@ -53,16 +53,13 @@ public class WrapperCommandSource extends SpongeSubject implements CommandSource
     final ICommandSender sender;
     private final MemorySubjectData data;
 
-    WrapperCommandSource(ICommandSender sender) {
+    private WrapperCommandSource(ICommandSender sender) {
         this.sender = sender;
         this.data = new MemorySubjectData(SpongeImpl.getGame().getServiceManager().provide(PermissionService.class).get());
 
         // ICommandSenders have a *very* basic understanding of permissions, so
         // get what we can.
-        this.data.setPermission(SubjectData.GLOBAL_CONTEXT, "minecraft.selector",
-                Tristate.fromBoolean(this.sender.canCommandSenderUseCommand(1, "@")));
-        this.data.setPermission(SubjectData.GLOBAL_CONTEXT, "minecraft.commandblock",
-                Tristate.fromBoolean(this.sender.canCommandSenderUseCommand(2, "")));
+        CommandPermissions.populateNonCommandPermissions(this.data, this.sender::canCommandSenderUseCommand);
         for (CommandMapping command : SpongeImpl.getGame().getCommandManager().getCommands()) {
             if (command.getCallable() instanceof MinecraftCommandWrapper) {
                 MinecraftCommandWrapper wrapper = (MinecraftCommandWrapper) command.getCallable();

--- a/src/main/java/org/spongepowered/common/command/WrapperICommandSender.java
+++ b/src/main/java/org/spongepowered/common/command/WrapperICommandSender.java
@@ -67,7 +67,7 @@ public class WrapperICommandSender implements ICommandSender {
 
     @Override
     public boolean canCommandSenderUseCommand(int permLevel, String commandName) {
-        return this.source.hasPermission(commandName);
+        return CommandPermissions.testPermission(this.source, commandName);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/command/MixinICommandSender.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/command/MixinICommandSender.java
@@ -29,29 +29,15 @@ import net.minecraft.command.server.CommandBlockLogic;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.rcon.RConConsoleSource;
 import net.minecraft.server.MinecraftServer;
-import org.spongepowered.api.command.CommandCallable;
-import org.spongepowered.api.command.CommandMapping;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.common.SpongeImpl;
-import org.spongepowered.common.command.MinecraftCommandWrapper;
+import org.spongepowered.common.command.CommandPermissions;
 import org.spongepowered.common.interfaces.IMixinCommandSender;
-
-import java.util.Optional;
 
 @Mixin(value = {EntityPlayerMP.class, MinecraftServer.class, RConConsoleSource.class, CommandBlockLogic.class}, targets = IMixinCommandSender.SIGN_CLICK_SENDER)
 public abstract class MixinICommandSender implements ICommandSender, IMixinCommandSender {
 
     @Override
     public boolean canCommandSenderUseCommand(int permissionLevel, String commandName) {
-        Optional<? extends CommandMapping> mapping = SpongeImpl.getGame().getCommandManager().get(commandName);
-        if (mapping.isPresent()) {
-            CommandCallable callable = mapping.get().getCallable();
-            if (callable instanceof MinecraftCommandWrapper) {
-                return asCommandSource().hasPermission(((MinecraftCommandWrapper) callable).getCommandPermission());
-            } else {
-                return callable.testPermission(asCommandSource());
-            }
-        }
-        return asCommandSource().hasPermission(commandName);
+        return CommandPermissions.testPermission(this.asCommandSource(), commandName);
     }
 }

--- a/src/main/java/org/spongepowered/common/service/permission/OpLevelCollection.java
+++ b/src/main/java/org/spongepowered/common/service/permission/OpLevelCollection.java
@@ -32,6 +32,7 @@ import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.common.command.CommandPermissions;
 import org.spongepowered.common.service.permission.base.GlobalMemorySubjectData;
 import org.spongepowered.common.service.permission.base.SpongeSubject;
 import org.spongepowered.common.service.permission.base.SpongeSubjectCollection;
@@ -99,6 +100,7 @@ public class OpLevelCollection extends SpongeSubjectCollection {
                     }
                 }
             };
+            CommandPermissions.populateNonCommandPermissions(this.data, (permLevel, name) -> level == permLevel);
         }
 
         public int getOpLevel() {


### PR DESCRIPTION
Assigns the `canCommandSenderUseCommand` calls for non-command permissions (for editing command blocks and using selectors) to use their Sponge permission equivalents.

Fixes SpongePowered/SpongeCommon#866.