### PR TITLE
Force Entity Spawns to Throw Instant Events

### DIFF
--- a/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/CauseTracker.java
@@ -59,7 +59,9 @@ import org.spongepowered.common.interfaces.entity.IMixinEntity;
 import org.spongepowered.common.interfaces.world.IMixinWorld;
 import org.spongepowered.common.interfaces.world.IMixinWorldServer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
@@ -510,7 +512,7 @@ public final class CauseTracker {
             // capture all entities until the phase is marked for completion.
             if (!isForced) {
                 try {
-                    return phase.spawnEntityOrCapture(phaseState, context, entity, chunkX, chunkZ);
+                    return phase.spawnEntityOrCapture(this, phaseState, context, entity, chunkX, chunkZ);
                 } catch (Exception e) {
                     // Just in case something really happened, we should print a nice exception for people to
                     // paste us
@@ -551,8 +553,6 @@ public final class CauseTracker {
         }
 
         final net.minecraft.entity.Entity minecraftEntity = EntityUtil.toNative(entity);
-        final WorldServer minecraftWorld = this.getMinecraftWorld();
-        final PhaseData phaseData = this.stack.peek();
         // Sponge End - continue with vanilla mechanics
 
         final int chunkX = MathHelper.floor_double(minecraftEntity.posX / 16.0D);
@@ -564,10 +564,12 @@ public final class CauseTracker {
         } else {
 
             // Sponge Start - throw an event
+            final List<Entity> entities = new ArrayList<>(1); // We need to use an arraylist so that filtering will work.
+            entities.add(entity);
 
             final SpawnEntityEvent.Custom
                     event =
-                    SpongeEventFactory.createSpawnEntityEventCustom(cause, Arrays.asList(entity), getWorld());
+                    SpongeEventFactory.createSpawnEntityEventCustom(cause, entities, getWorld());
             SpongeImpl.postEvent(event);
             if (entity instanceof EntityPlayer || !event.isCancelled()) {
                 getMixinWorld().forceSpawnEntity(entity);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/TrackingPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/TrackingPhase.java
@@ -257,6 +257,8 @@ public abstract class TrackingPhase {
      * <p>NOTE: This method should only be called and handled if and only if {@link #allowEntitySpawns(IPhaseState)}
      * returns {@code true}. Violation of this will have unforseen consequences.</p>
      *
+     *
+     * @param causeTracker
      * @param phaseState The current phase state
      * @param context The current context
      * @param entity The entity being captured
@@ -264,7 +266,8 @@ public abstract class TrackingPhase {
      * @param chunkZ The chunk z position
      * @return True if the entity was successfully captured
      */
-    public boolean spawnEntityOrCapture(IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX,
+            int chunkZ) {
         final net.minecraft.entity.Entity minecraftEntity = (net.minecraft.entity.Entity) entity;
         final WorldServer minecraftWorld = (WorldServer) minecraftEntity.worldObj;
         final User user = context.getNotifier().orElseGet(() -> context.getOwner().orElse(null));

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/block/BlockPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/block/BlockPhase.java
@@ -74,10 +74,11 @@ public final class BlockPhase extends TrackingPhase {
     }
 
     @Override
-    public boolean spawnEntityOrCapture(IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX,
+            int chunkZ) {
         return this.allowEntitySpawns(phaseState)
                ? context.getCapturedEntities().add(entity)
-               : super.spawnEntityOrCapture(phaseState, context, entity, chunkX, chunkZ);
+               : super.spawnEntityOrCapture(causeTracker, phaseState, context, entity, chunkX, chunkZ);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/entity/EntityPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/entity/EntityPhase.java
@@ -56,14 +56,15 @@ public final class EntityPhase extends TrackingPhase {
     }
 
     @Override
-    public boolean spawnEntityOrCapture(IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX,
+            int chunkZ) {
         if (phaseState == State.CHANGING_TO_DIMENSION) {
             final WorldServer worldServer = context.firstNamed(InternalNamedCauses.Teleporting.TARGET_WORLD, WorldServer.class)
                     .orElseThrow(TrackingUtil.throwWithContext("Expected to capture the target World for a teleport!", context));
             ((IMixinWorldServer) worldServer).forceSpawnEntity(entity);
             return true;
         }
-        return super.spawnEntityOrCapture(phaseState, context, entity, chunkX, chunkZ);
+        return super.spawnEntityOrCapture(causeTracker, phaseState, context, entity, chunkX, chunkZ);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/general/GeneralPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/general/GeneralPhase.java
@@ -349,10 +349,11 @@ public final class GeneralPhase extends TrackingPhase {
     }
 
     @Override
-    public boolean spawnEntityOrCapture(IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX,
+            int chunkZ) {
         return phaseState != State.COMPLETE
                ? context.getCapturedEntities().add(entity)
-               : super.spawnEntityOrCapture(phaseState, context, entity, chunkX, chunkZ);
+               : super.spawnEntityOrCapture(causeTracker, phaseState, context, entity, chunkX, chunkZ);
     }
 
 }

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/generation/GenerationPhase.java
@@ -121,7 +121,8 @@ public final class GenerationPhase extends TrackingPhase {
     }
 
     @Override
-    public boolean spawnEntityOrCapture(IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX,
+            int chunkZ) {
         return context.getCapturedEntities().add(entity);
     }
 

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/packet/PacketPhase.java
@@ -283,7 +283,8 @@ public final class PacketPhase extends TrackingPhase {
     }
 
     @Override
-    public boolean spawnEntityOrCapture(IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX,
+            int chunkZ) {
         return ((IPacketState) phaseState).shouldCaptureEntity()
                ? context.getCapturedEntities().add(entity)
                : ((IPacketState) phaseState).spawnEntity(context, entity, chunkX, chunkZ);

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/DimensionTickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/DimensionTickPhaseState.java
@@ -91,6 +91,12 @@ class DimensionTickPhaseState extends TickPhaseState {
     public void associateAdditionalBlockChangeCauses(PhaseContext context, Cause.Builder builder, CauseTracker causeTracker) {
 
     }
+
+    @Override
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+        return context.getCapturedEntities().add(entity);
+    }
+
     @Override
     public String toString() {
         return "DimensionTickPhase";

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhase.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhase.java
@@ -79,8 +79,8 @@ public final class TickPhase extends TrackingPhase {
     }
 
     @Override
-    public boolean spawnEntityOrCapture(IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
-        return context.getCapturedEntities().add(entity);
+    public boolean spawnEntityOrCapture(CauseTracker causeTracker, IPhaseState phaseState, PhaseContext context, Entity entity, int chunkX, int chunkZ) {
+        return ((TickPhaseState) phaseState).spawnEntityOrCapture(causeTracker, context, entity, chunkX, chunkZ);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhaseState.java
+++ b/src/main/java/org/spongepowered/common/event/tracking/phase/tick/TickPhaseState.java
@@ -103,4 +103,6 @@ abstract class TickPhaseState implements IPhaseState {
     public void appendExplosionContext(PhaseContext explosionContext, PhaseContext context) {
 
     }
+
+    public abstract boolean spawnEntityOrCapture(CauseTracker causeTracker, PhaseContext context, Entity entity, int chunkX, int chunkZ);
 }

--- a/src/main/java/org/spongepowered/common/mixin/core/block/MixinSoundType.java
+++ b/src/main/java/org/spongepowered/common/mixin/core/block/MixinSoundType.java
@@ -27,6 +27,7 @@ package org.spongepowered.common.mixin.core.block;
 import net.minecraft.util.SoundEvent;
 import org.spongepowered.api.block.BlockSoundGroup;
 import org.spongepowered.api.effect.sound.SoundType;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Intrinsic;
@@ -37,42 +38,40 @@ import org.spongepowered.asm.mixin.Shadow;
 @Implements(@Interface(iface = BlockSoundGroup.class, prefix = "group$"))
 public abstract class MixinSoundType {
 
-    @Shadow private SoundEvent breakSound;
-    @Shadow private SoundEvent hitSound;
+    @Shadow @Final public float volume;
+    @Shadow @Final public float pitch;
 
-    @Shadow public abstract float getVolume();
-    @Shadow public abstract float getPitch();
-    @Shadow public abstract SoundEvent getStepSound();
-    @Shadow public abstract SoundEvent getPlaceSound();
-    @Shadow public abstract SoundEvent getFallSound();
-    @Shadow public abstract SoundEvent getBreakSound();
-    @Shadow public abstract SoundEvent getHitSound();
+    @Shadow @Final public SoundEvent stepSound;
+    @Shadow @Final public SoundEvent placeSound;
+    @Shadow @Final public SoundEvent fallSound;
+    @Shadow @Final public SoundEvent breakSound;
+    @Shadow @Final public SoundEvent hitSound;
 
     public double group$getVolume() {
-        return this.getVolume();
+        return this.volume;
     }
 
     public double group$getPitch() {
-        return this.getPitch();
+        return this.pitch;
     }
 
     public SoundType group$getBreakSound() {
-        return (SoundType) this.getBreakSound();
+        return (SoundType) this.breakSound;
     }
 
     public SoundType group$getHitSound() {
-        return (SoundType) this.getHitSound();
+        return (SoundType) this.hitSound;
     }
 
     public SoundType group$getStepSound() {
-        return (SoundType) this.getStepSound();
+        return (SoundType) this.stepSound;
     }
 
     public SoundType group$getPlaceSound() {
-        return (SoundType) this.getPlaceSound();
+        return (SoundType) this.placeSound;
     }
 
     public SoundType group$getFallSound() {
-        return (SoundType) this.getFallSound();
+        return (SoundType) this.fallSound;
     }
 }


### PR DESCRIPTION
This is more of a fix than anything for various mod incompatibilities that check the `boolean` flag for entity spawns. There's more to come for this fix, but I felt it necessary for some discussion potentially with some other developers to evaluate the necessity of bulk entity spawn captures. 