### PR TITLE
Fire DestructEntityEvent.Death when setting a player's health to zero.

### DIFF
--- a/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java
@@ -376,7 +376,9 @@ public abstract class MixinEntityLivingBase extends MixinEntity implements Livin
         } else {
             this.entityAge = 0;
 
-            if (this.getHealth() <= 0.0F) {
+            // Sponge - if the damage source is ignored, then do not return false here, as the health
+            // has already been set to zero if Keys#HEALTH or SpongeHealthData is set to zero.
+            if (this.getHealth() <= 0.0F && source != DamageSourceRegistryModule.IGNORED_DAMAGE_SOURCE) {
                 return false;
             } else if (source.isFireDamage() && this.isPotionActive(MobEffects.FIRE_RESISTANCE)) {
                 return false;

--- a/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/entity/player/MixinEntityPlayer.java
@@ -87,6 +87,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.data.util.NbtDataUtil;
+import org.spongepowered.common.data.manipulator.mutable.entity.SpongeHealthData;
 import org.spongepowered.common.entity.EntityUtil;
 import org.spongepowered.common.event.damage.DamageEventHandler;
 import org.spongepowered.common.interfaces.ITargetedLocation;
@@ -94,6 +95,7 @@ import org.spongepowered.common.interfaces.entity.IMixinEntity;
 import org.spongepowered.common.interfaces.entity.player.IMixinEntityPlayer;
 import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 import org.spongepowered.common.mixin.core.entity.MixinEntityLivingBase;
+import org.spongepowered.common.registry.type.event.DamageSourceRegistryModule;
 import org.spongepowered.common.text.SpongeTexts;
 import org.spongepowered.common.text.serializer.LegacyTexts;
 import org.spongepowered.common.util.VecHelper;
@@ -146,6 +148,8 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
     @Shadow public abstract void takeStat(StatBase stat);
     @Shadow public abstract boolean canOpen(LockCode code);
     @Shadow protected abstract void destroyVanishingCursedItems(); // Filter vanishing curse enchanted items
+    @Shadow public abstract boolean isPlayerSleeping();
+    @Shadow public abstract void wakeUpPlayer(boolean immediately, boolean updateWorldFlag, boolean setSpawn);
 
     private boolean affectsSpawning = true;
     private UUID collidingEntityUuid = null;
@@ -406,6 +410,27 @@ public abstract class MixinEntityPlayer extends MixinEntityLivingBase implements
     @Override
     public UUID getCollidingEntityUuid() {
         return this.collidingEntityUuid;
+    }
+
+    /**
+     * @author dualspiral - October 7th, 2016
+     *
+     * @reason When setting {@link SpongeHealthData#setHealth(double)} to 0, {@link #onDeath(DamageSource)} was
+     * not being called. This check bypasses some of the checks that prevent the superclass method being called
+     * when the {@link DamageSourceRegistryModule#IGNORED_DAMAGE_SOURCE} is being used.
+     */
+    @Inject(method = "attackEntityFrom", cancellable = true, at = @At(value = "HEAD"))
+    public void onAttackEntityFrom(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        if (source == DamageSourceRegistryModule.IGNORED_DAMAGE_SOURCE) {
+            // Taken from the original method, wake the player up if they are about to die.
+            if (this.isPlayerSleeping() && !this.world.isRemote) {
+                this.wakeUpPlayer(true, true, false);
+            }
+
+            // We just throw it to the superclass method so that we can potentially get the
+            // onDeath method.
+            cir.setReturnValue(super.attackEntityFrom(source, amount));
+        }
     }
 
     /**


### PR DESCRIPTION
When setting a player's health to zero via the Data API, the `DestructEntityEvent.Death` event is not fired, and the normal Minecraft death code does not run, for example, a player's inventory might not get dropped, and no death message is fired. This is due to the folllowing lines calling `attackEntityFrom`:
- https://github.com/SpongePowered/SpongeCommon/blob/bleeding/src/main/java/org/spongepowered/common/data/processor/multi/entity/HealthDataProcessor.java#L69
- https://github.com/SpongePowered/SpongeCommon/blob/bleeding/src/main/java/org/spongepowered/common/data/processor/value/entity/HealthValueProcessor.java#L117

The issue with this is that [there is a line in that method in EntityLivingBase](https://github.com/SpongePowered/SpongeCommon/blob/668569410220699d05eb44d68beb11ac1f7f8377/src/main/java/org/spongepowered/common/mixin/core/entity/MixinEntityLivingBase.java#L375) (and a similar method in the non-overwritten `EntityPlayer` class method) that bails out early if the health is zero - which we've already set it to! Thus, nothing happens once health is set to zero, other than the client/server just recognising that the player needs a respawn as they have no health and telling them as such.

So, there are three potential fixes, depending on what we're trying to achieve:
- In `HealthDataProcessor` and `HealthValueProcessor`, call `onDeath` instead of `attackEntityFrom`, [like it did previously](https://github.com/SpongePowered/SpongeCommon/commit/cd9655f83216f0c206543b28d58e46e607553e6c#diff-d31e4027818aa8a40fc9699a9f089481L68), and send the death sound ourselves.
- In `HealthDataProcessor` and `HealthValueProcessor`, call `attackEntityFrom` _before_ setting the health. I rejected this approach as the value processor has some try/catch block which I would then end up having to undo the "attack" if it failed. In theory, you could just perform that attack without setting the health after - but I didn't do that because I figured it wouldn't then be obvious what was going on.
- The approach in the first commit, where the `EntityPlayer#attackEntityFrom` method is overriden and the health check is bypassed in `EntityLivingBase#attackEntityFrom` if using the Sponge damage source.

If there is no real reason to use `attackEntityFrom` over `onDeath`, then I actually suggest the first approach and would be happy for the first commit to be ignored.

The second commit in this PR fixes an issue I uncovered after writing the first commit, it causes Minecraft to use the generic death message if the translation for the key provided for the death message from the `DamageSource` is just the key. Without it, when a player dies via setting health, it printed "death.attack.spongespecific" to the game, with it, it simply states "dualspiral died".

Tested on both the lastest SpongeForge and SpongeVanilla codebases.

**Test Plugin** 

Plugin: [testplugin.zip](https://github.com/SpongePowered/SpongeCommon/files/517706/testplugin.zip)
Source: https://gist.github.com/dualspiral/13392996ee94c40e6d0e9b31e4981b9c

To use, run `/death <player>`. Prior to this PR, the player dies, keeps inventory, and no `DestructEntityEvent.Death` is fired. With this PR, the player dies, standard Minecraft processing applies, and a message is printed to all players with the name and type of death of the player (which should be `custom`).
