### PR TITLE
Update UserDiscoverer so that it does not try to parse files with extensions other than "dat"

### DIFF
--- a/src/main/java/org/spongepowered/common/service/user/UserDiscoverer.java
+++ b/src/main/java/org/spongepowered/common/service/user/UserDiscoverer.java
@@ -52,8 +52,13 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 class UserDiscoverer {
+
+    private static final Pattern UUID_PATTERN =
+            Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", Pattern.CASE_INSENSITIVE);
 
     private static final Cache<UUID, User> userCache = CacheBuilder.newBuilder()
             .expireAfterAccess(1, TimeUnit.DAYS)
@@ -123,11 +128,17 @@ class UserDiscoverer {
         // Add all known profiles from the data files
         SaveHandler saveHandler = (SaveHandler) DimensionManager.getWorldFromDimId(0).getSaveHandler();
         String[] uuids = saveHandler.getAvailablePlayerDat();
+        Matcher uuidMatcher = UUID_PATTERN.matcher("");
         for (String playerUuid : uuids) {
 
             // Some mods store other files in the 'playerdata' folder, so
             // we need to ensure that the filename is a valid UUID
-            if (playerUuid.split("-").length != 5) {
+            //
+            // It's also important to note that the SaveHandler's
+            // getAvailablePlayerDat method will only remove the
+            // extension from ".dat" files, any other file will retain
+            // their extension.
+            if (!uuidMatcher.reset(playerUuid).matches()) {
                 continue;
             }
 


### PR DESCRIPTION
This was originally reported to me as https://github.com/NucleusPowered/Nucleus/issues/381.

When trying to get all users from `UserDiscoverer.getAllProfiles()` and there are files that do not have the `.dat` suffix in the player data folder but _do_ use the UUID as the file name (such as older versions of Pixelmon putting `.pk` files in the same folder), a `NumberFormatException` exception is thrown when trying to parse the file name with the suffix. This PR resolves this by tightening the UUID check, using a regex `Matcher` over checking that there are four hyphens in the file name (which could also cause a problem if a non-UUID file name with four hyphens is there.)

To test this, I have written a small plugin: https://gist.github.com/dualspiral/a5df425333a73812009fa5e534b3a87b. To test fully, in the `world/playerdata` folder of a server, duplicate one of the player data files, giving it a different extension but keeping the UUID the same. Without this patch, if you run the test plugin, type `/getuser ` then press `tab`, you'll get an error on the console. With this patch, it will ignore all non-`dat` suffixed files.

This is targetting master as this has been reported to me for 1.8.9, but the same patch should also be applied to bleeding.