### PR TITLE
Implement SoundType changes

### DIFF
--- a/src/main/java/org/spongepowered/common/effect/sound/SpongeSoundBuilder.java
+++ b/src/main/java/org/spongepowered/common/effect/sound/SpongeSoundBuilder.java
@@ -24,21 +24,26 @@
  */
 package org.spongepowered.common.effect.sound;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvent;
 import org.spongepowered.api.effect.sound.SoundType;
-import org.spongepowered.common.SpongeCatalogType;
 
-public class SpongeSound extends SpongeCatalogType implements SoundType {
+public class SpongeSoundBuilder implements SoundType.Builder {
 
-    private final String name;
-
-    public SpongeSound(String name, String id) {
-        super(id);
-        this.name = name;
+    @Override
+    public SoundType.Builder from(SoundType value) {
+        return this;
     }
 
     @Override
-    public String getName() {
-        return this.name;
+    public SoundType.Builder reset() {
+        return this;
     }
 
+    @Override
+    public SoundType build(String id) throws IllegalStateException {
+        return (SoundType) new SoundEvent(new ResourceLocation(checkNotNull(id)));
+   }
 }

--- a/src/main/java/org/spongepowered/common/effect/sound/package-info.java
+++ b/src/main/java/org/spongepowered/common/effect/sound/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@org.spongepowered.api.util.annotation.NonnullByDefault package org.spongepowered.common.effect.sound;

--- a/src/main/java/org/spongepowered/common/interfaces/world/IMixinServerWorldEventHandler.java
+++ b/src/main/java/org/spongepowered/common/interfaces/world/IMixinServerWorldEventHandler.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.common.interfaces.world;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.SoundCategory;
+
+import javax.annotation.Nullable;
+
+public interface IMixinServerWorldEventHandler {
+
+    void playCustomSoundToAllNearExcept(@Nullable EntityPlayer player, String soundIn, SoundCategory category, double x, double y, double z,
+float volume, float pitch);
+
+}

--- a/src/main/java/org/spongepowered/common/interfaces/world/IMixinWorldServer.java
+++ b/src/main/java/org/spongepowered/common/interfaces/world/IMixinWorldServer.java
@@ -28,6 +28,8 @@ import co.aikar.timings.WorldTimingsHandler;
 import com.flowpowered.math.vector.Vector3d;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.world.BlockChangeFlag;
@@ -39,6 +41,8 @@ import org.spongepowered.common.entity.EntityUtil;
 import org.spongepowered.common.event.tracking.CauseTracker;
 import org.spongepowered.common.world.gen.SpongeChunkGenerator;
 import org.spongepowered.common.world.gen.SpongeWorldGenerator;
+
+import javax.annotation.Nullable;
 
 public interface IMixinWorldServer extends IMixinWorld {
 
@@ -91,5 +95,7 @@ public interface IMixinWorldServer extends IMixinWorld {
     long getChunkUnloadDelay();
 
     void triggerInternalExplosion(Explosion explosion);
+
+    void playCustomSound(@Nullable EntityPlayer player, double x, double y, double z, String soundIn, SoundCategory category, float volume, float pitch);
 
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayerMP.java
@@ -46,6 +46,7 @@ import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.SPacketBlockChange;
 import net.minecraft.network.play.server.SPacketChat;
 import net.minecraft.network.play.server.SPacketCombatEvent;
+import net.minecraft.network.play.server.SPacketCustomSound;
 import net.minecraft.network.play.server.SPacketResourcePackSend;
 import net.minecraft.network.play.server.SPacketSoundEffect;
 import net.minecraft.network.play.server.SPacketSpawnPosition;
@@ -61,6 +62,7 @@ import net.minecraft.stats.StatList;
 import net.minecraft.stats.StatisticsManagerServer;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.FoodStats;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.GameRules;
@@ -568,8 +570,19 @@ public abstract class MixinEntityPlayerMP extends MixinEntityPlayer implements P
 
     @Override
     public void playSound(SoundType sound, SoundCategory category, Vector3d position, double volume, double pitch, double minVolume) {
-        this.connection.sendPacket(new SPacketSoundEffect(SoundEvents.getRegisteredSoundEvent(sound.getId()), (net.minecraft.util.SoundCategory) (Object) category, position.getX(), position.getY(), position.getZ(),
-                (float) Math.max(minVolume, volume), (float) pitch));
+        SoundEvent event;
+        try {
+            // Check if the event is registered (ie has an integer ID)
+            event = SoundEvents.getRegisteredSoundEvent(sound.getId());
+        } catch (IllegalStateException e) {
+            // Otherwise send it as a custom sound
+            this.connection.sendPacket(new SPacketCustomSound(sound.getId(), (net.minecraft.util.SoundCategory) (Object) category,
+                    position.getX(), position.getY(), position.getZ(), (float) Math.max(minVolume, volume), (float) pitch));
+            return;
+        }
+
+        this.connection.sendPacket(new SPacketSoundEffect(event, (net.minecraft.util.SoundCategory) (Object) category, position.getX(),
+                position.getY(), position.getZ(), (float) Math.max(minVolume, volume), (float) pitch));
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/mixin/core/world/MixinServerWorldEventHandler.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/world/MixinServerWorldEventHandler.java
@@ -24,6 +24,10 @@
  */
 package org.spongepowered.common.mixin.core.world;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.network.play.server.SPacketCustomSound;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.SoundCategory;
 import net.minecraft.world.DimensionType;
 import net.minecraft.world.ServerWorldEventHandler;
 import net.minecraft.world.WorldServer;
@@ -32,12 +36,16 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.interfaces.world.IMixinServerWorldEventHandler;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 
+import javax.annotation.Nullable;
+
 @Mixin(ServerWorldEventHandler.class)
-public abstract class MixinServerWorldEventHandler {
+public abstract class MixinServerWorldEventHandler implements IMixinServerWorldEventHandler {
 
     @Shadow @Final private WorldServer theWorldServer;
+    @Shadow @Final private MinecraftServer mcServer;
 
     @Redirect(method = "playSoundToAllNearExcept", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/DimensionType;getId()I"), expect = 0, require = 0)
     private int getDimensionForPlayingSound(DimensionType dimensionType) {
@@ -49,4 +57,10 @@ public abstract class MixinServerWorldEventHandler {
         return ((IMixinWorldServer) this.theWorldServer).getDimensionId();
     }
 
+    @Override
+    public void playCustomSoundToAllNearExcept(@Nullable EntityPlayer player, String soundIn, SoundCategory category, double x, double y, double z,
+            float volume, float pitch) {
+        this.mcServer.getPlayerList().sendToAllNearExcept(player, x, y, z, volume > 1.0F ? (double)(16.0F * volume) : 16.0D,
+                ((IMixinWorldServer) this.theWorldServer).getDimensionId(), new SPacketCustomSound(soundIn, category, x, y, z, volume, pitch));
+    }
 }

--- a/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
+++ b/src/main/java/org/spongepowered/common/registry/CommonModuleRegistry.java
@@ -127,6 +127,7 @@ import org.spongepowered.common.boss.ServerBossBarBuilder;
 import org.spongepowered.common.data.builder.data.meta.SpongePatternLayerBuilder;
 import org.spongepowered.common.effect.particle.SpongeParticleEffectBuilder;
 import org.spongepowered.common.effect.potion.SpongePotionBuilder;
+import org.spongepowered.common.effect.sound.SpongeSoundBuilder;
 import org.spongepowered.common.entity.SpongeEntityArchetypeBuilder;
 import org.spongepowered.common.entity.SpongeEntitySnapshotBuilder;
 import org.spongepowered.common.entity.ai.*;
@@ -311,6 +312,7 @@ public final class CommonModuleRegistry {
             .registerBuilderSupplier(Schematic.Builder.class, SpongeSchematicBuilder::new)
             .registerBuilderSupplier(VirtualBiomeType.Builder.class, SpongeVirtualBiomeTypeBuilder::new)
             .registerBuilderSupplier(BiomeGenerationSettings.Builder.class, SpongeBiomeGenerationSettingsBuilder::new)
+            .registerBuilderSupplier(SoundType.Builder.class, SpongeSoundBuilder::new)
         ;
     }
 


### PR DESCRIPTION
[API](https://github.com/SpongePowered/SpongeAPI/pull/1364) | **Common** | [Forge](https://github.com/SpongePowered/SpongeForge/pull/923)

This PR fixed the issues with the `SoundType` implementation seen here: #954

- Allow for building a `SoundType`
- Redirect non-registered sounds to use the custom sound packet, as they do not have an int ID
- Fix up the registry so that IDs can be fetched by "my.sound.id" instead of "my_sound_id"
- Make registry support additional sounds (which are added in the forge PR)

Test code:
```
TO COME
```